### PR TITLE
Issue 122 version

### DIFF
--- a/artifactory-download-spec.json.template
+++ b/artifactory-download-spec.json.template
@@ -1,17 +1,17 @@
 {
   "files": [{
       "pattern": "rocket-closed-source-builds/latest/ZLUX.pax",
-      "target": "pax-workspace/content/zowe-{ARTIFACTORY_VERSION}/files/",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/",
       "flat": "true"
     },
     {
       "pattern": "libs-release-local/zowe-cli/bundle/0.9.3/zowe-cli-bundle.zip",
-      "target": "pax-workspace/content/zowe-{ARTIFACTORY_VERSION}/files/",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/",
       "flat": "true"
     },
     {
       "pattern": "atlas-local-snapshots/com/ibm/atlas/atlas-wlp-package/*.zip",
-      "target": "pax-workspace/content/zowe-{ARTIFACTORY_VERSION}/files/",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/",
       "flat": "true",
       "explode": "true",
       "build": "explorer-wlp-packaging :: master"
@@ -27,22 +27,22 @@
     },
     {
       "pattern": "libs-release-local/org/zowe/licenses/0.9.1/Zowe_Open_Beta_License_Agreement.pdf",
-      "target": "pax-workspace/content/zowe-{ARTIFACTORY_VERSION}/licenses/",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/licenses/",
       "flat": "true"
     },
     {
       "pattern": "libs-release-local/org/zowe/licenses/0.9.1/Zowe_CLI_TPSRs.zip",
-      "target": "pax-workspace/content/zowe-{ARTIFACTORY_VERSION}/licenses/",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/licenses/",
       "flat": "true"
     },
     {
       "pattern": "libs-release-local/org/zowe/licenses/0.9.1/Zowe_APIML_TPSRs.zip",
-      "target": "pax-workspace/content/zowe-{ARTIFACTORY_VERSION}/licenses/",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/licenses/",
       "flat": "true"
     },
     {
       "pattern": "libs-release-local/org/zowe/licenses/0.9.1/Explorer_Server_Licenses.zip",
-      "target": "pax-workspace/content/zowe-{ARTIFACTORY_VERSION}/licenses/",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/licenses/",
       "flat": "true"
     },
     {

--- a/install/zowe-install.sh
+++ b/install/zowe-install.sh
@@ -43,6 +43,9 @@ if [ -z "$ZOWE_VERSION" ]; then
   echo "Error: failed to determine Zowe version."
   echo "Error: failed to determine Zowe version." >> $LOG_FILE
   exit 1
+else
+  echo "Zowe v$ZOWE_VERSION"
+  echo "Zowe v$ZOWE_VERSION" >> $LOG_FILE
 fi
 
 echo "Install started at: "`date` >> $LOG_FILE

--- a/install/zowe-install.sh
+++ b/install/zowe-install.sh
@@ -15,6 +15,9 @@
 export PROFILE=.profile
 export INSTALL_DIR=$PWD/../
 
+# extract Zowe version from manifest.json
+export ZOWE_VERSION=$(cat $INSTALL_DIR/manifest.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')
+
 separator() {
     echo "---------------------------------------------------------------------"
 }
@@ -36,6 +39,12 @@ LOG_FILE=$LOG_DIR/$LOG_FILE
 touch $LOG_FILE
 chmod a+rw $LOG_FILE
 
+if [ -z "$ZOWE_VERSION" ]; then
+  echo "Error: failed to determine Zowe version."
+  echo "Error: failed to determine Zowe version." >> $LOG_FILE
+  exit 1
+fi
+
 echo "Install started at: "`date` >> $LOG_FILE
 
 # Populate the environment variables for ZOWE_SDSF_PATH, ZOWE_ZOSMF_PATH, ZOWE_JAVA_HOME, ZOWE_EXPLORER_HOST
@@ -47,7 +56,7 @@ echo "After zowe-init ZOWE_JAVA_HOME variable value="$ZOWE_JAVA_HOME >> $LOG_FIL
 # ZOWE_ROOT_DIR,  ZOWE_EXPLORER_SERVER_HTTP_PORT,  ZOWE_EXPLORER_SERVER_HTTPS_PORT,  ZOWE_ZLUX_SERVER_HTTP_PORT,  ZOWE_ZLUX_SERVER_HTTPS_PORT,  ZOWE_ZSS_SERVER_PORT
 . $INSTALL_DIR/scripts/zowe-parse-yaml.sh
 
-echo "Beginning install of Zowe 0.9.3 into directory " $ZOWE_ROOT_DIR
+echo "Beginning install of Zowe ${ZOWE_VERSION} into directory " $ZOWE_ROOT_DIR
 
 # warn about any prior installation
 if [[ -d $ZOWE_ROOT_DIR ]]; then
@@ -63,6 +72,9 @@ else
     mkdir -p $ZOWE_ROOT_DIR
 fi
 chmod a+rx $ZOWE_ROOT_DIR
+
+# copy manifest.json to root folder
+cp "$INSTALL_DIR/manifest.json" "$ZOWE_ROOT_DIR"
 
 # Create a temp directory to be a working directory for sed replacements
 export TEMP_DIR=$INSTALL_DIR/temp_"`date +%Y-%m-%d`"
@@ -103,7 +115,7 @@ cd $ZOWE_ROOT_DIR/zlux-build
 chmod a+x deploy.sh
 . deploy.sh > /dev/null
 
-echo "Zowe 0.9.3 runtime install completed into directory "$ZOWE_ROOT_DIR
+echo "Zowe ${ZOWE_VERSION} runtime install completed into directory "$ZOWE_ROOT_DIR
 echo "The install script zowe-install.sh does not need to be re-run as it completed successfully"
 separator
 echo "Attempting to set Unix file permissions ..."

--- a/install/zowe-install.yaml.template
+++ b/install/zowe-install.yaml.template
@@ -3,7 +3,7 @@
 # =================================================================
 # zowe-install: The directory that zowe will be installed into
 install:
-  rootDir=~/zowe/0.9.3
+  rootDir=~/zowe/{ZOWE_VERSION}
 
 # https ports for the api mediation layer
 api-mediation:

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "Zowe",
+  "version": "0.9.3",
+  "description": "Zowe offers modern interfaces to interact with z/OS and allows you to work with z/OS in a way that is similar to what you experience on cloud platforms today.",
+  "license": "EPL-2.0",
+  "homepage": "https://zowe.org"
+}

--- a/scripts/zowe-install-iframe-plugin.sh
+++ b/scripts/zowe-install-iframe-plugin.sh
@@ -14,7 +14,7 @@ URL=$4
 TILE_IMAGE_PATH=$5
 
 if [ "$#" -ne 5 ]; then
-  echo "Usage: $0 ZOWE_INSTALL_ROOT_DIRECTORY PLUGIN_ID PLUGIN_SHORTNAME URL TILE_IMAGE_PATH\neg. install-iframe-plugin.sh \"~/zowe-0.9.3\" \"org.zowe.plugin.example\" \"Example plugin\" \"https://zowe.org:443/about-us/\" \"/zowe_plugin/artifacts/tile_image.png\"" >&2
+  echo "Usage: $0 ZOWE_INSTALL_ROOT_DIRECTORY PLUGIN_ID PLUGIN_SHORTNAME URL TILE_IMAGE_PATH\neg. install-iframe-plugin.sh \"~/zowe\" \"org.zowe.plugin.example\" \"Example plugin\" \"https://zowe.org:443/about-us/\" \"/zowe_plugin/artifacts/tile_image.png\"" >&2
   exit 1
 fi
 if ! [ -d "$1" ]; then

--- a/scripts/zowe-parse-yaml.sh
+++ b/scripts/zowe-parse-yaml.sh
@@ -122,8 +122,8 @@ parseConfiguationFile ./zowe-install.yaml
 # If the values are not set default them
 if [[ $ZOWE_ROOT_DIR == "" ]] 
 then
-    $ZOWE_ROOT_DIR = "~/zowe/0.9.3"
-    echo "  ZOWE_ROOT_DIR not specified:  Defaulting to ~/zowe/0.9.3"
+    $ZOWE_ROOT_DIR = "~/zowe/$ZOWE_VERSION"
+    echo "  ZOWE_ROOT_DIR not specified:  Defaulting to ~/zowe/$ZOWE_VERSION"
 fi
 if [[ $ZOWE_EXPLORER_SERVER_HTTP_PORT == "" ]]
 then


### PR DESCRIPTION
Original issue https://github.com/zowe/zowe-install-packaging/issues/122

**Summary:** 

`manifest.json` is created to store Zowe version.

- This file will be added into PAX file under `zowe-{version}` folder, one level above `install`, `scripts` folders.
- During installation, this file will copied to target installation root folder.
- Installation script will pick version number from this file.

**Build & Test Result:**

Successful build https://wash.zowe.org:8443/job/zowe-install-packaging/job/issue-122-version/2/ are put in artifactory `libs-snapshot-local/com/project/zowe/0.9.3-ISSUE-122-VERSION/zowe-0.9.3-20181112.180848-2.pax`.

Build test result is https://wash.zowe.org:8443/job/zowe-install-test/job/094-fixes/3/console. Note: the failure test cases are caused by failing to start api-layer, which is not caused by this PR.