### PR TITLE
verify node.js version in post-install script

### DIFF
--- a/install/zowe-check-prereqs.sh
+++ b/install/zowe-check-prereqs.sh
@@ -423,14 +423,14 @@ echo
 echo Check Node version
 
 # 9.1. Node is installed and working
-# IBM SDK for Node.js z/OS Version 6.11.2 or later.
-nodeVersion=`node --version`
+# IBM SDK for Node.js z/OS Version 6.14.4 or later.
+nodeVersion=`node --version 2>&1`
 if [[ $? -ne 0 ]]
 then
   # node version error
 
   echo $nodeVersion | grep 'not found'
-  if [[ $? -eq 0 ]]   # this test is wrong.
+  if [[ $? -eq 0 ]]   # the 'node' command was not found.
   then 
     # echo node not found in your path ... trying standard location
     nodelink=`ls -l /usr/lpp/IBM/cnj/IBM/node-*|grep ^l`  # is there a node symlink in this list?
@@ -458,7 +458,7 @@ fi
 if [[ -n "${nodeVersion}" ]]
 then 
     # nodeVersion is not empty 
-    if [[ "$nodeVersion" < "v6.14" ]]
+    if [[ "$nodeVersion" < "v6.14.4" ]]
           then 
             echo Error: node version $nodeVersion is less than minimum level required
           else 

--- a/scripts/zowe-verify.sh
+++ b/scripts/zowe-verify.sh
@@ -747,20 +747,26 @@ echo
 echo Check Node is installed and working
 
 # IBM SDK for Node.js z/OS Version 6.11.2 or later.
-  response=`node --version`  2>/dev/null
-  echo $response | grep 'not found'
-  if [[ `echo $?` == 0 ]]
+response=`node --version`  2>/dev/null
+if [[ $? -ne 0 ]]
 then 
-    echo Info: node not found in your path ... searching standard location
-else 
+    echo Warning: node not found in your path ... searching standard location
+ 
     nodelink=`ls -l /usr/lpp/IBM/cnj/IBM/node-*|grep ^l`
-    if [[ `echo $?` == 0 ]]
+    if [[ $? -eq 0 ]]
     then 
         # echo "Info: symlink to node found : $nodelink"
-        echo Info: node version is
+        echo Info: node version in /usr/lpp/IBM/cnj/IBM is
         /usr`echo $nodelink | sed 's+.*/usr\(.*\) ->.*+\1+'`/bin/node --version
     else 
         echo Error: node not found
+    fi
+else
+    if [[ $response < v6.14 ]]
+    then
+        echo Error: version $response is lower than required 
+    else 
+        echo OK: version is $response 
     fi
 fi
 

--- a/scripts/zowe-verify.sh
+++ b/scripts/zowe-verify.sh
@@ -746,7 +746,7 @@ fi
 echo
 echo Check Node is installed and working
 
-# IBM SDK for Node.js z/OS Version 6.11.2 or later.
+# IBM SDK for Node.js z/OS Version 6.14.4 or later.
 response=`node --version`  2>/dev/null
 if [[ $? -ne 0 ]]
 then 
@@ -762,7 +762,7 @@ then
         echo Error: node not found
     fi
 else
-    if [[ $response < v6.14 ]]
+    if [[ $response < v6.14.4]]
     then
         echo Error: version $response is lower than required 
     else 


### PR DESCRIPTION
Signed-off-by: John Davies <daviesja@uk.ibm.com>

The part of `zowe-verify.sh ` that checks node.js version did not detect if node was not found, and neither did it check the version was at least the level required.  

`zowe-check-prereqs.sh` does check the version was at least the level required, but users might not run that.  