### PR TITLE
Use cp to copy ZWESIS01.

### DIFF
--- a/scripts/zss/zowe-xmem-deploy-loadmodule.sh
+++ b/scripts/zss/zowe-xmem-deploy-loadmodule.sh
@@ -43,7 +43,7 @@ fi
 
 if [[ "$rc" = 0 ]] ; then
   echo "Copying load module ${loadmodule}"
-  if ${BASEDIR}/ocopyshr.rexx ${ZSS}/LOADLIB/${loadmodule} "${loadlib}(${loadmodule})" BINARY
+  if cp -X ${ZSS}/LOADLIB/${loadmodule} "//'${loadlib}(${loadmodule})'"
   then
     echo "Info:  module ${loadmodule} has been successfully copied to dataset ${loadlib}"
     rc=0


### PR DESCRIPTION
The OCOPY documentation states that it cannot be used to copy
executables to an MVS dataset:

An executable file copied from the file system into an MVS
data set is not executable under MVS. Some required
directory information is lost during the copy.

Fixes #400
