### PR TITLE
missing `$CONFIG_DIR/`

### DIFF
--- a/scripts/configure/zowe-configure.sh
+++ b/scripts/configure/zowe-configure.sh
@@ -42,7 +42,7 @@ echo "Beginning to configure zowe installed in ${ZOWE_ROOT_DIR}"
 
 if [[ $ZOWE_APIM_ENABLE_SSO == "true" ]]; then
     # Add APIML authentication plugin to zLUX
-    . zowe-install-existing-plugin.sh $ZOWE_ROOT_DIR "org.zowe.zlux.auth.apiml" $ZOWE_ROOT_DIR/api-mediation/apiml-auth
+    . $CONFIG_DIR/zowe-install-existing-plugin.sh $ZOWE_ROOT_DIR "org.zowe.zlux.auth.apiml" $ZOWE_ROOT_DIR/api-mediation/apiml-auth
 
     # Activate the plugin
     _JSON='"apiml": { "plugins": ["org.zowe.zlux.auth.apiml"] }'


### PR DESCRIPTION

 when  `$CONFIG_DIR/` is missing in ` . zowe-install-existing-plugin.sh $ZOWE_ROOT_DIR "org.zowe.zlux.auth.apiml" $ZOWE_ROOT_DIR/api-mediation/apiml-auth` in `zowe-install-existing-plugin.sh`
Error message:
`/a/vlcvi01/zowe/upgradable/scripts/configure/zowe-configure.sh: line 45: zowe-install-existing-plugin.sh: EDC5129I No such file or directory. (errno2=0x05620062)`