### PR TITLE
Added code to pre-create directories for Liberty that need to have th…

### DIFF
--- a/scripts/zowe-runtime-authorize.sh
+++ b/scripts/zowe-runtime-authorize.sh
@@ -39,6 +39,9 @@ chgrp IZUADMIN $PWD
 chmod -R g+w wlp
 mkdir -p ./wlp/usr/servers/Atlas/resources
 chmod g+w ./wlp/usr/servers/Atlas/resources
+# Added to pre-create liberty directories which are normally created at first startup
+mkdir -p ./wlp/usr/servers/Atlas/workarea/org.eclipse.osgi/169/0/.cp/lib
+chmod -R +X ./wlp/usr/servers/Atlas/workarea
 
 # Permission fixing for the explorer server
 # These must be done before the symlinks are changed, as otherwise it tries to change the actual


### PR DESCRIPTION
…e DirSearch attribute set.  This suppresses 10 ICH408I error messages that describe a search error because of a missing attribute.  Working with the IBM Liberty team to correct this issue.

Signed-off-by: Matt Hogstrom <matt@hogstrom.org>