### PR TITLE
use tls1.2 restricted version of explorer components

### DIFF
--- a/artifactory-download-spec.json.template
+++ b/artifactory-download-spec.json.template
@@ -130,7 +130,7 @@
       "limit": 1
     },    
     {             
-      "pattern": "libs-snapshot-local/com/ca/mfaas/sdk/mfaas-zowe-install/1.1.*/mfaas-zowe-install-1.1.*.zip",
+      "pattern": "libs-release-local/com/ca/mfaas/sdk/mfaas-zowe-install/1.1.1/mfaas-zowe-install-1.1.1.zip",
       "target": "pax-workspace/mediation/",
       "flat": "true",
       "explode": "true",

--- a/artifactory-download-spec.json.template
+++ b/artifactory-download-spec.json.template
@@ -88,7 +88,7 @@
       "limit": 1
     },
     {
-      "pattern": "libs-release-local/org/zowe/explorer/jobs/jobs-zowe-server-package/0.2.*/jobs-zowe-server-package-0.2.*.zip",
+      "pattern": "libs-release-local/org/zowe/explorer/jobs/jobs-zowe-server-package/0.2.0/jobs-zowe-server-package-0.2.0.zip",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/",
       "sortBy": ["created"],
       "sortOrder": "desc",
@@ -97,7 +97,7 @@
       "explode": "true"
     },
     {
-      "pattern": "libs-release-local/org/zowe/explorer/datasets/data-sets-zowe-server-package/0.1.*/data-sets-zowe-server-package-0.1.*.zip",
+      "pattern": "libs-release-local/org/zowe/explorer/datasets/data-sets-zowe-server-package/0.1.3/data-sets-zowe-server-package-0.1.3.zip",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/",
       "sortBy": ["created"],
       "sortOrder": "desc",
@@ -106,7 +106,7 @@
       "explode": "true"
     },
     {
-      "pattern": "libs-release-local/org/zowe/explorer-jes/0.0.*/explorer-jes-0.0.*.pax",
+      "pattern": "libs-release-local/org/zowe/explorer-jes/0.0.16/explorer-jes-0.0.16.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/",
       "flat": "true",
       "sortBy": ["created"],
@@ -114,7 +114,7 @@
       "limit": 1
     },
     {
-      "pattern": "libs-release-local/org/zowe/explorer-mvs/0.0.*/explorer-mvs-0.0.*.pax",
+      "pattern": "libs-release-local/org/zowe/explorer-mvs/0.0.11/explorer-mvs-0.0.11.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/",
       "flat": "true",
       "sortBy": ["created"],
@@ -122,7 +122,7 @@
       "limit": 1
     },
     {
-      "pattern": "libs-release-local/org/zowe/explorer-uss/0.0.*/explorer-uss-0.0.*.pax",
+      "pattern": "libs-release-local/org/zowe/explorer-uss/0.0.10/explorer-uss-0.0.10.pax",
       "target": "pax-workspace/content/zowe-{ZOWE_VERSION}/files/",
       "flat": "true",
       "sortBy": ["created"],

--- a/artifactory-download-spec.json.template
+++ b/artifactory-download-spec.json.template
@@ -130,7 +130,7 @@
       "limit": 1
     },    
     {             
-      "pattern": "libs-release-local/com/ca/mfaas/sdk/mfaas-zowe-install/1.1.*/mfaas-zowe-install-1.1.*.zip",
+      "pattern": "libs-snapshot-local/com/ca/mfaas/sdk/mfaas-zowe-install/1.1.*/mfaas-zowe-install-1.1.*.zip",
       "target": "pax-workspace/mediation/",
       "flat": "true",
       "explode": "true",


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

This is a demonstration build which has explorer TLS v1.2 changes. This build will fail more test cases, so we may need to revert the changes once the debugging session is done.