### PR TITLE
Update zowe-install.yaml.template

### DIFF
--- a/install/zowe-install.yaml.template
+++ b/install/zowe-install.yaml.template
@@ -1,7 +1,8 @@
 # =================================================================
 # zowe install configuration
 # =================================================================
-# zowe-install: The directory that zowe will be installed into
+# zowe-install: The directory that zowe instance will be installed 
+# into.  (default: <home directory>/zowe/{ZOWE_VERSION} )
 install:
   rootDir=~/zowe/{ZOWE_VERSION}
 


### PR DESCRIPTION
Added a comment to clarify the directory is install of a zowe instance.
There has been some confusion between where zowe is unpax'd, which has been called the install directory, and where a zowe instance is installed.  Also wanted to specify the default directory goes into the home directory of the user running the script.  There are folks new to *nix, and this is meant as a gentle clue.