### PR TITLE
Use ocopy shr to deploy xmem to datasets

### DIFF
--- a/scripts/zss/ocopyshr.rexx
+++ b/scripts/zss/ocopyshr.rexx
@@ -1,0 +1,37 @@
+/* REXX */
+
+/**
+ * This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which accompanies
+ * this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+
+/**
+ * Script to copy a USS file to a shared dataset / shared PDS member using OCOPY.
+ */
+
+
+trace 'o'
+parse arg filename dsname mode tail
+
+if filename = '' | dsname = '' | (mode <> 'BINARY' & mode <> 'TEXT') | tail <> '' then
+do
+  say 'Usage: ocopyshr.rexx "<filename>" "<dsname[(member)]>" BINARY|TEXT'
+  say '    <filename>            absolute path of file'
+  say '    <dsname[(member)]>    data set name to copy into'
+  exit 1
+end
+
+address TSO "alloc fi(file) path('"filename"')"
+if rc <> 0 then exit rc
+address TSO "alloc fi(ds) dataset('"dsname"') shr"
+if rc <> 0 then exit rc
+address TSO "ocopy indd(file) outdd(ds) "mode
+if rc <> 0 then exit rc
+address TSO "free fi(file ds)"
+exit rc

--- a/scripts/zss/ocopyshr.rexx
+++ b/scripts/zss/ocopyshr.rexx
@@ -29,9 +29,16 @@ end
 
 address TSO "alloc fi(file) path('"filename"')"
 if rc <> 0 then exit rc
+
 address TSO "alloc fi(ds) dataset('"dsname"') shr"
-if rc <> 0 then exit rc
+if rc <> 0 then
+do
+  alloc_rc = rc
+  address TSO "free fi(file)"
+  exit alloc_rc
+end
+
 address TSO "ocopy indd(file) outdd(ds) "mode
-if rc <> 0 then exit rc
+ocopy_rc = rc
 address TSO "free fi(file ds)"
-exit rc
+exit ocopy_rc

--- a/scripts/zss/zowe-xmem-deploy-loadmodule.sh
+++ b/scripts/zss/zowe-xmem-deploy-loadmodule.sh
@@ -43,7 +43,7 @@ fi
 
 if [[ "$rc" = 0 ]] ; then
   echo "Copying load module ${loadmodule}"
-  if cp ${ZSS}/LOADLIB/${loadmodule} "//'${loadlib}'"
+  if ${BASEDIR}/ocopyshr.rexx ${ZSS}/LOADLIB/${loadmodule} "${loadlib}(${loadmodule})" BINARY
   then
     echo "Info:  module ${loadmodule} has been successfully copied to dataset ${loadlib}"
     rc=0

--- a/scripts/zss/zowe-xmem-deploy-parmlib.sh
+++ b/scripts/zss/zowe-xmem-deploy-parmlib.sh
@@ -36,7 +36,7 @@ fi
 
 if [[ "$rc" = 0 ]] ; then
   echo "Copying parmlib member ${parm}"
-  if cp ${ZSS}/SAMPLIB/${parm} "//'${parmlib}'"
+  if ${BASEDIR}/ocopyshr.rexx ${ZSS}/SAMPLIB/${parm} "${parmlib}(${parm})" TEXT
   then
     echo "Info:  PARMLIB member ${parm} has been successfully copied to dataset ${parmlib}"
     rc=0

--- a/scripts/zss/zowe-xmem-deploy-proclib.sh
+++ b/scripts/zss/zowe-xmem-deploy-proclib.sh
@@ -21,7 +21,7 @@ if [[ $? -eq 0 ]]; then
 fi
 
 echo "Copy PROCLIB member ${member} to ${proclib}"
-if cp ${ZSS}/SAMPLIB/${jclfile} "//'${proclib}(${member})'" 
+if ${BASEDIR}/ocopyshr.rexx ${ZSS}/SAMPLIB/${jclfile} "${proclib}(${member})" TEXT
 then
   echo "Info:  PROCLIB member ${member} has been successfully copied to dataset ${proclib}"
   exit 0


### PR DESCRIPTION
https://github.com/zowe/zowe-install-packaging/issues/384

`zowe-install-apf-server.sh` may fail to copy files to datasets, because the `cp` command can't write to a z/OS dataset if any process has it allocated even if only for READ

`scripts/zowe-copy-proc.sh` can't be re-used for xmem installation:
- we need to deploy PARMLIB, LOADLIB and PROCLIB not only PROCLIB
- the existing script works in TEXT mode only
- it expects a certain context (variables and temp datasets) set up in `zowe-install.sh`

Signed-off-by: Dmitry Nikolaev <dnikolaev@rocketsoftware.com>