### PR TITLE
Remove prereq check for existence of log directory

### DIFF
--- a/install/zowe-check-prereqs.sh
+++ b/install/zowe-check-prereqs.sh
@@ -37,7 +37,7 @@ fi
 echo
 echo Check entries in the install directory
 instdirOK=1
-for dir in files install licenses log scripts
+for dir in files install licenses scripts
 do
   ls ${INSTALL_DIR}/../$dir >/dev/null
   if [[ $? -ne 0 ]]


### PR DESCRIPTION
Signed-off-by: John Davies <daviesja@uk.ibm.com>

The script `zowe-check-prereqs.sh` should not check for the existence of a directory named `log`, which will not exist when the install has newly been un-PAXed.  Previously, this check was part of ensuring that the prereq script was launched from the right directory, but the log directory is not present at first, so this check should be removed.