### PR TITLE
fix typo in ZOWESVR.jcl

### DIFF
--- a/files/templates/ZOWESVR.jcl
+++ b/files/templates/ZOWESVR.jcl
@@ -12,7 +12,7 @@
 //* ZOWE SERVER PROCEDURE                                            *
 //*                                                                  *
 //* This is a procedure to start the Node servers, API Mediation     *
-//* and explorera                                                    *
+//* and explorers                                                    *
 //*                                                                  *
 //* Invoke this procedure, specifying the root path where the        *
 //* ZOWE server is installed on your system.                         *


### PR DESCRIPTION
There was a typo in line 15 of the PROC.  It was a comment line but I fixed it anyway.