### PR TITLE
Cert Creation to lower in install sequence

### DIFF
--- a/install/zowe-install.sh
+++ b/install/zowe-install.sh
@@ -88,9 +88,6 @@ echo "  Installing API Mediation into $ZOWE_ROOT_DIR/api-mediation ..."
 echo "  Installing zLUX server into $ZOWE_ROOT_DIR/zlux-example-server ..." 
 . $INSTALL_DIR/scripts/zlux-install-script.sh
 
-# Configure API Mediation layer 
-. $INSTALL_DIR/scripts/zowe-api-mediation-configure.sh
-
 # Configure the ports for the zLUX server
 . $INSTALL_DIR/scripts/zowe-zlux-configure-ports.sh
 
@@ -109,8 +106,8 @@ echo "-----"
 # Run deploy on the zLUX app server to propogate the changes made
 
 # TODO LATER - revisit to work out the best permissions, but currently needed so deploy.sh can run	
-chmod -R 755 $ZOWE_ROOT_DIR/zlux-example-server/deploy/product	
-chmod -R 755 $ZOWE_ROOT_DIR/zlux-example-server/deploy/instance
+chmod -R 775 $ZOWE_ROOT_DIR/zlux-example-server/deploy/product	
+chmod -R 775 $ZOWE_ROOT_DIR/zlux-example-server/deploy/instance
 
 cd $ZOWE_ROOT_DIR/zlux-build
 chmod a+x deploy.sh
@@ -118,6 +115,13 @@ chmod a+x deploy.sh
 
 echo "Zowe ${ZOWE_VERSION} runtime install completed into directory "$ZOWE_ROOT_DIR
 echo "The install script zowe-install.sh does not need to be re-run as it completed successfully"
+separator
+
+# Configure API Mediation layer.  Because this script may fail because of priviledge issues with the user ID
+# this script is run after all the folders have been created and paxes expanded above
+echo "Attempting to setup Zowe API Mediation Layer certificates ... "
+. $INSTALL_DIR/scripts/zowe-api-mediation-configure.sh
+
 separator
 echo "Attempting to set Unix file permissions ..."
 

--- a/scripts/zlux-install-script.sh
+++ b/scripts/zlux-install-script.sh
@@ -25,10 +25,6 @@ cd zlux-example-server
 chmod -R a-w bin/ build/ config/ deploy/product/ js/ plugins/ .gitattributes .gitignore README.md 2>/dev/null
 chmod ug+w bin/zssServer
 
-# grant write permission for Zowe task owner (IZUSVR) to update configurations
-chown -R IZUSVR deploy/instance
-chown -R IZUSVR deploy/site
-
 # Open the permission so that a user other than the one who does the install can start the nodeServer
 # and create logs
 chmod a+w log

--- a/scripts/zowe-runtime-authorize.sh
+++ b/scripts/zowe-runtime-authorize.sh
@@ -31,8 +31,10 @@ if extattr ./zlux-example-server/bin/zssServer | grep "APF authorized = NO"; the
 fi
 
 #
-# Permission fix for zLux Server
+# Permission fix for zLux Server.  This is so that the user IZUSVR that owns the ZOWESVR
+# started task is able to write to folder in order to persist details like pinned desktop items
 # 
+chgrp -R IZUUSER ./zlux-example-server/deploy
 chmod -R ug+w ./zlux-example-server/deploy
 chmod -R ug+w ./zlux-example-server/deploy/site
 chmod -R ug+w ./zlux-example-server/deploy/instance


### PR DESCRIPTION
Signed-off-by: Joe-Winchester <winchest@uk.ibm.com> 

The install log now has the folder creation all finished before it configures the certificates which makes for a cleaner install.

Zowe 0.9.5 runtime install completed into directory /u/winchj/zowe/0.9.5_a
The install script zowe-install.sh does not need to be re-run as it completed successfully

  Setting up Zowe API Mediation Layer certificates...
ls: FSUM6785 File or directory "keystore/local_ca/extca.*.cer" is not found
keytool: trust_zosmf 4: scripts/apiml_cm.sh 436: FSUM9209 cannot execute: reason code = 0b1b03d1: EDC5139I Operation not permitted.
apiml_cm.sh --action trust-zosmf has failed. See /u/winchj/zowe-0.9.5/install/..//log/2018-12-17-19-33-49.log for more details
ERROR: z/OSMF is not trusted by the API Mediation Layer. Follow instructions in Zowe documentation about manual steps to trust z/OSMF
  Certificate setup done.

Attempting to set Unix file permissions ...
  The permissions were successfully changed
