### PR TITLE
Fix zlux paths upon server rename

### DIFF
--- a/install/zowe-install.sh
+++ b/install/zowe-install.sh
@@ -84,7 +84,7 @@ echo "  Installing API Mediation into $ZOWE_ROOT_DIR/api-mediation ..."
 . $INSTALL_DIR/scripts/zowe-api-mediation-install.sh
 
 # Install the zLUX server
-echo "  Installing zLUX server into $ZOWE_ROOT_DIR/zlux-example-server ..." 
+echo "  Installing zLUX server into $ZOWE_ROOT_DIR/zlux-app-server ..." 
 . $INSTALL_DIR/scripts/zlux-install-script.sh
 
 # Install the Explorer API
@@ -114,14 +114,14 @@ CATALOG_GATEWAY_URL=https://$ZOWE_EXPLORER_HOST:$ZOWE_APIM_GATEWAY_PORT/ui/v1/ap
 echo "---- After expanding ZLUX.pax and Atlas.pax this is a directory listing of "$ZOWE_ROOT_DIR >> $LOG_FILE
 ls $ZOWE_ROOT_DIR >> $LOG_FILE
 echo "-----"
-# run the atlasZluxInection script that copies folders into the zlux-example-server
+# run the atlasZluxInection script that copies folders into the zlux-app-server
 # and gets the explorer tiles onto the desktop
 . $INSTALL_DIR/scripts/zowe-prepare-runtime.sh
 # Run deploy on the zLUX app server to propogate the changes made
 
 # TODO LATER - revisit to work out the best permissions, but currently needed so deploy.sh can run	
-chmod -R 775 $ZOWE_ROOT_DIR/zlux-example-server/deploy/product	
-chmod -R 775 $ZOWE_ROOT_DIR/zlux-example-server/deploy/instance
+chmod -R 775 $ZOWE_ROOT_DIR/zlux-app-server/deploy/product	
+chmod -R 775 $ZOWE_ROOT_DIR/zlux-app-server/deploy/instance
 
 cd $ZOWE_ROOT_DIR/zlux-build
 chmod a+x deploy.sh

--- a/scripts/run-zowe.sh
+++ b/scripts/run-zowe.sh
@@ -20,9 +20,9 @@
 # //  PARM='PGM /bin/sh &SRVRPATH/../scripts/internal/run-zowe.sh'
 #
 #
-#export "NODE_PATH='"$ZOWE_ROOT_DIR"/zlux-example-server/bin':$NODE_PATH"
+#export "NODE_PATH='"$ZOWE_ROOT_DIR"/zlux-app-server/bin':$NODE_PATH"
 export NODE_HOME=$nodehome
-`dirname $0`/../../zlux-example-server/bin/nodeServer.sh --allowInvalidTLSProxy=true &
+`dirname $0`/../../zlux-app-server/bin/nodeServer.sh --allowInvalidTLSProxy=true &
 `dirname $0`/../../api-mediation/scripts/api-mediation-start-discovery.sh
 `dirname $0`/../../api-mediation/scripts/api-mediation-start-catalog.sh
 `dirname $0`/../../api-mediation/scripts/api-mediation-start-gateway.sh

--- a/scripts/zlux-install-script.sh
+++ b/scripts/zlux-install-script.sh
@@ -16,12 +16,12 @@ umask 0002
 echo "Unpax $INSTALL_DIR/files/ZLUX.pax " >> $LOG_FILE
 pax -r -px -f $INSTALL_DIR/files/ZLUX.pax
 
-chmod -R a-w tn3270-ng2/ vt-ng2/ zlux-app-manager/ zlux-example-server/ zlux-ng2/ zlux-proxy-server/ zlux-shared/ zos-subsystems/ 2>/dev/null
-chmod ug+w zlux-example-server/
-mkdir zlux-example-server/log
-chmod ug-w zlux-example-server/
+chmod -R a-w tn3270-ng2/ vt-ng2/ zlux-app-manager/ zlux-app-server/ zlux-ng2/ zlux-server-framework/ zlux-shared/ zos-subsystems/ 2>/dev/null
+chmod ug+w zlux-app-server/
+mkdir zlux-app-server/log
+chmod ug-w zlux-app-server/
 
-cd zlux-example-server
+cd zlux-app-server
 chmod -R a-w bin/ build/ config/ deploy/product/ js/ plugins/ .gitattributes .gitignore README.md 2>/dev/null
 chmod ug+w bin/zssServer
 

--- a/scripts/zowe-install-iframe-plugin.sh
+++ b/scripts/zowe-install-iframe-plugin.sh
@@ -26,7 +26,7 @@ if ! [ -f "$5" ]; then
   exit 1
 fi
 
-zluxserverdirectory='zlux-example-server'
+zluxserverdirectory='zlux-app-server'
 
 chmod -R u+w $ZOWE_ROOT_DIR/$zluxserverdirectory/plugins/
 # switch spaces to underscores and lower case it for use as folder name

--- a/scripts/zowe-prepare-runtime.sh
+++ b/scripts/zowe-prepare-runtime.sh
@@ -10,7 +10,7 @@
 # Copyright IBM Corporation 2018
 ################################################################################
 
-zluxserverdirectory='zlux-example-server'
+zluxserverdirectory='zlux-app-server'
 
 echo "Preparing folder permission for zLux plugins foder..." >> $LOG_FILE
 chmod -R u+w $ZOWE_ROOT_DIR/$zluxserverdirectory/plugins/

--- a/scripts/zowe-runtime-authorize.sh
+++ b/scripts/zowe-runtime-authorize.sh
@@ -11,10 +11,10 @@
 set -e
 # We are in the /scripts folder beneath a Zowe install
 # If we are run directly from the shell we need to switch up a directory to 
-# be able to work with zlux-example-server and explorer-server
+# be able to work with zlux-app-server and explorer-server
 # If we are run from the zowe-install.sh script then we need to switch into the
 # ZOWE_ROOT_DIR as this will be where the install has put us, so we can work from there
-# cd to the top level folder as this is where the zlux-example-server and the explorer-server are
+# cd to the top level folder as this is where the zlux-app-server and the explorer-server are
 if [[ $ZOWE_ROOT_DIR == "" ]]
     then
         cd ..
@@ -24,9 +24,9 @@ fi
 
 # This is from the zLUX install
 
-if extattr ./zlux-example-server/bin/zssServer | grep "APF authorized = NO"; then
+if extattr ./zlux-app-server/bin/zssServer | grep "APF authorized = NO"; then
   echo "zssServer does not have the proper extattr values"
-  echo "   Please run extattr +a $PWD/zlux-example-server/bin/zssServer"
+  echo "   Please run extattr +a $PWD/zlux-app-server/bin/zssServer"
   exit 1
 fi
 
@@ -34,10 +34,10 @@ fi
 # Permission fix for zLux Server.  This is so that the user IZUSVR that owns the ZOWESVR
 # started task is able to write to folder in order to persist details like pinned desktop items
 # 
-chgrp -R IZUUSER ./zlux-example-server/deploy
-chmod -R ug+w ./zlux-example-server/deploy
-chmod -R ug+w ./zlux-example-server/deploy/site
-chmod -R ug+w ./zlux-example-server/deploy/instance
+chgrp -R IZUUSER ./zlux-app-server/deploy
+chmod -R ug+w ./zlux-app-server/deploy
+chmod -R ug+w ./zlux-app-server/deploy/site
+chmod -R ug+w ./zlux-app-server/deploy/instance
 
 # This is from the explorer-server install
 cd explorer-server

--- a/scripts/zowe-verify.sh
+++ b/scripts/zowe-verify.sh
@@ -32,8 +32,8 @@ echo Check we are in the right directory, with the right contents
 dirOK=1
 for dir in \
 README.md             uss_explorer          sample-iframe-app     zlux-app-manager      zlux-platform         zosmf-auth \
-api-mediation         explorer-server       scripts               zlux-build            zlux-proxy-server     zss-auth \
-jes_explorer          explorer-server-auth  tn3270-ng2            zlux-example-server   zlux-shared \
+api-mediation         explorer-server       scripts               zlux-build            zlux-server-framework     zss-auth \
+jes_explorer          explorer-server-auth  tn3270-ng2            zlux-app-server   zlux-shared \
 mvs_explorer          vt-ng2                zlux-ng2              zos-subsystems
 #
 do
@@ -405,9 +405,9 @@ echo Check port settings from Zowe config files
   explorer_server_http_port=7290            # explorer-server/wlp/usr/servers/Atlas/server.xml  ASCII
   explorer_server_https_port=7941           # explorer-server/wlp/usr/servers/Atlas/server.xml  ASCII
                                             # explorer-??S/web/index.html
-  zlux_server_http_port=8543                # zlux-example-server/config/zluxserver.json
-  zlux_server_https_port=8544               # zlux-example-server/config/zluxserver.json
-  zss_server_http_port=8542                 # zlux-example-server/config/zluxserver.json
+  zlux_server_http_port=8543                # zlux-app-server/config/zluxserver.json
+  zlux_server_https_port=8544               # zlux-app-server/config/zluxserver.json
+  zss_server_http_port=8542                 # zlux-app-server/config/zluxserver.json
   terminal_sshPort=22                       # vt-ng2/_defaultVT.json
   terminal_telnetPort=23                    # tn3270-ng2/_defaultTN3270.json
 
@@ -416,7 +416,7 @@ for file in \
  "api-mediation/scripts/api-mediation-start-discovery.sh" \
  "api-mediation/scripts/api-mediation-start-gateway.sh" \
  "explorer-server/wlp/usr/servers/Atlas/server.xml" \
- "zlux-example-server/config/zluxserver.json" \
+ "zlux-app-server/config/zluxserver.json" \
  "vt-ng2/_defaultVT.json" \
  "tn3270-ng2/_defaultTN3270.json"
 do

--- a/scripts/zowe-zlux-configure-certificates.sh
+++ b/scripts/zowe-zlux-configure-certificates.sh
@@ -10,7 +10,7 @@
 # Copyright Broadcom 2018
 ################################################################################
 
-ZLUX_SERVER_CONFIG_PATH=${ZOWE_ROOT_DIR}/zlux-example-server/config
+ZLUX_SERVER_CONFIG_PATH=${ZOWE_ROOT_DIR}/zlux-app-server/config
 APIML_KEYSTORE_PATH=${ZOWE_ROOT_DIR}/api-mediation/keystore
 SUFFIX=""
 if [ `uname` = "OS/390" ]; then
@@ -23,7 +23,7 @@ echo "<zowe-zlux-configure-certificates.sh>" >> $LOG_FILE
 chmod -R u+w ${ZLUX_SERVER_CONFIG_PATH}/
 cd ${ZLUX_SERVER_CONFIG_PATH}
 
-# Update the /zlux-example-server/deploy/instance/ZLUX/serverConfig/zluxserver.json
+# Update the /zlux-app-server/deploy/instance/ZLUX/serverConfig/zluxserver.json
 echo "Updating certificates in zluxserver.json to use key store in ${APIML_KEYSTORE_PATH}" >> $LOG_FILE 
 sed 's|.*"keys".*|      "keys": ["'${APIML_KEYSTORE_PATH}'/localhost/localhost.keystore.key"]|g' zluxserver.json > ${TEMP_DIR}/transform1.json
 sed 's|.*"certificates".*|    , "certificates": ["'${APIML_KEYSTORE_PATH}'/localhost/localhost.keystore.cer'${SUFFIX}'"]|g' ${TEMP_DIR}/transform1.json > ${TEMP_DIR}/transform2.json

--- a/scripts/zowe-zlux-configure-ports.sh
+++ b/scripts/zowe-zlux-configure-ports.sh
@@ -10,8 +10,8 @@
 # Copyright IBM Corporation 2018
 ################################################################################
 
-# update the /zlux-example-server/deploy/instance/ZLUX/serverConfig/zluxserver.json
-ZLUX_SERVER_CONFIG_PATH=$ZOWE_ROOT_DIR/zlux-example-server/config/
+# update the /zlux-app-server/deploy/instance/ZLUX/serverConfig/zluxserver.json
+ZLUX_SERVER_CONFIG_PATH=$ZOWE_ROOT_DIR/zlux-app-server/config/
 echo "<zowe-zlux-configure-ports.sh>" >> $LOG_FILE
 # Change the permission to allow us to write and modify the port numbers
 chmod -R u+w $ZLUX_SERVER_CONFIG_PATH/

--- a/tests/test_zowe-zlux-configure-certificates.py
+++ b/tests/test_zowe-zlux-configure-certificates.py
@@ -5,10 +5,10 @@ import json
 
 
 def test_script_replaces_correctly():
-    if not os.path.exists("tmp/zlux-example-server/config"):
-        os.makedirs("tmp/zlux-example-server/config")
+    if not os.path.exists("tmp/zlux-app-server/config"):
+        os.makedirs("tmp/zlux-app-server/config")
     shutil.copy("tests/data/zluxserver.json",
-                "tmp/zlux-example-server/config/zluxserver.json")
+                "tmp/zlux-app-server/config/zluxserver.json")
 
     env = {
         "LOG_FILE": os.path.join(os.getcwd(), "tmp", "test.log"),
@@ -28,7 +28,7 @@ def test_script_replaces_correctly():
     assert result.stdout.strip() == ""
     assert result.stderr.strip() == ""
 
-    with open(os.path.join(env["TEMP_DIR"], "zlux-example-server", "config", "zluxserver.json")) as json_data:
+    with open(os.path.join(env["TEMP_DIR"], "zlux-app-server", "config", "zluxserver.json")) as json_data:
         lines = []
         for line in json_data.readlines():
             if not line.strip().startswith("//"):


### PR DESCRIPTION
Depends on zlux repo also being updated, so please don't merge if you approve... I'll coordinate merging.
Text replace of zlux-example-server to zlux-app-server, zlux-proxy-server to zlux-server-framework

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>