### PR TITLE
Update with latest APIML master

### DIFF
--- a/artifactory-download-spec.json.template
+++ b/artifactory-download-spec.json.template
@@ -12,7 +12,7 @@
       "build": "explorer-wlp-packaging :: master"
     },
     {
-      "pattern": "libs-snapshot-local/com/ca/mfaas/sdk/mfaas-zowe-install/0.3.0-SNAPSHOT/mfaas-zowe-install-0.3.0-20181127.154103-2.zip",
+      "pattern": "libs-snapshot-local/com/ca/mfaas/sdk/mfaas-zowe-install/0.3.0-SNAPSHOT/mfaas-zowe-install-0.3.0-20181130.223039-4.zip",
       "target": "pax-workspace/mediation/",
       "flat": "true",
       "explode": "true",


### PR DESCRIPTION
This PR updates the APIML. It contains the fix to API catalog be accessed via `localhost` hostname.

All the APIML services are now listening on all interfaces