### PR TITLE
WIP - Include latest APIML build

### DIFF
--- a/artifactory-download-spec.json
+++ b/artifactory-download-spec.json
@@ -17,7 +17,7 @@
       "build": "atlas-wlp-package-pipeline :: master"
     },
     {
-      "pattern": "libs-snapshot-local/com/ca/mfaas/sdk/mfaas-zowe-install/0.2.0-SNAPSHOT/mfaas-zowe-install-0.2.0-20180926.082944-73.zip",
+      "pattern": "libs-snapshot-local/com/ca/mfaas/sdk/mfaas-zowe-install/0.2.0-SNAPSHOT/mfaas-zowe-install-0.2.0-20180927.142125-74.zip",
       "target": "pax-workspace/mediation/",
       "flat": "true",
       "explode": "true"

--- a/scripts/zowe-api-mediation-configure.sh
+++ b/scripts/zowe-api-mediation-configure.sh
@@ -65,7 +65,7 @@ sed -e "s|\*\*JAVA_SETUP\*\*|export JAVA_HOME=$ZOWE_JAVA_HOME|g" \
     -e 's/\*\*DISCOVERY_PORT\*\*/'$ZOWE_APIM_DISCOVERY_HTTP_PORT'/g' \
     -e 's/\*\*CATALOG_PORT\*\*/'$ZOWE_APIM_CATALOG_HTTP_PORT'/g' \
     -e 's/\*\*GATEWAY_PORT\*\*/'$ZOWE_APIM_GATEWAY_HTTPS_PORT'/g' \
-    -e 's/\*\*STATIC_DEF_CONFIG\*\*/'$STATIC_DEF_CONFIG'/g' \
+    -e 's|\*\*STATIC_DEF_CONFIG\*\*|'$STATIC_DEF_CONFIG'|g' \
     api-mediation-start-discovery-template.sh > api-mediation-start-discovery.sh
 
 # Make configured script executable


### PR DESCRIPTION
This PR includes latest APIML build.

It fixes the substitution of new `STATIC_DEF_CONFIG` variable.

The PAX file will be used for testing of the APIML in PAX file.

We are researching a way how to select the latest version automatically.