### PR TITLE
Add support script

### DIFF
--- a/install/zowe-install.sh
+++ b/install/zowe-install.sh
@@ -23,15 +23,15 @@ separator() {
 }
 separator
 
-# Create a log file with the year and time.log in a log folder 
-# that scripts can echo to and can be written to by scripts to diagnose any install 
-# problems.  
+# Create a log file with the year and time.log in a log folder
+# that scripts can echo to and can be written to by scripts to diagnose any install
+# problems.
 
 export LOG_DIR=$INSTALL_DIR/log
 # Make the log directory if needed - first time through - subsequent installs create new .log files
 if [[ ! -d $LOG_DIR ]]; then
     mkdir -p $LOG_DIR
-    chmod a+rwx $LOG_DIR 
+    chmod a+rwx $LOG_DIR
 fi
 # Make the log file (unique assuming there is only one install per second)
 export LOG_FILE="`date +%Y-%m-%d-%H-%M-%S`.log"
@@ -110,7 +110,7 @@ if [[ $ZOWE_APIM_ENABLE_SSO == "true" ]]; then
     sed 's/"zss": {/'"${_JSON}"', "zss": {/g' ${ZLUX_SERVER_CONFIG_PATH}/zluxserver.json > ${TEMP_DIR}/transform1.json
     cp ${TEMP_DIR}/transform1.json ${ZLUX_SERVER_CONFIG_PATH}/zluxserver.json
     rm ${TEMP_DIR}/transform1.json
-    
+
     # Access API Catalog with token injector
     CATALOG_GATEWAY_URL=https://$ZOWE_EXPLORER_HOST:$ZOWE_ZLUX_SERVER_HTTPS_PORT/ZLUX/plugins/org.zowe.zlux.auth.apiml/services/tokenInjector/1.0.0/ui/v1/apicatalog/
 else
@@ -128,8 +128,8 @@ echo "-----"
 . $INSTALL_DIR/scripts/zowe-prepare-runtime.sh
 # Run deploy on the zLUX app server to propagate the changes made
 
-# TODO LATER - revisit to work out the best permissions, but currently needed so deploy.sh can run	
-chmod -R 775 $ZOWE_ROOT_DIR/zlux-app-server/deploy/product	
+# TODO LATER - revisit to work out the best permissions, but currently needed so deploy.sh can run
+chmod -R 775 $ZOWE_ROOT_DIR/zlux-app-server/deploy/product
 chmod -R 775 $ZOWE_ROOT_DIR/zlux-app-server/deploy/instance
 
 cd $ZOWE_ROOT_DIR/zlux-build
@@ -200,6 +200,9 @@ chmod -R 755 $ZOWE_ROOT_DIR/scripts/internal
 
 sed -e 's|/zowe/install/path|'$ZOWE_ROOT_DIR'|' $INSTALL_DIR/files/templates/ZOWESVR.jcl > $TEMP_DIR/ZOWESVR.jcl
 $INSTALL_DIR/scripts/zowe-copy-proc.sh $TEMP_DIR/ZOWESVR.jcl $ZOWE_SERVER_PROCLIB_MEMBER $ZOWE_SERVER_PROCLIB_DSNAME
+
+sed -e 's|$nodehome|'$NODE_HOME'|; s|$prefix|'$ZOWE_PREFIX'|; s|$javahome|'$ZOWE_JAVA_HOME'|; s|$zowestc|'$ZOWE_SERVER_PROCLIB_MEMBER'|' $INSTALL_DIR/scripts/zowe-support.sh  > $TEMP_DIR/zowe-support.sh
+cp $TEMP_DIR/zowe-support.sh $ZOWE_ROOT_DIR/scripts/zowe-support.sh
 
 separator
 echo "To start Zowe run the script "$ZOWE_ROOT_DIR/scripts/zowe-start.sh

--- a/install/zowe-install.yaml.template
+++ b/install/zowe-install.yaml.template
@@ -15,7 +15,7 @@ api-mediation:
   verifyCertificatesOfServices=true
   enableSso=false
   zosmfKeyring=IZUKeyring.IZUDFLT
-  zosmfUser=IZUSVR
+  zosmfUserid=IZUSVR
 
 zos-services:
   jobsAPIPort=8545
@@ -38,10 +38,10 @@ terminals:
 # started task JCL member for Zowe job - these entries are not case-sensitive
 zowe-server-proclib:
 # dsName=SYS1.PROCLIB   # Example of required dataset name.  Do not enclose it in quotes.
-#  If you omit the 'dsName' tag or specify 'dsName=auto', 
-#  the install script scans the datasets in the PROCLIB concatenation 
-#  and places the JCL member in the first dataset where the installing 
-#  user has write access.  
+#  If you omit the 'dsName' tag or specify 'dsName=auto',
+#  the install script scans the datasets in the PROCLIB concatenation
+#  and places the JCL member in the first dataset where the installing
+#  user has write access.
   dsName=auto
   memberName=ZOWESVR
 

--- a/scripts/zowe-parse-yaml.sh
+++ b/scripts/zowe-parse-yaml.sh
@@ -12,7 +12,7 @@
 
 # Assign default values that will be filled in as we parse the yaml file
 
-echo "<zowe-parse-yaml.sh>" >> $LOG_FILE 
+echo "<zowe-parse-yaml.sh>" >> $LOG_FILE
 echo "Reading install variables from zowe-install.sh"
 
 parseConfiguationFile() {
@@ -42,65 +42,65 @@ do
             if [[ $key == "rootDir" ]] && [[ $section == "install" ]]
             then
 # If the value starts with a ~ for the home variable then evaluate it
-                ZOWE_ROOT_DIR=`sh -c "echo $value"` 
+                ZOWE_ROOT_DIR=`sh -c "echo $value"`
                 export ZOWE_ROOT_DIR
             fi
 # Look for jobsAPIPort= beneath zos-services:
-            if [[ $key == "jobsAPIPort" ]] && [[ $section == "zos-services" ]] 
+            if [[ $key == "jobsAPIPort" ]] && [[ $section == "zos-services" ]]
             then
                 ZOWE_EXPLORER_SERVER_JOBS_PORT=$value
                 export ZOWE_EXPLORER_SERVER_JOBS_PORT
             fi
 # Look for mvsAPIPort= beneath zos-services:
-            if [[ $key == "mvsAPIPort" ]] && [[ $section == "zos-services" ]] 
+            if [[ $key == "mvsAPIPort" ]] && [[ $section == "zos-services" ]]
             then
                 ZOWE_EXPLORER_SERVER_DATASETS_PORT=$value
                 export ZOWE_EXPLORER_SERVER_DATASETS_PORT
             fi
 # Look for httpsPort= beneath zlux-server:
-            if [[ $key == "httpsPort" ]] && [[ $section == "zlux-server" ]] 
+            if [[ $key == "httpsPort" ]] && [[ $section == "zlux-server" ]]
             then
                 ZOWE_ZLUX_SERVER_HTTPS_PORT=$value
                 export ZOWE_ZLUX_SERVER_HTTPS_PORT
             fi
 # Look for zssPort= beneath zlux-server:
-            if [[ $key == "zssPort" ]] && [[ $section == "zlux-server" ]] 
+            if [[ $key == "zssPort" ]] && [[ $section == "zlux-server" ]]
             then
                 ZOWE_ZSS_SERVER_PORT=$value
                 export ZOWE_ZSS_SERVER_PORT
             fi
 # Look for sshPort= beneath terminals:
-            if [[ $key == "sshPort" ]] && [[ $section == "terminals" ]] 
+            if [[ $key == "sshPort" ]] && [[ $section == "terminals" ]]
             then
                 ZOWE_ZLUX_SSH_PORT=$value
                 export ZOWE_ZLUX_SSH_PORT
             fi
 # Look for telnetPort= beneath terminals:
-            if [[ $key == "telnetPort" ]] && [[ $section == "terminals" ]] 
+            if [[ $key == "telnetPort" ]] && [[ $section == "terminals" ]]
             then
                 ZOWE_ZLUX_TELNET_PORT=$value
                 export ZOWE_ZLUX_TELNET_PORT
             fi
 # Look for jobsExplorerPort= beneath zowe-desktop-apps:
-            if [[ $key == "jobsExplorerPort" ]] && [[ $section == "zowe-desktop-apps" ]] 
+            if [[ $key == "jobsExplorerPort" ]] && [[ $section == "zowe-desktop-apps" ]]
             then
                 ZOWE_EXPLORER_JES_UI_PORT=$value
                 export ZOWE_EXPLORER_JES_UI_PORT
             fi
 # Look for mvsExplorerPort= beneath zowe-desktop-apps:
-            if [[ $key == "mvsExplorerPort" ]] && [[ $section == "zowe-desktop-apps" ]] 
+            if [[ $key == "mvsExplorerPort" ]] && [[ $section == "zowe-desktop-apps" ]]
             then
                 ZOWE_EXPLORER_MVS_UI_PORT=$value
                 export ZOWE_EXPLORER_MVS_UI_PORT
             fi
 # Look for ussExplorerPort= beneath zowe-desktop-apps:
-            if [[ $key == "ussExplorerPort" ]] && [[ $section == "zowe-desktop-apps" ]] 
+            if [[ $key == "ussExplorerPort" ]] && [[ $section == "zowe-desktop-apps" ]]
             then
                 ZOWE_EXPLORER_USS_UI_PORT=$value
                 export ZOWE_EXPLORER_USS_UI_PORT
             fi
 # Look for security= beneath terminals:
-            if [[ $key == "security" ]] && [[ $section == "terminals" ]] 
+            if [[ $key == "security" ]] && [[ $section == "terminals" ]]
             then
                 ZOWE_ZLUX_SECURITY_TYPE=$value
                 export ZOWE_ZLUX_SECURITY_TYPE
@@ -175,7 +175,7 @@ done < $1
 parseConfiguationFile ./zowe-install.yaml
 
 # If the values are not set default them
-if [[ $ZOWE_ROOT_DIR == "" ]] 
+if [[ $ZOWE_ROOT_DIR == "" ]]
 then
     ZOWE_ROOT_DIR="~/zowe/$ZOWE_VERSION"
     echo "  ZOWE_ROOT_DIR not specified:  Defaulting to ~/zowe/$ZOWE_VERSION"
@@ -261,10 +261,10 @@ fi
 if [[ $ZOWE_ZLUX_TELNET_PORT == "" ]]
 then
     ZOWE_ZLUX_TELNET_PORT=23
-fi 
+fi
 if [[ $ZOWE_SERVER_PROCLIB_MEMBER == "" ]]
 then
-    ZOWE_SERVER_PROCLIB_MEMBER=ZOWESVR 
+    ZOWE_SERVER_PROCLIB_MEMBER=ZOWESVR
     echo "  ZOWE_SERVER_PROCLIB_MEMBER not specified:  Defaulting to ZOWESVR"
 fi
 if [[ $ZOWE_SERVER_PROCLIB_DSNAME == "" ]]

--- a/scripts/zowe-support.sh
+++ b/scripts/zowe-support.sh
@@ -1,0 +1,156 @@
+#!/bin/sh
+
+# Variable Definition
+VAR=`dirname $0`			# Obtain the scripts directory name
+cd $VAR/..				    # Change to its parent which should be ZOWE_ROOT_DIR
+ZOWE_ROOT_DIR=`pwd`			# Set our environment variable
+ZOWE_PREFIX=$prefix
+ZOWE_INSTALL_LOG_DIR=${ZOWE_ROOT_DIR}/install_log/
+ZOWE_INSTALL_ZLUX_SERVER_LOG=${ZOWE_ROOT_DIR}/zlux-app-server/log/
+
+DATE=`date +%Y-%m-%d-%H-%M-%S`
+SUPPORT_ARCHIVE_LOCATION=$ZOWE_INSTALL_LOG_DIR
+SUPPORT_ARCHIVE_NAME="zowe_support_${DATE}.pax"
+SUPPORT_ARCHIVE=${SUPPORT_ARCHIVE_LOCATION}${SUPPORT_ARCHIVE_NAME}
+SUPPORT_ARCHIVE_LOG="${SUPPORT_ARCHIVE_LOCATION}zowe_support_${DATE}.log"
+PS_OUTPUT_FILE=${SUPPORT_ARCHIVE_LOCATION}"ps_output"
+VERSION_FILE=${SUPPORT_ARCHIVE_LOCATION}"version_output"
+
+NODE_HOME=$nodehome
+JAVA_HOME=$javahome
+ZOWE_STC=$zowestc
+
+# Function Definition
+# Not really sure if we should use this, it takes a lot of time to search in directory tree
+# Alternative is to count on the directory structure, and assume that needed files are there
+function realpath {
+    # returns full file specification (full path)
+    echo $(cd $(dirname ${1}); pwd)/$(basename ${1});
+}
+
+function findfile {
+    # finds a file in a given directory tree (all subdirs) and returns it with full path
+    file_path="$(find ${1} -name ${2} -print)";
+    realpath ${file_path};
+}
+
+function psgrep {
+    pattern=[^]]${1};
+    # [^]] used to concatenate a static string to the pattern. Done to remove grep command from output
+    ps -A -o pid,ppid,time,etime,user,jobname,args | grep -e "^[[:space:]]*PID" -e ${pattern}
+}
+
+function write_to_log {
+    echo $1 | tee -a ${SUPPORT_ARCHIVE_LOG}
+}
+
+function add_to_pax {
+    case $2 in
+        process_info)
+            SUBSTITUTION="-s#${SUPPORT_ARCHIVE_LOCATION}#PS_OUTPUT_FILE-#"
+        ;;
+        version_file)
+            SUBSTITUTION="-s#${SUPPORT_ARCHIVE_LOCATION}#VERSION_FILE-#"
+        ;;
+        installation_log)
+            SUBSTITUTION="-s#${ZOWE_INSTALL_LOG_DIR}#INSTALL_LOG-#"
+        ;;
+        support_archive_log)
+            SUBSTITUTION="-s#${SUPPORT_ARCHIVE_LOCATION}#SUPPORT_LOG-#"
+        ;;
+        zlux_server_log)
+            SUBSTITUTION="-s#${ZOWE_INSTALL_ZLUX_SERVER_LOG}#ZLUX_SERVER_LOG-#"
+        ;;
+        run_zowe_sh)
+            SUBSTITUTION="-s$3"
+        ;;
+        *)  # basic command (no substitution is applied)
+            SUBSTITUTION=""
+        ;;
+    esac
+    pax -wva -o saveext ${SUBSTITUTION} -f ${SUPPORT_ARCHIVE}  $1 2>&1 | tee -a ${SUPPORT_ARCHIVE_LOG}
+}
+
+# Collecting software versions
+write_to_log "Collecting version of z/OS, Java, NodeJS"
+ZOS_VERSION=`${ZOWE_ROOT_DIR}/scripts/internal/opercmd "D IPLINFO" | grep -i release | xargs`
+write_to_log "  - z/OS "$ZOS_VERSION
+JAVA_VERSION=`$JAVA_HOME/bin/java -version 2>&1 | head -n 1`
+write_to_log "  - Java "$JAVA_VERSION
+NODE_VERSION=`$NODE_HOME/bin/node --version`
+write_to_log "  - NodeJS "$NODE_VERSION
+echo "z/OS version: "$ZOS_VERSION > $VERSION_FILE
+echo "Java version: "$JAVA_VERSION >> $VERSION_FILE
+echo "NodeJS version: "$NODE_VERSION >> $VERSION_FILE
+add_to_pax $VERSION_FILE version_file
+rm $VERSION_FILE
+
+# Collect the manifest file
+write_to_log "Collecting manifest.json"
+add_to_pax $ZOWE_ROOT_DIR/manifest.json
+
+# Collect process information
+write_to_log "Collecting current process information based on the following prefix: ${ZOWE_PREFIX}"
+psgrep $ZOWE_PREFIX > $PS_OUTPUT_FILE
+write_to_log "Adding ${PS_OUTPUT_FILE}"
+add_to_pax $PS_OUTPUT_FILE process_info
+rm $PS_OUTPUT_FILE
+
+# Collect STC output
+STC_JOBS=`tsocmd "STATUS ${ZOWE_STC}" 2>/dev/null | grep 'ON OUTPUT'` | cut -d' ' -f3
+for STC in ${STCS[*]}
+do
+    write_to_log "Collecting output for Zowe started task ${STC}"
+    STC_FILE = `echo ${STC} | tr '()' '-.'`log
+    tsocmd output $STC > $STC_FILE
+    add_to_pax $STC_FILE
+    rm $STC_FILE
+done
+
+# Collect install logs
+if [[ -d ${ZOWE_INSTALL_LOG_DIR} ]];then
+    write_to_log "Collecting installation log files from ${ZOWE_INSTALL_LOG_DIR}:"
+    add_to_pax ${ZOWE_INSTALL_LOG_DIR} installation_log *.log
+else
+    write_to_log "Directory ${ZOWE_INSTALL_LOG_DIR} was not found."
+fi
+
+# Collect launch scripts
+set +A SCRIPTS '/zlux-app-server/bin/nodeCluster.sh'\
+ '/api-mediation/scripts/api-mediation-start-discovery.sh'\
+ '/api-mediation/scripts/api-mediation-start-catalog.sh'\
+ '/api-mediation/scripts/api-mediation-start-gateway.sh'\
+ '/explorer-jobs-api/scripts/jobs-api-server-start.sh'\
+ '/explorer-data-sets-api/scripts/data-sets-api-server-start.sh'\
+ '/jes_explorer/scripts/start-explorer-jes-ui-server.sh'\
+ '/mvs_explorer/scripts/start-explorer-mvs-ui-server.sh'\
+ '/uss_explorer/scripts/start-explorer-uss-ui-server.sh'
+
+for SCRIPT in ${SCRIPTS[*]}
+do
+    write_to_log "Collecting launch script ${SCRIPT}"
+    add_to_pax ${ZOWE_ROOT_DIR}/${SCRIPT}
+done
+
+# Getting zlux-server log
+if [[ -d ${ZOWE_INSTALL_ZLUX_SERVER_LOG} ]];then
+    write_to_log "Adding ${ZOWE_INSTALL_ZLUX_SERVER_LOG}"
+    add_to_pax ${ZOWE_INSTALL_ZLUX_SERVER_LOG} zlux_server_log
+else
+    write_to_log "Directory ${ZOWE_INSTALL_ZLUX_SERVER_LOG} was not found."
+fi
+
+# Add support log file to pax
+write_to_log "Adding ${SUPPORT_ARCHIVE_LOG}"
+add_to_pax ${SUPPORT_ARCHIVE_LOG} support_archive_log
+rm ${SUPPORT_ARCHIVE_LOG}
+
+# Compress pax file and delete the uncompressed one
+pax -wzf ${SUPPORT_ARCHIVE}.Z ${SUPPORT_ARCHIVE}
+rm ${SUPPORT_ARCHIVE}
+
+# Print final message
+echo "The support file was created, pass it to support guys. Thanks."
+echo ${SUPPORT_ARCHIVE}.Z
+
+# done


### PR DESCRIPTION
Automatically collect basic data for support:
- Installation logs
- Scripts that are called from `run-zowe.sh`
- SW version:
    - `manifest.json` file
    - z/OS version
    - Zava version
    - NodeJS version
- Log files
- Started task output
- Process list

Also fixed bug in `zowe-install.yaml.template`: rename `zosmfUser` to `zosmfUserid`.