### PR TITLE
Sed blanks

### DIFF
--- a/install/zowe-install.sh
+++ b/install/zowe-install.sh
@@ -194,7 +194,7 @@ chmod a+x $ZOWE_ROOT_DIR/scripts/internal
 echo "Copying the opercmd into "$ZOWE_ROOT_DIR/scripts/internal >> $LOG_FILE
 cp $INSTALL_DIR/scripts/opercmd $ZOWE_ROOT_DIR/scripts/internal/opercmd
 echo "Copying the run-zowe.sh into "$ZOWE_ROOT_DIR/scripts/internal >> $LOG_FILE
-sed -e 's|$nodehome|'$NODE_HOME'|' $INSTALL_DIR/scripts/run-zowe.sh  > $TEMP_DIR/run-zowe.sh
+sed -e "s|\$nodehome|$NODE_HOME|" $INSTALL_DIR/scripts/run-zowe.sh  > $TEMP_DIR/run-zowe.sh
 cp $TEMP_DIR/run-zowe.sh $ZOWE_ROOT_DIR/scripts/internal/run-zowe.sh
 chmod -R 755 $ZOWE_ROOT_DIR/scripts/internal
 

--- a/scripts/zowe-api-mediation-configure.sh
+++ b/scripts/zowe-api-mediation-configure.sh
@@ -45,11 +45,11 @@ echo "About to set JAVA_HOME to $ZOWE_JAVA_HOME in APIML script templates" >> $L
 cd scripts/
 # Add JAVA_HOME to both script templates
 sed -e "s|\*\*JAVA_SETUP\*\*|export JAVA_HOME=$ZOWE_JAVA_HOME|g" \
-    -e 's/\*\*HOSTNAME\*\*/'$ZOWE_EXPLORER_HOST'/g' \
-    -e 's/\*\*IPADDRESS\*\*/'$ZOWE_IPADDRESS'/g' \
-    -e 's/\*\*VERIFY_CERTIFICATES\*\*/'$ZOWE_APIM_VERIFY_CERTIFICATES'/g' \
-    -e 's/\*\*ZOSMF_KEYRING\*\*/'$ZOWE_ZOSMF_KEYRING'/g' \
-    -e 's/\*\*ZOSMF_USER\*\*/'$ZOWE_ZOSMF_USERID'/g' \
+    -e "s/\*\*HOSTNAME\*\*/$ZOWE_EXPLORER_HOST/g" \
+    -e "s/\*\*IPADDRESS\*\*/$ZOWE_IPADDRESS/g" \
+    -e "s/\*\*VERIFY_CERTIFICATES\*\*/$ZOWE_APIM_VERIFY_CERTIFICATES/g" \
+    -e "s/\*\*ZOSMF_KEYRING\*\*/$ZOWE_ZOSMF_KEYRING/g" \
+    -e "s/\*\*ZOSMF_USER\*\*/$ZOWE_ZOSMF_USERID/g" \
     -e "s|\*\*EXTERNAL_CERTIFICATE\*\*|$ZOWE_APIM_EXTERNAL_CERTIFICATE|g" \
     -e "s|\*\*EXTERNAL_CERTIFICATE_ALIAS\*\*|$ZOWE_APIM_EXTERNAL_CERTIFICATE_ALIAS|g" \
     -e "s|\*\*EXTERNAL_CERTIFICATE_AUTHORITIES\*\*|$ZOWE_APIM_EXTERNAL_CERTIFICATE_AUTHORITIES|g" \
@@ -61,33 +61,33 @@ chmod a+x setup-apiml-certificates.sh
 
 # Inject parameters into API Mediation startup scripts, which contains command-line parameters as configuration
 sed -e "s|\*\*JAVA_SETUP\*\*|export JAVA_HOME=$ZOWE_JAVA_HOME|g" \
-    -e 's/\*\*HOSTNAME\*\*/'$ZOWE_EXPLORER_HOST'/g' \
-    -e 's/\*\*IPADDRESS\*\*/'$ZOWE_IPADDRESS'/g' \
-    -e 's/\*\*DISCOVERY_PORT\*\*/'$ZOWE_APIM_DISCOVERY_PORT'/g' \
-    -e 's/\*\*CATALOG_PORT\*\*/'$ZOWE_APIM_CATALOG_PORT'/g' \
-    -e 's/\*\*GATEWAY_PORT\*\*/'$ZOWE_APIM_GATEWAY_PORT'/g' \
-    -e 's/\*\*VERIFY_CERTIFICATES\*\*/'$ZOWE_APIM_VERIFY_CERTIFICATES'/g' \
+    -e "s/\*\*HOSTNAME\*\*/$ZOWE_EXPLORER_HOST/g" \
+    -e "s/\*\*IPADDRESS\*\*/$ZOWE_IPADDRESS/g" \
+    -e "s/\*\*DISCOVERY_PORT\*\*/$ZOWE_APIM_DISCOVERY_PORT/g" \
+    -e "s/\*\*CATALOG_PORT\*\*/$ZOWE_APIM_CATALOG_PORT/g" \
+    -e "s/\*\*GATEWAY_PORT\*\*/$ZOWE_APIM_GATEWAY_PORT/g" \
+    -e "s/\*\*VERIFY_CERTIFICATES\*\*/$ZOWE_APIM_VERIFY_CERTIFICATES/g" \
     api-mediation-start-catalog-template.sh > api-mediation-start-catalog.sh
 
 # Inject parameters into API Mediation startup, which contains command-line parameters as configuration
 sed -e "s|\*\*JAVA_SETUP\*\*|export JAVA_HOME=$ZOWE_JAVA_HOME|g" \
-    -e 's/\*\*HOSTNAME\*\*/'$ZOWE_EXPLORER_HOST'/g' \
-    -e 's/\*\*IPADDRESS\*\*/'$ZOWE_IPADDRESS'/g' \
-    -e 's/\*\*DISCOVERY_PORT\*\*/'$ZOWE_APIM_DISCOVERY_PORT'/g' \
-    -e 's/\*\*CATALOG_PORT\*\*/'$ZOWE_APIM_CATALOG_PORT'/g' \
-    -e 's/\*\*GATEWAY_PORT\*\*/'$ZOWE_APIM_GATEWAY_PORT'/g' \
-    -e 's/\*\*VERIFY_CERTIFICATES\*\*/'$ZOWE_APIM_VERIFY_CERTIFICATES'/g' \
+    -e "s/\*\*HOSTNAME\*\*/$ZOWE_EXPLORER_HOST/g" \
+    -e "s/\*\*IPADDRESS\*\*/$ZOWE_IPADDRESS/g" \
+    -e "s/\*\*DISCOVERY_PORT\*\*/$ZOWE_APIM_DISCOVERY_PORT/g" \
+    -e "s/\*\*CATALOG_PORT\*\*/$ZOWE_APIM_CATALOG_PORT/g" \
+    -e "s/\*\*GATEWAY_PORT\*\*/$ZOWE_APIM_GATEWAY_PORT/g" \
+    -e "s/\*\*VERIFY_CERTIFICATES\*\*/$ZOWE_APIM_VERIFY_CERTIFICATES/g" \
     api-mediation-start-gateway-template.sh > api-mediation-start-gateway.sh
 
 # Inject parameters into API Mediation startup, which contains command-line parameters as configuration
 sed -e "s|\*\*JAVA_SETUP\*\*|export JAVA_HOME=$ZOWE_JAVA_HOME|g" \
-    -e 's/\*\*HOSTNAME\*\*/'$ZOWE_EXPLORER_HOST'/g' \
-    -e 's/\*\*IPADDRESS\*\*/'$ZOWE_IPADDRESS'/g' \
-    -e 's/\*\*DISCOVERY_PORT\*\*/'$ZOWE_APIM_DISCOVERY_PORT'/g' \
-    -e 's/\*\*CATALOG_PORT\*\*/'$ZOWE_APIM_CATALOG_PORT'/g' \
-    -e 's/\*\*GATEWAY_PORT\*\*/'$ZOWE_APIM_GATEWAY_PORT'/g' \
-    -e 's|\*\*STATIC_DEF_CONFIG\*\*|'$STATIC_DEF_CONFIG'|g' \
-    -e 's/\*\*VERIFY_CERTIFICATES\*\*/'$ZOWE_APIM_VERIFY_CERTIFICATES'/g' \
+    -e "s/\*\*HOSTNAME\*\*/$ZOWE_EXPLORER_HOST/g" \
+    -e "s/\*\*IPADDRESS\*\*/$ZOWE_IPADDRESS/g" \
+    -e "s/\*\*DISCOVERY_PORT\*\*/$ZOWE_APIM_DISCOVERY_PORT/g" \
+    -e "s/\*\*CATALOG_PORT\*\*/$ZOWE_APIM_CATALOG_PORT/g" \
+    -e "s/\*\*GATEWAY_PORT\*\*/$ZOWE_APIM_GATEWAY_PORT/g" \
+    -e "s|\*\*STATIC_DEF_CONFIG\*\*|$STATIC_DEF_CONFIG|g" \
+    -e "s/\*\*VERIFY_CERTIFICATES\*\*/$ZOWE_APIM_VERIFY_CERTIFICATES/g" \
     api-mediation-start-discovery-template.sh > api-mediation-start-discovery.sh
 
 # Make the scripts executable

--- a/scripts/zowe-explorer-api-configure.sh
+++ b/scripts/zowe-explorer-api-configure.sh
@@ -55,12 +55,12 @@ for one in $EXPLORER_API_LIST; do
   # Add JAVA_HOME to start script templates
   sed -e "s|\*\*JAVA_SETUP\*\*|export JAVA_HOME=$ZOWE_JAVA_HOME|g" \
       -e "s/\*\*${ZOWE_EXPLORER_JAR_MACRO}\*\*/${EXPLORER_API_JAR}/g" \
-      -e 's/\*\*SERVER_PORT\*\*/'$ZOWE_EXPLORER_API_PORT'/g' \
+      -e "s/\*\*SERVER_PORT\*\*/$ZOWE_EXPLORER_API_PORT/g" \
       -e "s|\*\*KEY_ALIAS\*\*|localhost|g" \
       -e "s|\*\*KEYSTORE\*\*|$ZOWE_ROOT_DIR/api-mediation/keystore/localhost/localhost.keystore.p12|g" \
       -e "s|\*\*KEYSTORE_PASSWORD\*\*|password|g" \
-      -e 's/\*\*ZOSMF_HTTPS_PORT\*\*/'$ZOWE_ZOSMF_PORT'/g' \
-      -e 's/\*\*ZOSMF_IP\*\*/'$ZOWE_IPADDRESS'/g' \
+      -e "s/\*\*ZOSMF_HTTPS_PORT\*\*/$ZOWE_ZOSMF_PORT/g" \
+      -e "s/\*\*ZOSMF_IP\*\*/$ZOWE_IPADDRESS/g" \
       "${one}-api-server-start.sh" > "${one}-api-server-start.sh.tmp"
   mv "${one}-api-server-start.sh.tmp" "${one}-api-server-start.sh"
 


### PR DESCRIPTION
If the user enters blanks in the input string for any of the env variables, some of the `sed` commands fail because the way the `sed` string is quoted induces a syntax error if the variable has embedded blanks.  The `sed` strings have been re-formed to eliminate the syntax errors.