### PR TITLE
Updated to fix Explorer related security issues

### DIFF
--- a/scripts/zowe-runtime-authorize.sh
+++ b/scripts/zowe-runtime-authorize.sh
@@ -39,6 +39,10 @@ chgrp IZUADMIN $PWD
 chmod -R g+w wlp
 mkdir -p ./wlp/usr/servers/Atlas/resources
 chmod g+w ./wlp/usr/servers/Atlas/resources
+# Added to address permissions problems after first start
+mkdir -p ./wlp/usr/servers/Atlas/workarea/org.eclipse.osgi/169/0/.cp/lib
+chmod -R ug+rwx ./wlp/usr/servers/Atlas/workarea
+chmod -R a+rx ./wlp/usr/servers/Atlas/workarea
 
 # Permission fixing for the explorer server
 # These must be done before the symlinks are changed, as otherwise it tries to change the actual


### PR DESCRIPTION
The lines added pre-create the directories needed for explorer and allow for reading of the dirs for STAT purposes.  This eliminates the ICH408I messages issues while starting Explorer jars.  This fix pre-creates the following dirs in explorer

In `./explorer-server/wlp/usr/servers/Atlas`
`./workarea/org.eclipse.osgi/169/0/.cp` are created and set with a+rx permissions to allow STATing