### PR TITLE
Select stable version of APIML

### DIFF
--- a/artifactory-download-spec.json.template
+++ b/artifactory-download-spec.json.template
@@ -12,7 +12,7 @@
       "build": "explorer-wlp-packaging :: master"
     },
     {
-      "pattern": "libs-snapshot-local/com/ca/mfaas/sdk/mfaas-zowe-install/0.2.0-SNAPSHOT/mfaas-zowe-install-*.zip",
+      "pattern": "libs-snapshot-local/com/ca/mfaas/sdk/mfaas-zowe-install/0.3.0-SNAPSHOT/mfaas-zowe-install-0.3.0-20181127.154103-2.zip",
       "target": "pax-workspace/mediation/",
       "flat": "true",
       "explode": "true",


### PR DESCRIPTION
Contains the APIML build that fixes https://github.com/zowe/api-layer/issues/139.

It stops selecting the latest master of APIML automatically.