### PR TITLE
rtc defect 21266: remove existing environment entries before adding new

### DIFF
--- a/scripts/zowe-init.sh
+++ b/scripts/zowe-init.sh
@@ -161,6 +161,7 @@ getJavaVersion() {
 persist() {
     echo "** Adding line: export "$1"="$2" to "~/$PROFILE " **"
     echo "** Adding line: export "$1"="$2" to "~/$PROFILE " **" >> $LOG_FILE
+    grep -v "export $1=" ~/$PROFILE > ~/$PROFILE.zowe-tmp && mv ~/$PROFILE.zowe-tmp ~/$PROFILE
     echo "export $1="$2 >> ~/$PROFILE
 }
 


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>