### PR TITLE
Switch to nodeCluster instead of nodeServer

### DIFF
--- a/scripts/run-zowe.sh
+++ b/scripts/run-zowe.sh
@@ -22,7 +22,7 @@ if [[ ! -f $NODE_HOME/"./bin/node" ]]
 then
 export NODE_HOME=$nodehome
 fi
-`dirname $0`/../../zlux-app-server/bin/nodeServer.sh --allowInvalidTLSProxy=true &
+`dirname $0`/../../zlux-app-server/bin/nodeCluster.sh --allowInvalidTLSProxy=true &
 `dirname $0`/../../api-mediation/scripts/api-mediation-start-discovery.sh
 `dirname $0`/../../api-mediation/scripts/api-mediation-start-catalog.sh
 `dirname $0`/../../api-mediation/scripts/api-mediation-start-gateway.sh


### PR DESCRIPTION
Use nodeCluster instead of nodeServer as it is crash-resistent for uncaught exceptions

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>