### PR TITLE
fixed missing oping and ocopyshr.sh

### DIFF
--- a/scripts/configure/zowe-copy-proc.sh
+++ b/scripts/configure/zowe-copy-proc.sh
@@ -167,7 +167,7 @@ then
     exitone 
   else
     echo "    "found PROCLIB dataset $proclib >> $LOG_FILE
-      ./ocopyshr.sh $proclib $memberName
+      ${ZOWE_ROOT_DIR}/scripts/internal/ocopyshr.sh $proclib $memberName
       if [[ $? > 0 ]]
       then
         echo "  "Unable to write to requested PROCLIB $proclib >> $LOG_FILE


### PR DESCRIPTION
fixed two problems:
 * missing `ping`  - if `ping` is missing use `oping`
 *  fixed problem `./ocopyshr.sh: /a/vlcvi01/zowe/upgradable/scripts/configure/zowe-copy-proc.sh 170: FSUM7351 not found`

Signed-off-by: Vitek Vlcek <vitezslav@vvvlcek.info>