### PR TITLE
Set jobname on ZOWESVR parent STCs

### DIFF
--- a/scripts/configure/zowe-configure-scripts.sh
+++ b/scripts/configure/zowe-configure-scripts.sh
@@ -3,7 +3,7 @@ sed -e "s#{{stc_name}}#${ZOWE_SERVER_PROCLIB_MEMBER}#" \
   "${ZOWE_ROOT_DIR}/scripts/templates/zowe-start.template.sh" \
   > "${ZOWE_ROOT_DIR}/scripts/zowe-start.sh" 
 
-sed -e "s#{{stc_name}}#${ZOWE_SERVER_PROCLIB_MEMBER}#" \
+sed -e "s#{{zowe_prefix}}#${ZOWE_PREFIX}#" \
   "${ZOWE_ROOT_DIR}/scripts/templates/zowe-stop.template.sh" \
   > "${ZOWE_ROOT_DIR}/scripts/zowe-stop.sh" 
 

--- a/scripts/configure/zowe-configure-scripts.sh
+++ b/scripts/configure/zowe-configure-scripts.sh
@@ -1,5 +1,6 @@
 #Inject variables into zowe runtime scripts
 sed -e "s#{{stc_name}}#${ZOWE_SERVER_PROCLIB_MEMBER}#" \
+    -e "s#{{zowe_prefix}}#${ZOWE_PREFIX}#" \
   "${ZOWE_ROOT_DIR}/scripts/templates/zowe-start.template.sh" \
   > "${ZOWE_ROOT_DIR}/scripts/zowe-start.sh" 
 

--- a/scripts/zowe-start.template.sh
+++ b/scripts/zowe-start.template.sh
@@ -14,5 +14,6 @@
 VAR=`dirname $0`			# Obtain the scripts directory name
 cd $VAR/..				# Change to its parent which should be ZOWE_ROOT_DIR
 ZOWE_ROOT_DIR=`pwd`			# Set our environment variable
-$ZOWE_ROOT_DIR/scripts/internal/opercmd "S {{stc_name}},SRVRPATH='"$ZOWE_ROOT_DIR"'"
+$ZOWE_ROOT_DIR/scripts/internal/opercmd \
+    "S {{stc_name}},SRVRPATH='"$ZOWE_ROOT_DIR"'",JOBNAME={{zowe_prefix}}SV1
 echo Start command issued, check SDSF job log ...

--- a/scripts/zowe-stop.template.sh
+++ b/scripts/zowe-stop.template.sh
@@ -15,4 +15,4 @@ VAR=`dirname $0`			# Obtain the scripts directory name
 cd $VAR/..				# Change to its parent which should be ZOWE_ROOT_DIR
 ZOWE_ROOT_DIR=`pwd`			# Set our environment variable
 echo Stopping ZOWE server
-$ZOWE_ROOT_DIR/scripts/internal/opercmd "c {{stc_name}}"
+$ZOWE_ROOT_DIR/scripts/internal/opercmd "c {{zowe_prefix}}SV1"


### PR DESCRIPTION
Signed-off-by: John Davies <daviesja@uk.ibm.com>

Fixes #560 by setting JOBNAME in `zowe-start.sh`.  