### PR TITLE
Update zLUX version

### DIFF
--- a/artifactory-download-spec.json.template
+++ b/artifactory-download-spec.json.template
@@ -1,6 +1,6 @@
 {
   "files": [{
-      "pattern": "rocket-closed-source-builds/0.9.4+20181127/ZLUX.pax",
+      "pattern": "rocket-closed-source-builds/1.0.0+20190114/ZLUX.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/",
       "flat": "true"
     },

--- a/install/zowe-install.yaml.template
+++ b/install/zowe-install.yaml.template
@@ -22,7 +22,6 @@ explorer-server:
 
 # http and https ports for the zlux node server, as well as the port for the zss server
 zlux-server:
-  httpPort=8543
   httpsPort=8544
   zssPort=8542
 

--- a/scripts/zowe-parse-yaml.sh
+++ b/scripts/zowe-parse-yaml.sh
@@ -59,13 +59,6 @@ do
                 echo "  explorer-server data sets api port="$ZOWE_EXPLORER_SERVER_DATASETS_PORT
                 export ZOWE_EXPLORER_SERVER_DATASETS_PORT
             fi
-# Look for httpPort= beneath zlux-server:
-            if [[ $key == "httpPort" ]] && [[ $section == "zlux-server" ]] 
-            then
-                ZOWE_ZLUX_SERVER_HTTP_PORT=$value
-               echo "  zlux-server http port"=$ZOWE_ZLUX_SERVER_HTTP_PORT
-                export ZOWE_ZLUX_SERVER_HTTP_PORT
-            fi
 # Look for httpsPort= beneath zlux-server:
             if [[ $key == "httpsPort" ]] && [[ $section == "zlux-server" ]] 
             then
@@ -209,11 +202,6 @@ then
     ZOWE_ZLUX_SERVER_HTTPS_PORT=8544
     echo "  ZOWE_ZLUX_SERVER_HTTPS_PORT not specified:  Defaulting to 8544"
 fi
-if [[ $ZOWE_ZLUX_SERVER_HTTP_PORT == "" ]]
-then
-    ZOWE_ZLUX_SERVER_HTTP_PORT=8543
-    echo "  ZOWE_ZLUX_SERVER_HTTP_PORT not specified:  Defaulting to 8543"
-fi
 if [[ $ZOWE_ZSS_SERVER_PORT == "" ]]
 then
     ZOWE_ZSS_SERVER_PORT=8542
@@ -277,7 +265,6 @@ then
 fi
 
 echo "  ZOWE_ROOT_DIR="$ZOWE_ROOT_DIR >> $LOG_FILE
-echo "  ZOWE_ZLUX_SERVER_HTTP_PORT="$ZOWE_ZLUX_SERVER_HTTP_PORT >> $LOG_FILE
 echo "  ZOWE_ZLUX_SERVER_HTTPS_PORT="$ZOWE_ZLUX_SERVER_HTTPS_PORT >> $LOG_FILE
 echo "  ZOWE_EXPLORER_SERVER_JOBS_PORT="$ZOWE_EXPLORER_SERVER_JOBS_PORT >> $LOG_FILE
 echo "  ZOWE_EXPLORER_SERVER_DATASETS_PORT="$ZOWE_EXPLORER_SERVER_DATASETS_PORT >> $LOG_FILE

--- a/scripts/zowe-verify.sh
+++ b/scripts/zowe-verify.sh
@@ -385,7 +385,6 @@ fi
     #   httpsPort=7443
     # http and https ports for the node server
     #   zlux-server:
-    #   httpPort=8543
     #   httpsPort=8544
     #   zssPort=8542
 
@@ -402,7 +401,6 @@ echo Check port settings from Zowe config files
   api_mediation_discovery_http_port=7553    # api-mediation/scripts/api-mediation-start-discovery.sh
   api_mediation_gateway_https_port=7554     # api-mediation/scripts/api-mediation-start-gateway.sh
 
-  zlux_server_http_port=8543                # zlux-example-server/config/zluxserver.json
   zlux_server_https_port=8544               # zlux-example-server/config/zluxserver.json
   zss_server_http_port=8542                 # zlux-example-server/config/zluxserver.json
   terminal_sshPort=22                       # vt-ng2/_defaultVT.json
@@ -503,14 +501,6 @@ do
         *\.json) 
         # echo Checking .json files 
         # fragile search
-        zlux_server_http_port=`sed -n 's/.*"port" *: *\([0-9]*\) *$/\1/p' ${ZOWE_ROOT_DIR}/$file`
-        if [[ -n "$zlux_server_http_port" ]]
-        then
-            echo OK: zlux server httpPort is $zlux_server_http_port
-        else
-            echo Error: zlux server httpPort not found in ${ZOWE_ROOT_DIR}/$file
-        fi         
-                
         zlux_server_https_port=`sed -n 's/.*"port" *: *\([0-9]*\) *,.*/\1/p; /}/q' ${ZOWE_ROOT_DIR}/$file`
         if [[ -n "$zlux_server_https_port" ]]
         then
@@ -610,7 +600,6 @@ then    # job name is short enough to have a suffix
                 6)
                 # job6
                     for port in \
-                        $zlux_server_http_port \
                         $api_mediation_discovery_http_port \
                         $zlux_server_https_port 
                     do

--- a/scripts/zowe-zlux-configure-ports.sh
+++ b/scripts/zowe-zlux-configure-ports.sh
@@ -17,10 +17,9 @@ echo "<zowe-zlux-configure-ports.sh>" >> $LOG_FILE
 chmod -R u+w $ZLUX_SERVER_CONFIG_PATH/
 cd $ZLUX_SERVER_CONFIG_PATH/
 
-echo "Updating ports in zluxserver.json "$ZOWE_ZLUX_SERVER_HTTPS_PORT";"$ZOWE_ZLUX_SERVER_HTTP_PORT";"$ZOWE_ZLUX_SERVER_HTTPS_PORT  >> $LOG_FILE 
+echo "Updating ports in zluxserver.json "$ZOWE_ZLUX_SERVER_HTTPS_PORT";"$ZOWE_ZSS_SERVER_PORT  >> $LOG_FILE 
 sed 's/"port": 8544,/"port": '"${ZOWE_ZLUX_SERVER_HTTPS_PORT}",'/g' zluxserver.json > $TEMP_DIR/transform1.json
-sed 's/"port": 8543/"port": '"${ZOWE_ZLUX_SERVER_HTTP_PORT}"'/g' $TEMP_DIR/transform1.json > $TEMP_DIR/transform2.json
-sed 's/"zssPort":8542/"zssPort": '"${ZOWE_ZSS_SERVER_PORT}"'/g' $TEMP_DIR/transform2.json > $TEMP_DIR/transform3.json
+sed 's/"zssPort":8542/"zssPort": '"${ZOWE_ZSS_SERVER_PORT}"'/g' $TEMP_DIR/transform1.json > $TEMP_DIR/transform3.json
 if grep -q gatewayPort "zluxserver.json"; then
     sed 's/"gatewayPort":10010/"gatewayPort": '"${ZOWE_APIM_GATEWAY_PORT}"'/g' $TEMP_DIR/transform3.json > zluxserver.json
 else

--- a/tests/data/zluxserver.json
+++ b/tests/data/zluxserver.json
@@ -7,9 +7,6 @@
       "certificates": ["../deploy/product/ZLUX/serverConfig/zlux.keystore.cer"],
       "certificateAuthorities": ["../deploy/product/ZLUX/serverConfig/apiml-localca.cer"]
     },
-    "http": {
-      "port": 8543
-    },
     "mediationLayer": {
       "server": {
         "hostname": "localhost",


### PR DESCRIPTION
Update zLUX to 1.0.0+<Metadata>.

Include fixes removing the zLUX HTTP port, only HTTPS configured @ install time.