### PR TITLE
Made iframe plugin install use semver

### DIFF
--- a/scripts/zowe-install-iframe-plugin.sh
+++ b/scripts/zowe-install-iframe-plugin.sh
@@ -55,8 +55,8 @@ EOF
 cat <<EOF >$PLUGIN_FOLDER/pluginDefinition.json
 {
   "identifier": "$PLUGIN_ID",
-  "apiVersion": "1.0",
-  "pluginVersion": "1.0",
+  "apiVersion": "1.0.0",
+  "pluginVersion": "1.0.0",
   "pluginType": "application",
   "webContent": {
     "framework": "iframe",


### PR DESCRIPTION
https://github.com/zowe/zlux-proxy-server/pull/41 will be enforcing plugins conformance to a spec (it'll evolve over time) and so this PR updates the iframe plugin creator to conform to the initial spec (apiVersion=1.0.0).