### PR TITLE
Use individual zLUX artifacts & put zLUX release configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,7 @@ sed -e 's/{BUILD_BRANCH}/${env.BRANCH_NAME}/g' \
       echo downloadResult
       def downloadResultObject = readJSON(text: downloadResult)
       if (downloadResultObject['status'] != 'success' ||
-          downloadResultObject['totals']['success'] != 9 || downloadResultObject['totals']['failure'] != 0) {
+          downloadResultObject['totals']['success'] != 18 || downloadResultObject['totals']['failure'] != 0) {
         echo "status: ${downloadResultObject['status']}"
         echo "success: ${downloadResultObject['totals']['success']}"
         echo "failure: ${downloadResultObject['totals']['failure']}"

--- a/artifactory-download-spec.json.template
+++ b/artifactory-download-spec.json.template
@@ -1,7 +1,52 @@
 {
   "files": [{
-      "pattern": "rocket-closed-source-builds/1.0.1+20190228/ZLUX.pax",
-      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/",
+      "pattern": "libs-snapshot-local/org/zowe/zlux/zlux-core/1.0.1-STAGING/zlux-core-1.0.1-20190313.111628.pax",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/zlux-core.pax",
+      "flat": "true"
+    },
+    {
+      "pattern": "libs-snapshot-local/org/zowe/zlux/zss-auth/1.0.1-STAGING/zss-auth-1.0.1-20190313.121413.pax",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/zss-auth.pax",
+      "flat": "true"
+    },
+    {
+      "pattern": "libs-snapshot-local/org/zowe/zlux/sample-angular-app/1.0.1-STAGING/sample-angular-app-1.0.1-20190313.115640.pax",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/sample-angular-app.pax",
+      "flat": "true"
+    },
+    {
+      "pattern": "libs-snapshot-local/org/zowe/zlux/sample-iframe-app/1.0.1-STAGING/sample-iframe-app-1.0.1-20190313.121210.pax",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/sample-iframe-app.pax",
+      "flat": "true"
+    },
+    {
+      "pattern": "libs-snapshot-local/org/zowe/zlux/sample-react-app/1.0.1-STAGING/sample-react-app-1.0.1-20190313.120623.pax",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/sample-react-app.pax",
+      "flat": "true"
+    },
+    {
+      "pattern": "libs-snapshot-local/org/zowe/zlux/tn3270-ng2/1.0.1-STAGING/tn3270-ng2-1.0.1-20190313.125326.pax",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/tn3270-ng2.pax",
+      "flat": "true"
+    },
+    {
+      "pattern": "libs-snapshot-local/org/zowe/zlux/vt-ng2/1.0.1-STAGING/vt-ng2-1.0.1-20190313.125120.pax",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/vt-ng2.pax",
+      "flat": "true"
+    },
+    {
+      "pattern": "libs-snapshot-local/org/zowe/zlux/zlux-editor/1.0.1-STAGING/zlux-editor-1.0.1-20190313.122244.pax",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/zlux-editor.pax",
+      "flat": "true"
+    },
+    {
+      "pattern": "libs-snapshot-local/org/zowe/zlux/zlux-workflow/1.0.1-STAGING/zlux-workflow-1.0.1-20190313.121818.pax",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/zlux-workflow.pax",
+      "flat": "true"
+    },
+    {
+      "pattern": "libs-snapshot-local/org/zowe/zlux/zosmf-auth/1.0.1-STAGING/zosmf-auth-1.0.1-20190313.121551.pax",
+      "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/zosmf-auth.pax",
       "flat": "true"
     },
     {

--- a/artifactory-download-spec.json.template
+++ b/artifactory-download-spec.json.template
@@ -1,56 +1,56 @@
 {
   "files": [{
-      "pattern": "libs-snapshot-local/org/zowe/zlux/zlux-core/1.0.1-STAGING/zlux-core-1.0.1-20190313.111628.pax",
+      "pattern": "libs-snapshot-local/org/zowe/zlux/zlux-core/1.0.1-STAGING/zlux-core-1.0.1-20190315.102503.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/zlux-core.pax",
       "flat": "true"
     },
     {
-      "pattern": "libs-snapshot-local/org/zowe/zlux/zss-auth/1.0.1-STAGING/zss-auth-1.0.1-20190313.121413.pax",
+      "pattern": "libs-snapshot-local/org/zowe/zlux/zss-auth/1.0.1-STAGING/zss-auth-1.0.1-20190315.103851.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/zss-auth.pax",
       "flat": "true"
     },
     {
-      "pattern": "libs-snapshot-local/org/zowe/zlux/sample-angular-app/1.0.1-STAGING/sample-angular-app-1.0.1-20190313.115640.pax",
+      "pattern": "libs-snapshot-local/org/zowe/zlux/sample-angular-app/1.0.1-STAGING/sample-angular-app-1.0.1-20190315.103610.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/sample-angular-app.pax",
       "flat": "true"
     },
     {
-      "pattern": "libs-snapshot-local/org/zowe/zlux/sample-iframe-app/1.0.1-STAGING/sample-iframe-app-1.0.1-20190313.121210.pax",
+      "pattern": "libs-snapshot-local/org/zowe/zlux/sample-iframe-app/1.0.1-STAGING/sample-iframe-app-1.0.1-20190315.103551.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/sample-iframe-app.pax",
       "flat": "true"
     },
     {
-      "pattern": "libs-snapshot-local/org/zowe/zlux/sample-react-app/1.0.1-STAGING/sample-react-app-1.0.1-20190313.120623.pax",
+      "pattern": "libs-snapshot-local/org/zowe/zlux/sample-react-app/1.0.1-STAGING/sample-react-app-1.0.1-20190315.104040.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/sample-react-app.pax",
       "flat": "true"
     },
     {
-      "pattern": "libs-snapshot-local/org/zowe/zlux/tn3270-ng2/1.0.1-STAGING/tn3270-ng2-1.0.1-20190313.125326.pax",
+      "pattern": "libs-snapshot-local/org/zowe/zlux/tn3270-ng2/1.0.1-STAGING/tn3270-ng2-1.0.1-20190315.103636.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/tn3270-ng2.pax",
       "flat": "true"
     },
     {
-      "pattern": "libs-snapshot-local/org/zowe/zlux/vt-ng2/1.0.1-STAGING/vt-ng2-1.0.1-20190313.125120.pax",
+      "pattern": "libs-snapshot-local/org/zowe/zlux/vt-ng2/1.0.1-STAGING/vt-ng2-1.0.1-20190315.103701.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/vt-ng2.pax",
       "flat": "true"
     },
     {
-      "pattern": "libs-snapshot-local/org/zowe/zlux/zlux-editor/1.0.1-STAGING/zlux-editor-1.0.1-20190313.122244.pax",
+      "pattern": "libs-snapshot-local/org/zowe/zlux/zlux-editor/1.0.1-STAGING/zlux-editor-1.0.1-20190315.104100.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/zlux-editor.pax",
       "flat": "true"
     },
     {
-      "pattern": "libs-snapshot-local/org/zowe/zlux/zlux-workflow/1.0.1-STAGING/zlux-workflow-1.0.1-20190313.121818.pax",
+      "pattern": "libs-snapshot-local/org/zowe/zlux/zlux-workflow/1.0.1-STAGING/zlux-workflow-1.0.1-20190315.103814.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/zlux-workflow.pax",
       "flat": "true"
     },
     {
-      "pattern": "libs-snapshot-local/org/zowe/zlux/zosmf-auth/1.0.1-STAGING/zosmf-auth-1.0.1-20190313.121551.pax",
+      "pattern": "libs-snapshot-local/org/zowe/zlux/zosmf-auth/1.0.1-STAGING/zosmf-auth-1.0.1-20190315.103723.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zlux/zosmf-auth.pax",
       "flat": "true"
     },
     {
-      "pattern": "libs-snapshot-local/org/zowe/zss/1.0.1-SNAPSHOT/zss-1.0.1-20190228.174537-3.pax",
+      "pattern": "libs-snapshot-local/org/zowe/zss/1.0.1-STAGING/zss-1.0.1-20190311.151658-1.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/zss.pax",
       "flat": "true"
     },

--- a/artifactory-download-spec.json.template
+++ b/artifactory-download-spec.json.template
@@ -55,14 +55,20 @@
       "flat": "true"
     },
     {
-      "pattern": "libs-release-local/org/zowe/explorer/jobs/jobs-zowe-server-package/0.1.1/jobs-zowe-server-package-0.1.1.zip",
+      "pattern": "libs-release-local/org/zowe/explorer/jobs/jobs-zowe-server-package/0.1.*/jobs-zowe-server-package-0.1.*.zip",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/",
+      "sortBy": ["created"],
+      "sortOrder": "desc",
+      "limit": 1,
       "flat": "true",
       "explode": "true"
     },
     {
-      "pattern": "libs-release-local/org/zowe/explorer/datasets/data-sets-zowe-server-package/0.1.1/data-sets-zowe-server-package-0.1.1.zip",
+      "pattern": "libs-release-local/org/zowe/explorer/datasets/data-sets-zowe-server-package/0.1.*/data-sets-zowe-server-package-0.1.*.zip",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/",
+      "sortBy": ["created"],
+      "sortOrder": "desc",
+      "limit": 1,
       "flat": "true",
       "explode": "true"
     },

--- a/files/zlux/config/pinnedPlugins.json
+++ b/files/zlux/config/pinnedPlugins.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "org.zowe.terminal.tn3270",
+    "org.zowe.terminal.vt",
+    "org.zowe.zlux.sample.angular",
+    "org.zowe.zlux.sample.react",
+    "org.zowe.zlux.sample.iframe"
+  ]
+}

--- a/files/zlux/config/plugins/org.zowe.configjs.json
+++ b/files/zlux/config/plugins/org.zowe.configjs.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.configjs",
+  "pluginLocation": "../../zlux-server-framework/plugins/config"
+}

--- a/files/zlux/config/plugins/org.zowe.editor.json
+++ b/files/zlux/config/plugins/org.zowe.editor.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.editor",
+  "pluginLocation": "../../zlux-editor"
+}

--- a/files/zlux/config/plugins/org.zowe.terminal.proxy.json
+++ b/files/zlux/config/plugins/org.zowe.terminal.proxy.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.terminal.proxy",
+  "pluginLocation": "../../zlux-server-framework/plugins/terminal-proxy"
+}

--- a/files/zlux/config/plugins/org.zowe.terminal.tn3270.json
+++ b/files/zlux/config/plugins/org.zowe.terminal.tn3270.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.terminal.tn3270",
+  "pluginLocation": "../../tn3270-ng2"
+}

--- a/files/zlux/config/plugins/org.zowe.terminal.vt.json
+++ b/files/zlux/config/plugins/org.zowe.terminal.vt.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.terminal.vt",
+  "pluginLocation": "../../vt-ng2"
+}

--- a/files/zlux/config/plugins/org.zowe.zlux.appmanager.app.propview.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.appmanager.app.propview.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.zlux.appmanager.app.propview",
+  "pluginLocation": "../../zlux-app-manager/system-apps/app-prop-viewer"
+}

--- a/files/zlux/config/plugins/org.zowe.zlux.auth.trivial.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.auth.trivial.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.zlux.auth.trivial",
+  "pluginLocation": "../../zlux-server-framework/plugins/trivial-auth"
+}

--- a/files/zlux/config/plugins/org.zowe.zlux.auth.zosmf.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.auth.zosmf.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.zlux.auth.zosmf",
+  "pluginLocation": "../../zosmf-auth"
+}

--- a/files/zlux/config/plugins/org.zowe.zlux.auth.zss.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.auth.zss.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.zlux.auth.zss",
+  "pluginLocation": "../../zss-auth"
+}

--- a/files/zlux/config/plugins/org.zowe.zlux.bootstrap.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.bootstrap.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.zlux.bootstrap",
+  "pluginLocation": "../../zlux-app-manager/bootstrap"
+}

--- a/files/zlux/config/plugins/org.zowe.zlux.logger.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.logger.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.zlux.logger",
+  "pluginLocation": "../../zlux-shared/src/logging"
+}

--- a/files/zlux/config/plugins/org.zowe.zlux.ng2desktop.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.ng2desktop.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.zlux.ng2desktop",
+  "pluginLocation": "../../zlux-app-manager/virtual-desktop"
+}

--- a/files/zlux/config/plugins/org.zowe.zlux.proxy.zosmf.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.proxy.zosmf.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.zlux.proxy.zosmf",
+  "pluginLocation": "../../zosmf-auth/proxy"
+}

--- a/files/zlux/config/plugins/org.zowe.zlux.sample.angular.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.sample.angular.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.zlux.sample.angular",
+  "pluginLocation": "../../sample-angular-app"
+}

--- a/files/zlux/config/plugins/org.zowe.zlux.sample.iframe.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.sample.iframe.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.zlux.sample.iframe",
+  "pluginLocation": "../../sample-iframe-app"
+}

--- a/files/zlux/config/plugins/org.zowe.zlux.sample.react.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.sample.react.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.zlux.sample.react",
+  "pluginLocation": "../../sample-react-app"
+}

--- a/files/zlux/config/plugins/org.zowe.zosmf.workflows.json
+++ b/files/zlux/config/plugins/org.zowe.zosmf.workflows.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.zosmf.workflows",
+  "pluginLocation": "../../zlux-workflow"
+}

--- a/files/zlux/config/zluxserver.json
+++ b/files/zlux/config/zluxserver.json
@@ -1,0 +1,67 @@
+{
+  "node": {
+    "https": {
+      "ipAddresses": ["0.0.0.0"],
+      "port": 8544,
+      //pfx (string), keys, certificates, certificateAuthorities, and certificateRevocationLists are all valid here.
+      "keys": ["../deploy/product/ZLUX/serverConfig/zlux.keystore.key"],
+      "certificates": ["../deploy/product/ZLUX/serverConfig/zlux.keystore.cer"],
+      "certificateAuthorities": ["../deploy/product/ZLUX/serverConfig/apiml-localca.cer"]
+    },
+    "mediationLayer": {
+      "server": {
+        "hostname": "localhost",
+        "port": 10011,
+        "isHttps": false
+      },
+      "enabled": false
+    },
+    "childProcesses": [
+      {
+        "path": "../bin/zssServer.sh",
+        "once": true
+      }
+    ]
+  },
+  "agent": {
+    //host is for zlux to know, not zss
+    "host": "localhost",
+    "http": {
+      "ipAddresses": ["127.0.0.1"],
+      //to be a replacement for zssPort
+      "port": 8542
+    }
+  },
+// All paths relative to ZLUX/node or ZLUX/bin
+// In real installations, these values will be configured during the install.
+  "rootDir":"../deploy",
+  "productDir":"../deploy/product",
+  "siteDir":"../deploy/site",
+  "instanceDir":"../deploy/instance",
+  "groupsDir":"../deploy/instance/groups",
+  "usersDir":"../deploy/instance/users",
+  "pluginsDir":"../deploy/instance/ZLUX/plugins",
+
+  "dataserviceAuthentication": {
+    //this specifies the default authentication type for dataservices that didn't specify which type to use. These dataservices therefore should not expect a particular type of authentication to be used.
+    "defaultAuthentication": "zss",
+    
+    //each authentication type may have more than one implementing plugin. define defaults and fallbacks below as well
+    //any types that have no implementers are ignored, and any implementations specified here that are not known to the server are also ignored.
+    "implementationDefaults": {
+      //each type has an object which describes which implementation to use based on some criteria to find which is best for the task. For now, just "plugins" will
+      //be used to state that you want a particular plugin.
+      "zosmf": {
+      // zosmf plugin needs to be configured to target a zosmf instance. configure before using.
+      // "plugins": ["org.zowe.zlux.auth.zosmf"]
+      },
+
+      "zss": {
+        "plugins": ["org.zowe.zlux.auth.zss"]
+      } 
+      
+    }
+  },
+  // internal port, do not connect browser to this port
+  "zssPort":8542
+}

--- a/install/zowe-install-apf-server.sh
+++ b/install/zowe-install-apf-server.sh
@@ -194,7 +194,7 @@ if $safOk ; then
   echo
   echo "************************ Install step 'Security profile' start *****************"
   xmemProfileCmd1="sh $SCRIPT_DIR/zowe-xmem-check-profile.sh ${saf} FACILITY ${XMEM_PROFILE} ${ZOWE_USER}"
-  xmemProfileCmd2="sh $SCRIPT_DIR/zowe-xmem-define-xmem-profile.sh ${saf} ${XMEM_PROFILE}"
+  xmemProfileCmd2="sh $SCRIPT_DIR/zowe-xmem-define-xmem-profile.sh ${saf} ${XMEM_PROFILE} ${ZOWE_TSS_FAC_OWNER}"
   $xmemProfileCmd1
   rc=$?
   if [[ $rc -eq 1 ]]; then

--- a/install/zowe-install-apf-server.yaml
+++ b/install/zowe-install-apf-server.yaml
@@ -15,6 +15,8 @@ install:
 users:
   # User to run Zowe server (required, no default values)
   zoweUser=
+  # TSS Facility Owner (Required for TSS. 'auto' supplies the running user)
+  tssFacilityOwner=auto
   # APF server STC user (ZWESISTC by default)
   stcUser=
   # APF server STC user UID (required if STC user doesn't exist)

--- a/install/zowe-install.sh
+++ b/install/zowe-install.sh
@@ -121,7 +121,7 @@ fi
 # Add API Catalog application to zLUX - required before we issue ZLUX deploy.sh
 . $INSTALL_DIR/scripts/zowe-install-iframe-plugin.sh $ZOWE_ROOT_DIR "org.zowe.api.catalog" "API Catalog" $CATALOG_GATEWAY_URL $INSTALL_DIR/files/assets/api-catalog.png
 
-echo "---- After expanding ZLUX.pax this is a directory listing of "$ZOWE_ROOT_DIR >> $LOG_FILE
+echo "---- After expanding zLUX artifacts this is a directory listing of "$ZOWE_ROOT_DIR >> $LOG_FILE
 ls $ZOWE_ROOT_DIR >> $LOG_FILE
 echo "-----"
 

--- a/scripts/zlux-install-script.sh
+++ b/scripts/zlux-install-script.sh
@@ -13,8 +13,26 @@
 
 cd $ZOWE_ROOT_DIR
 umask 0002
-echo "Unpax $INSTALL_DIR/files/ZLUX.pax " >> $LOG_FILE
-pax -r -px -f $INSTALL_DIR/files/ZLUX.pax
+echo "Unpax $INSTALL_DIR/files/zlux/zlux-core.pax " >> $LOG_FILE
+pax -r -px -f $INSTALL_DIR/files/zlux/zlux-core.pax
+
+for paxfile in ${INSTALL_DIR}/files/zlux/*.pax
+do
+  if [[ $paxfile != "${INSTALL_DIR}/files/zlux/zlux-core.pax" ]]
+  then
+    filename=$(basename $paxfile)
+    pluginName="${filename%.*}"
+    mkdir $pluginName && cd $pluginName
+    echo "Unpax ${paxfile} " >> $LOG_FILE
+    pax -r -px -f ${paxfile}
+    cd ..
+  fi
+done
+
+mkdir -p zlux-app-server/pluginDefaults/org.zowe.zlux.ng2desktop/ui/launchbar/plugins
+cp -f ${INSTALL_DIR}/files/zlux/config/pinnedPlugins.json zlux-app-server/pluginDefaults/org.zowe.zlux.ng2desktop/ui/launchbar/plugins/
+cp -f ${INSTALL_DIR}/files/zlux/config/zluxserver.json zlux-app-server/config/
+cp -f ${INSTALL_DIR}/files/zlux/config/plugins/* zlux-app-server/plugins/
 
 echo "Unpax zssServer " >> $LOG_FILE
 cd zlux-app-server/bin

--- a/scripts/zss/zowe-xmem-check-access.sh
+++ b/scripts/zss/zowe-xmem-check-access.sh
@@ -46,9 +46,32 @@ ACF2)
 ;;
 
 TSS)
-  echo "Warning:  TopSecret support has not been implemented," \
-    "please manually check if ${user} has access"
-  rc=8
+  if [[ "${class}" = "FACILITY" ]]; then
+    class="IBMFAC"
+  fi
+  tsocmd "TSS WHOHAS ${class}(${profile})" \
+    1>/tmp/cmd.out 2>/tmp/cmd.err
+  tsoRC=$?
+  if [[ $tsoRC -eq 0 ]]
+  then
+    cat /tmp/cmd.out | grep -F "${user}" 1>/dev/null
+    if [[ $? -eq 0 ]]
+    then
+      echo "Info: user ${user} has access to ${profile} in class ${class}"
+      rc=0
+    else
+      echo "Warning: user ${user} has no access to ${profile} in class ${class}"
+      rc=1
+    fi
+  elif [[ $tsoRC -eq 4 ]]
+  then
+    echo "Warning: user ${user} has no access to ${profile} in class ${class}"
+    rc=1
+  else
+    echo Error:  WHOHAS failed with the following errors
+    cat /tmp/cmd.out /tmp/cmd.err
+    rc=8
+  fi
 ;;
 
 *)

--- a/scripts/zss/zowe-xmem-check-profile.sh
+++ b/scripts/zss/zowe-xmem-check-profile.sh
@@ -52,9 +52,50 @@ ACF2)
 ;;
 
 TSS)
-  echo "Warning:  TopSecret support has not been implemented," \
-    "please manually check if ${profile} is defined in class ${class}"
-  rc=8
+  if [[ "${class}" = "FACILITY" ]]; then
+    class="IBMFAC"
+  fi
+  tsocmd "TSS WHOOWNS ${class}(${profile})" \
+    1>/tmp/cmd.out 2>/tmp/cmd.err
+  tsoRC=$?
+  if [[ $tsoRC -eq 0 ]]
+  then
+    # This line converts the facility to an HLQ. e.g, ZWES.IS becomes ZWES.
+    # For longer HLQs, "ZWES.DUMMY.HLQ", this returns "ZWES.DUMMY.". This behavior may not be
+    #  desirable in all cases, but is not a risk to current 1.x install which only uses 'ZWES.IS'.
+    # This HLQ facility format is required for TSS, as there may be an HLQ facility definition
+    #  with read access granted to a sub-facility.
+    profileHlq=$(echo "${profile}" | sed 's/\(.*\.\).*/\1/g')
+    cat /tmp/cmd.out | grep -F "${profileHlq}" 1>/dev/null
+    if [[ $? -eq 0 ]]
+    then
+      echo "Info: profile ${profile} is defined in class ${class}"
+      rc=0
+    else
+      echo "Warning: profile ${profile} is not defined in class ${class}"
+      rc=1
+    fi
+  elif [[ $tsoRC -eq 4 ]]
+  then
+    echo "Warning: profile ${profile} is not defined in class ${class}"
+    rc=1
+  elif [[ $tsoRC -eq 8 ]]
+  then
+    tss0318e="TSS0318E  RESOURCE NOT FOUND IN SECURITY FILE"
+    cat /tmp/cmd.out | grep -F "${tss0318e}" 1>/dev/null
+    if [[ $? -eq 0 ]]; then
+      echo "Warning: profile ${profile} is not defined in class ${class}"
+      rc=1
+    else
+      echo Error: WHOOWNS failed with the following errors
+      cat /tmp/cmd.out /tmp/cmd.err
+      rc=8
+    fi
+  else # RC > 8
+    echo Error:  WHOOWNS failed with the following errors
+    cat /tmp/cmd.out /tmp/cmd.err
+    rc=8
+  fi
 ;;
 
 *)

--- a/scripts/zss/zowe-xmem-check-stc-profile.sh
+++ b/scripts/zss/zowe-xmem-check-stc-profile.sh
@@ -15,7 +15,49 @@ profile=$prefix"*.*"
 
 echo "Check STC profile ${profile} (SAF=${saf})"
 
-sh $BASEDIR/zowe-xmem-check-profile.sh $saf STARTED $profile
+case $saf in
 
-exit $?
+RACF)
+  sh $BASEDIR/zowe-xmem-check-profile.sh $saf STARTED $profile
+;;
+
+ACF2)
+  echo "Warning:  ACF2 support has not been implemented," \
+    "please manually check if ${profile} is defined as an STC in ACF2"
+  rc=8
+;;
+
+TSS)
+  tsocmd "TSS LIST(STC) PROCNAME(${prefix})PREFIX" \
+    1>/tmp/cmd.out 2>/tmp/cmd.err
+  tsoRC=$?
+  if [[ $tsoRC -eq 0 ]]
+  then
+    cat /tmp/cmd.out | grep -F "${prefix}" 1>/dev/null
+    if [[ $? -eq 0 ]]
+    then
+      echo "Info: STC with prefix \"${prefix}\" is defined in TSS"
+      rc=0
+    else
+      echo "Warning: STC with prefix \"${prefix}\" is not defined to TSS"
+      rc=1
+    fi
+  elif [[ $tsoRC -eq 4 ]]
+  then
+    echo "Warning: STC with prefix \"${prefix}\" is not defined to TSS"
+    rc=1
+  else
+    echo "Error:  LIST(STC) failed with the following errors"
+    cat /tmp/cmd.out /tmp/cmd.err
+    rc=8
+  fi
+;;
+
+*)
+  echo "Error:  Unexpected SAF $saf"
+  rc=8
+esac
+
+rm /tmp/cmd.out /tmp/cmd.err 1> /dev/null 2> /dev/null
+exit $rc
 

--- a/scripts/zss/zowe-xmem-check-user.sh
+++ b/scripts/zss/zowe-xmem-check-user.sh
@@ -1,61 +1,66 @@
 #!/bin/sh
-
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies
 # this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
-# 
+#
 # Copyright Contributors to the Zowe Project.
-
 BASEDIR=$(dirname "$0")
 saf=$1
 user=$2
-
 echo "Check if user ${user} is defined (SAF=${saf})"
-
 case $saf in
-
 RACF)
   msg=`tsocmd "LU ${user}" 2>/dev/null | head -1`
-
   case $msg in
   UNABLE\ TO\ LOCATE\ USER\ *)
     echo "Warning:  User ${user} is not defined"
     exit 1
   ;;
-
   NOT\ AUTHORIZED\ TO\ LIST\ *)
     echo "Error: User ${user} is defined but you are not authorized to list it"
     exit 8
   ;;
-
   USER=${user}\ *)
     echo "Info:  User ${user} is defined and you are authorized to list it"
     exit 0
   ;;
-
   *)
     echo "Error:  Unexpected response to LU command"
     echo $msg
     exit 8
   esac
 ;;
-
 ACF2)
   echo "Warning:  ACF2 support has not been implemented," \
     "please manually check if user ${user} is defined"
   exit 8
 ;;
-
 TSS)
-  echo "Warning:  TopSecret support has not been implemented," \
-    "please manually check if user ${user} is defined"
-  exit 8
+  tss0314="TSS0314E  ACID DOES NOT EXIST"
+  tss0352="TSS0352E  ACID NOT OWNED WITHIN SCOPE"
+  msg=`tsocmd "TSS LIST(${user}) DATA(NAME)" 2>/dev/null | head -1 `
+  case $msg in
+  ${tss0314}*)
+    echo "Warning:  User ${user} is not defined"
+    exit 1
+  ;;
+  ${tss0352}*)
+    echo "Error: User ${user} is defined but you are not authorized to list it"
+    exit 8
+  ;;
+  ACCESSORID\ =\ ${user}\ *)
+    echo "Info:  User ${user} is defined and you are authorized to list it"
+    exit 0
+  ;;
+  *)
+    echo "Error:  Unexpected response to TSS LIST command"
+    echo $msg
+    exit 8
+  esac
 ;;
-
 *)
   echo "Error:  Unexpected SAF $saf"
   exit 8
 esac
-

--- a/scripts/zss/zowe-xmem-define-stc-profile.sh
+++ b/scripts/zss/zowe-xmem-define-stc-profile.sh
@@ -69,15 +69,15 @@ ACF2)
   ;;
 
 TSS)
-  tsocmd "TSS ADDTO(STC) PROCNAME(${tcProfile}*) ACID(${stcUser})" \
+  tsocmd "TSS ADD(STC) PROCNAME(${stcPrefix}*) ACID(${stcUser})" \
     1> /tmp/cmd.out 2> /tmp/cmd.err 
   if [[ $? -ne 0 ]]
   then
-    echo "Error:  TSS ADDTO(STC) failed with the following errors"
+    echo "Error:  TSS ADDTO(STC) PROCNAME(${stcPrefix}) ACID(${stcUser}) failed with the following errors"
     cat /tmp/cmd.out /tmp/cmd.err
     rc=8
   else
-    echo "Info:  STC profile has been defined"
+    echo "Info:  STC profile ${stcPrefix}* has been added to ${stcUser}"
     rc=0
   fi 
   ;;

--- a/scripts/zss/zowe-xmem-define-stc-user.sh
+++ b/scripts/zss/zowe-xmem-define-stc-user.sh
@@ -68,14 +68,14 @@ ACF2)
   ;;
 
 TSS)
-  tsocmd "TSS ADD(${stcUser}) OMVSGRP(${stcGroup}) UID(${uid})" \
+  tsocmd "TSS ADDTO(${stcUser}) DFLTGRP(${stcGroup}) UID(${uid})" \
     1>/tmp/cmd.out 2>/tmp/cmd.err
   if [[ $? -eq 0 ]]
   then
-    echo "Info:  User ${stcUser} has been added"
+    echo "Info:  Group ${stcGroup} and UID ${uid} have been added to User ${stcUser}"
     rc=0
   else
-    echo "Error:  User ${stcUser} has not been added"
+    echo "Error:  Group ${stcGroup} and UID ${uid} were not added to User ${stcUser}"
     cat /tmp/cmd.out /tmp/cmd.err
     rc=8
   fi

--- a/scripts/zss/zowe-xmem-define-xmem-profile.sh
+++ b/scripts/zss/zowe-xmem-define-xmem-profile.sh
@@ -11,6 +11,7 @@
 BASEDIR=$(dirname "$0")
 saf=$1
 profile=$2
+tssOwner=$3
 
 rc=8
 
@@ -41,9 +42,17 @@ ACF2)
 ;;
 
 TSS)
-  echo "Warning:  TopSecret support has not been implemented," \
-    "please manually create ${profile} in the FACILITY class with UACC(NONE)"
-  rc=8
+  tsocmd "TSS ADDTO(${tssOwner}) IBMFAC(${profile})" \
+    1> /tmp/cmd.out 2> /tmp/cmd.err
+  if [[ $? -ne 0 ]]
+  then
+    echo "Error:  TSS ADD IBMFAC(${profile}) failed with the following errors: "
+    cat /tmp/cmd.out /tmp/cmd.err
+    rc=8
+  else
+    echo "Info:  IBMFAC(${profile}) has been defined to ${tssOwner}"
+    rc=0
+  fi
 ;;
 
 *)

--- a/scripts/zss/zowe-xmem-parse-yaml.sh
+++ b/scripts/zss/zowe-xmem-parse-yaml.sh
@@ -78,6 +78,16 @@ do
                     XMEM_STC_GROUP=$value
                     echo "  STC user group="${XMEM_STC_GROUP}
                 fi
+                if [[ $key == "tssFacilityOwner" ]] && [[ $value != "" ]]
+                then
+                    if [[ $value = "auto" ]]
+                    then
+                        ZOWE_TSS_FAC_OWNER=`id -u -n`
+                    else
+                        ZOWE_TSS_FAC_OWNER=$value
+                    fi
+                    echo "  TSS Facility Owner(if applicable)="${ZOWE_TSS_FAC_OWNER}
+                fi
             fi
         fi
     fi
@@ -122,4 +132,9 @@ fi
 if [[ ${XMEM_STC_GROUP} == "" ]]
 then
     echo "  STC user group not specified"
+fi
+if [[ ${ZOWE_TSS_FAC_OWNER} == "" ]]
+then
+    echo "  ERROR: TSS Facility Owner not specified, exiting. If you are not running TSS, please set this field to 'auto'."
+    exit 1
 fi

--- a/scripts/zss/zowe-xmem-permit.sh
+++ b/scripts/zss/zowe-xmem-permit.sh
@@ -42,10 +42,27 @@ ACF2)
 ;;
 
 TSS)
-  echo "Warning:  TopSecret support has not been implemented," \
-    "please manually grant user ${user} READ access to ${profile} in the FACILITY class"
-  rc=8
-;;
+  tsocmd "TSS PERMIT(${user}) IBMFAC(${profile}) ACCESS(READ)" \
+    1>/tmp/cmd.out 2>/tmp/cmd.err
+  tsoRC=$?
+  tss0300="TSS0300I  PERMIT   FUNCTION SUCCESSFUL"
+
+  if [[ $tsoRC -eq 0 ]]
+  then
+    cat /tmp/cmd.out | grep -F "${tss0300}" 1>/dev/null
+    if [[ $? -eq 0 ]]
+    then
+      echo "Info: User ${user} was granted READ access to ${profile}."
+      rc=0
+    else
+      rc=8
+    fi
+  fi
+  if [[ $rc -ne 0 ]]; then
+    echo "Error:  PERMIT function failed with the following errors:"
+    cat /tmp/cmd.out /tmp/cmd.err
+  fi
+  ;;
 
 *)
   echo "Error:  Unexpected SAF $saf"


### PR DESCRIPTION
That's a part of https://github.com/zowe/zlux/issues/110

Due to the zLUX capstone changes:
- packaging should use individual artifacts for each plugin and zLUX framework
- release configuration should be defined in the packaging repository

Signed-off-by: Dmitry Nikolaev <dnikolaev@rocketsoftware.com>