### PR TITLE
Make opercmd executable in install scripts directory

### DIFF
--- a/install/zowe-install.sh
+++ b/install/zowe-install.sh
@@ -47,6 +47,8 @@ fi
 
 echo "Install started at: "`date` >> $LOG_FILE
 
+chmod a+x $INSTALL_DIR/scripts/opercmd
+
 # Populate the environment variables for ZOWE_SDSF_PATH, ZOWE_ZOSMF_PATH, ZOWE_JAVA_HOME, ZOWE_EXPLORER_HOST
 . $INSTALL_DIR/scripts/zowe-init.sh
 


### PR DESCRIPTION
Signed-off-by: John Davies <daviesja@uk.ibm.com>

I added this to ensure that `opercmd` is made executable earlier on in the install process, even if you don't run `zowe-check-prereqs.sh` first (which sets it executable).  It is already set executable when it is copied to the runtime directory.