### PR TITLE
update download spec to use explorer api release pipeline results

### DIFF
--- a/artifactory-download-spec.json.template
+++ b/artifactory-download-spec.json.template
@@ -5,13 +5,13 @@
       "flat": "true"
     },
     {
-      "pattern": "libs-release-local/org/zowe/explorer/jobs/0.0.1/jobs-zowe-server-package-0.0.1.zip",
+      "pattern": "libs-release-local/org/zowe/explorer/jobs/jobs-zowe-server-package/0.1.0/jobs-zowe-server-package-0.1.0.zip",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/",
       "flat": "true",
       "explode": "true"
     },
     {
-      "pattern": "libs-release-local/org/zowe/explorer/datasets/0.0.1/data-sets-zowe-server-package-0.0.1.zip",
+      "pattern": "libs-release-local/org/zowe/explorer/datasets/data-sets-zowe-server-package/0.1.0/data-sets-zowe-server-package-0.1.0.zip",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/",
       "flat": "true",
       "explode": "true"


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

Explorer API release pipelines:
- https://wash.zowe.org:8443/job/Explorer-Data%20Sets-Release/
- https://wash.zowe.org:8443/job/Explorer-Jobs-Release/
are on place.

Do a PATCH_RELEASE after each change. The release pipeline will do tag and bump on master branch.