### PR TITLE
Zosmf overide

### DIFF
--- a/scripts/configure/zowe-configure-api-mediation.sh
+++ b/scripts/configure/zowe-configure-api-mediation.sh
@@ -16,6 +16,8 @@
 # $ZOWE_ROOT_DIR
 # $ZOWE_EXPLORER_HOST
 # $ZOWE_IPADDRESS
+# $ZOWE_ZOSMF_HOST
+# $ZOWE_ZOSMF_PORT
 # $ZOWE_APIM_CATALOG_PORT
 # $ZOWE_APIM_DISCOVERY_PORT
 # $ZOWE_APIM_GATEWAY_PORT
@@ -126,7 +128,7 @@ cat <<EOF >$TEMP_DIR/zosmf.yml
 # Static definition for z/OSMF
 #
 # Once configured you can access z/OSMF via the API gateway:
-# http --verify=no GET https://$ZOWE_EXPLORER_HOST:$ZOWE_APIM_GATEWAY_PORT/api/v1/zosmf/info 'X-CSRF-ZOSMF-HEADER;'
+# http --verify=no GET https://$ZOWE_ZOSMF_HOST:$ZOWE_APIM_GATEWAY_PORT/api/v1/zosmf/info 'X-CSRF-ZOSMF-HEADER;'
 #	
 services:
     - serviceId: zosmf
@@ -134,7 +136,7 @@ services:
       description: IBM z/OS Management Facility REST API service
       catalogUiTileId: zosmf
       instanceBaseUrls:
-        - https://$ZOWE_EXPLORER_HOST:$ZOWE_ZOSMF_PORT/zosmf/
+        - https://$ZOWE_ZOSMF_HOST:$ZOWE_ZOSMF_PORT/zosmf/
       homePageRelativeUrl:  # Home page is at the same URL
       routedServices:
         - gatewayUrl: api/v1  # [api/ui/ws]/v{majorVersion}

--- a/scripts/configure/zowe-configure-explorer-api.sh
+++ b/scripts/configure/zowe-configure-explorer-api.sh
@@ -60,7 +60,7 @@ for one in $EXPLORER_API_LIST; do
       -e "s|\*\*KEYSTORE\*\*|$ZOWE_ROOT_DIR/api-mediation/keystore/localhost/localhost.keystore.p12|g" \
       -e "s|\*\*KEYSTORE_PASSWORD\*\*|password|g" \
       -e "s/\*\*ZOSMF_HTTPS_PORT\*\*/$ZOWE_ZOSMF_PORT/g" \
-      -e "s/\*\*ZOSMF_IP\*\*/$ZOWE_IPADDRESS/g" \
+      -e "s/\*\*ZOSMF_IP\*\*/$ZOWE_ZOSMF_HOST/g" \
       "${one}-api-server-start.sh" > "${one}-api-server-start.sh.tmp"
   mv "${one}-api-server-start.sh.tmp" "${one}-api-server-start.sh"
 

--- a/scripts/zowe-init.sh
+++ b/scripts/zowe-init.sh
@@ -31,6 +31,7 @@ echo "<zowe-init.sh>" >> $LOG_FILE
 #set-x
 export ZOWE_ZOSMF_PATH
 export ZOWE_ZOSMF_PORT
+export ZOWE_ZOSMF_HOST
 export ZOWE_JAVA_HOME
 export ZOWE_EXPLORER_HOST
 export ZOWE_IPADDRESS
@@ -47,6 +48,7 @@ then
     grep \
     -e ZOWE_ZOSMF_PATH= \
     -e ZOWE_ZOSMF_PORT= \
+    -e ZOWE_ZOSMF_HOST= \
     -e ZOWE_JAVA_HOME= \
     -e ZOWE_EXPLORER_HOST= \
     -e ZOWE_IPADDRESS= \
@@ -399,4 +401,15 @@ else
     esac
     echo "  ZOWE_IPADDRESS variable value="$ZOWE_IPADDRESS >> $LOG_FILE
 fi
+
+if [[ $ZOWE_ZOSMF_HOST == "" ]]
+then
+    ZOWE_ZOSMF_HOST = $ZOWE_EXPLORER_HOST
+    echo "  ZOWE_ZOSMF_HOST variable not specified, value defaults to "$ZOWE_ZOSMF_HOST >> $LOG_FILE
+    persist "ZOWE_ZOSMF_HOST" $ZOWE_ZOSMF_HOST
+else
+    echo "  ZOWE_ZOSMF_HOST variable value="$ZOWE_ZOSMF_HOST >> $LOG_FILE
+fi
+    
+
 echo "</zowe-init.sh>" >> $LOG_FILE


### PR DESCRIPTION
This is a fix for  https://github.com/zowe/zowe-install-packaging/issues/427, when z/OSMF runs on another host than whole zowe (APIML, Explorer APIs, ZAF), user performing installation has to carry out some post installation changes.

This PR introduces a new environment variable `ZOWE_ZOSMF_HOST` that is used like `ZOWE_ZOSMF_PORT`. 
To exploit it execute
```sh
export ZOWE_ZOSMF_HOST=myzosfm.customhostname.abc
export ZOWE_ZOSMF_PORT=1443
zowe-install.sh
```
if `ZOWE_ZOSMF_HOST` is not specified it defaults to `ZOWE_EXPLORER_HOST`.

`ZOWE_ZOSMF_HOST` is used in these places:
 *   `scripts/configure/zowe-configure-api-mediation.sh`
    from `https://$ZOWE_EXPLORER_HOST:$ZOWE_ZOSMF_PORT/zosmf/` 
    to `https://$ZOWE_ZOSMF_HOST:$ZOWE_ZOSMF_PORT/zosmf/`
 * `scripts/configure/zowe-configure-explorer-api.sh`
  from  `-e "s/\*\*ZOSMF_IP\*\*/$ZOWE_IPADDRESS/g" \` 
  to `-e "s/\*\*ZOSMF_IP\*\*/$ZOWE_ZOSMF_HOST/g" \` 

As we can see there are two variables `ZOWE_EXPLORER_HOST` and `ZOWE_IPADDRESS` used to point to z/OSMF, I decided that I would rather use hostname rather than ip address, hopefully this will not cause any issue because both hostname and ip address has been used until now.

NOTE: this PR is based on https://github.com/zowe/zowe-install-packaging/pull/593