### PR TITLE
Add Zowe CLI Bundle 0.9.1

### DIFF
--- a/artifactory-download-spec.json
+++ b/artifactory-download-spec.json
@@ -5,7 +5,7 @@
       "flat": "true"
     },
     {
-      "pattern": "libs-release-local/zowe-cli/bundle/zowe-cli-bundle.zip",
+      "pattern": "libs-release-local/zowe-cli/bundle/0.9.1/zowe-cli-bundle.zip",
       "target": "pax-workspace/content/zowe-{ARTIFACTORY_VERSION}/files/",
       "flat": "true"
     },


### PR DESCRIPTION
Adds the zowe cli offline bundle for 0.9.1

Contains:
Core-CLI
CICS Plugin