### PR TITLE
Ptf prep2

### DIFF
--- a/install/zowe-install.sh
+++ b/install/zowe-install.sh
@@ -10,8 +10,12 @@
 # Copyright IBM Corporation 2018, 2019
 ################################################################################
 
-while getopts "f:h:i:I" opt; do
+while getopts "f:h:i:dI" opt; do
   case $opt in
+    d) # enable debug mode
+      # future use, accept parm to stabilize SMPE packaging
+      #debug="-d"
+      ;;
     f) # override default value for LOG_FILE
       # future use, issue 801, accept parm to stabilize SMPE packaging
       #...="$OPTARG"

--- a/smpe/bld/alter.sh
+++ b/smpe/bld/alter.sh
@@ -134,10 +134,10 @@ then                                     # make exectuable after update
 fi    #
 
 TmP=${TMPDIR:-/tmp}/$(basename $1).$$
-#_cmd --repl $TmP sed "$SED" $1                  # sed '...' $1 > $TmP
-test "$debug" && echo
-test "$debug" && echo "sed $SED 2>&1 $1 > $TmP"
-sed "$SED" $1 2>&1 > $TmP                       # sed '...' $1 > $TmP
+_cmd --repl $TmP sed "$SED" $1                  # sed '...' $1 > $TmP
+#test "$debug" && echo
+#test "$debug" && echo "sed $SED 2>&1 $1 > $TmP"
+#sed "$SED" $1 2>&1 > $TmP                       # sed '...' $1 > $TmP
 _cmd mv $TmP ${2:-$1}                           # give $TmP actual name
 test -n "$ExEc" && _cmd chmod a+x ${2:-$1}      # make executable
 }    # _sed

--- a/smpe/bld/get-config.sh
+++ b/smpe/bld/get-config.sh
@@ -88,8 +88,6 @@ install:
   stage=
   # HLQ holding product MVS data sets (= SMP/E input)
   outMVS=
-  # directory holding product USS files (= SMP/E input)
-  outUSS=
 split:
   # absolute maximum number of lines in a PTF
   ptfLines=
@@ -97,6 +95,8 @@ split:
   ptfPercent=
   # limit historical manifest delta log to x lines
   deltaLines=
+  # directory holding product USS files (= SMP/E input)
+  outUSS=
   # temporary directory to stage MVS members for reporting
   mvs=
   # temporary directory to split product in chunks
@@ -174,12 +174,12 @@ do
     _export install log        log           ${ROOT}/logs   # permanent
     _export install extract    extract       ${ROOT}/extract # internal
     _export install stage      stage         ${ROOT}/stage  # pass
-    _export install outMVS     mvsI          ${HLQ}.BLD     # output
-    _export install outUSS     ussI          ${ROOT}/BLD    # output
+    _export install outMVS     mvsI          ${HLQ}.BLD     # pass
 # split
     _export split   ptfLines   maxPtfLines   5000000        # permanent
     _export split   ptfPercent maxPtfPercent 90             # permanent
     _export split   deltaLines maxDeltaLines 30000          # permanent
+    _export split   outUSS     ussI          ${ROOT}/BLD    # pass
     _export split   mvs        mvs           ${ROOT}/mvs    # internal
     _export split   split      split         ${ROOT}/split  # internal
 # fmid

--- a/smpe/bld/smpe-config.sh
+++ b/smpe/bld/smpe-config.sh
@@ -55,23 +55,23 @@ test "$debug" && echo
 if test "$1" = "--null"
 then         # stdout -> null, stderr -> stdout (without going to null)
   shift
-  test "$debug" && echo "$@ 2>&1 >/dev/null"
-                         $@ 2>&1 >/dev/null
+  test "$debug" && echo "\"$@\" 2>&1 >/dev/null"
+                          "$@"  2>&1 >/dev/null
 elif test "$1" = "--save"
 then         # stdout -> >>$2, stderr -> stdout (without going to $2)
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>&1 >> $sAvE"
-                         $@ 2>&1 >> $sAvE
+  test "$debug" && echo "\"$@\" 2>&1 >> $sAvE"
+                          "$@"  2>&1 >> $sAvE
 elif test "$1" = "--repl"
 then         # stdout -> >$2, stderr -> stdout (without going to $2)
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>&1 > $sAvE"
-                         $@ 2>&1 > $sAvE
+  test "$debug" && echo "\"$@\" 2>&1 > $sAvE"
+                          "$@"  2>&1 > $sAvE
 else         # stderr -> stdout, caller can add >/dev/null to trash all
-  test "$debug" && echo "$@ 2>&1"
-                         $@ 2>&1
+  test "$debug" && echo "\"$@\" 2>&1"
+                          "$@"  2>&1
 fi    #
 sTaTuS=$?
 if test $sTaTuS -ne 0

--- a/smpe/bld/smpe-fmid.sh
+++ b/smpe/bld/smpe-fmid.sh
@@ -337,23 +337,23 @@ test "$debug" && echo
 if test "$1" = "--null"
 then                                 # stdout -> null, stderr -> null
   shift
-  test "$debug" && echo "$@ 2>/dev/null >/dev/null"
-                         $@ 2>/dev/null >/dev/null
+  test "$debug" && echo "\"$@\" 2>/dev/null >/dev/null"
+                          "$@"  2>/dev/null >/dev/null
 elif test "$1" = "--save"
 then                                 # stdout -> >>$2, stderr -> null
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>/dev/null >> $sAvE"
-                         $@ 2>/dev/null >> $sAvE
+  test "$debug" && echo "\"$@\" 2>/dev/null >> $sAvE"
+                          "$@"  2>/dev/null >> $sAvE
 elif test "$1" = "--repl"
 then                                 # stdout -> >$2, stderr -> null
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>/dev/null > $sAvE"
-                         $@ 2>/dev/null > $sAvE
+  test "$debug" && echo "\"$@\" 2>/dev/null > $sAvE"
+                          "$@"  2>/dev/null > $sAvE
 else                                 # stdout -> stdout, stderr -> null
-  test "$debug" && echo "$@ 2>/dev/null"
-                         $@ 2>/dev/null
+  test "$debug" && echo "\"$@\" 2>/dev/null"
+                          "$@"  2>/dev/null
 fi    #
 sTaTuS=$?
 if test $sTaTuS -ne 0
@@ -378,23 +378,23 @@ test "$debug" && echo
 if test "$1" = "--null"
 then         # stdout -> null, stderr -> stdout (without going to null)
   shift
-  test "$debug" && echo "$@ 2>&1 >/dev/null"
-                         $@ 2>&1 >/dev/null
+  test "$debug" && echo "\"$@\" 2>&1 >/dev/null"
+                          "$@"  2>&1 >/dev/null
 elif test "$1" = "--save"
 then         # stdout -> >>$2, stderr -> stdout (without going to $2)
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>&1 >> $sAvE"
-                         $@ 2>&1 >> $sAvE
+  test "$debug" && echo "\"$@\" 2>&1 >> $sAvE"
+                          "$@"  2>&1 >> $sAvE
 elif test "$1" = "--repl"
 then         # stdout -> >$2, stderr -> stdout (without going to $2)
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>&1 > $sAvE"
-                         $@ 2>&1 > $sAvE
+  test "$debug" && echo "\"$@\" 2>&1 > $sAvE"
+                          "$@"  2>&1 > $sAvE
 else         # stderr -> stdout, caller can add >/dev/null to trash all
-  test "$debug" && echo "$@ 2>&1"
-                         $@ 2>&1
+  test "$debug" && echo "\"$@\" 2>&1"
+                          "$@"  2>&1
 fi    #
 sTaTuS=$?
 if test $sTaTuS -ne 0

--- a/smpe/bld/smpe-install.sh
+++ b/smpe/bld/smpe-install.sh
@@ -166,7 +166,7 @@ opts="$opts -i $stage"                         # target directory
 opts="$opts -I"                                # install only, no config
 opts="$opts -f $log/$logFile"                  # install log
 test $removeInstall -eq 1 && opts="$opts -R"   # remove input when done
-_cmd $extract/$prodScript $opts </dev/null
+_cmd $extract/$prodScript $debug $opts </dev/null
 
 # allow caller to alter product after install                    #debug
 test "$alter" && _cmd $alter $debug ZOWE POST $extract $stage
@@ -396,23 +396,23 @@ test "$debug" && echo
 if test "$1" = "--null"
 then                                 # stdout -> null, stderr -> null
   shift
-  test "$debug" && echo "$@ 2>/dev/null >/dev/null"
-                         $@ 2>/dev/null >/dev/null
+  test "$debug" && echo "\"$@\" 2>/dev/null >/dev/null"
+                          "$@"  2>/dev/null >/dev/null
 elif test "$1" = "--save"
 then                                 # stdout -> >>$2, stderr -> null
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>/dev/null >> $sAvE"
-                         $@ 2>/dev/null >> $sAvE
+  test "$debug" && echo "\"$@\" 2>/dev/null >> $sAvE"
+                          "$@"  2>/dev/null >> $sAvE
 elif test "$1" = "--repl"
 then                                 # stdout -> >$2, stderr -> null
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>/dev/null > $sAvE"
-                         $@ 2>/dev/null > $sAvE
+  test "$debug" && echo "\"$@\" 2>/dev/null > $sAvE"
+                          "$@"  2>/dev/null > $sAvE
 else                                 # stdout -> stdout, stderr -> null
-  test "$debug" && echo "$@ 2>/dev/null"
-                         $@ 2>/dev/null
+  test "$debug" && echo "\"$@\" 2>/dev/null"
+                          "$@"  2>/dev/null
 fi    #
 sTaTuS=$?
 if test $sTaTuS -ne 0
@@ -437,23 +437,23 @@ test "$debug" && echo
 if test "$1" = "--null"
 then         # stdout -> null, stderr -> stdout (without going to null)
   shift
-  test "$debug" && echo "$@ 2>&1 >/dev/null"
-                         $@ 2>&1 >/dev/null
+  test "$debug" && echo "\"$@\" 2>&1 >/dev/null"
+                          "$@"  2>&1 >/dev/null
 elif test "$1" = "--save"
 then         # stdout -> >>$2, stderr -> stdout (without going to $2)
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>&1 >> $sAvE"
-                         $@ 2>&1 >> $sAvE
+  test "$debug" && echo "\"$@\" 2>&1 >> $sAvE"
+                          "$@"  2>&1 >> $sAvE
 elif test "$1" = "--repl"
 then         # stdout -> >$2, stderr -> stdout (without going to $2)
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>&1 > $sAvE"
-                         $@ 2>&1 > $sAvE
+  test "$debug" && echo "\"$@\" 2>&1 > $sAvE"
+                          "$@"  2>&1 > $sAvE
 else         # stderr -> stdout, caller can add >/dev/null to trash all
-  test "$debug" && echo "$@ 2>&1"
-                         $@ 2>&1
+  test "$debug" && echo "\"$@\" 2>&1"
+                          "$@"  2>&1
 fi    #
 sTaTuS=$?
 if test $sTaTuS -ne 0

--- a/smpe/bld/smpe-pd.sh
+++ b/smpe/bld/smpe-pd.sh
@@ -47,23 +47,23 @@ test "$debug" && echo
 if test "$1" = "--null"
 then         # stdout -> null, stderr -> stdout (without going to null)
   shift
-  test "$debug" && echo "$@ 2>&1 >/dev/null"
-                         $@ 2>&1 >/dev/null
+  test "$debug" && echo "\"$@\" 2>&1 >/dev/null"
+                          "$@"  2>&1 >/dev/null
 elif test "$1" = "--save"
 then         # stdout -> >>$2, stderr -> stdout (without going to $2)
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>&1 >> $sAvE"
-                         $@ 2>&1 >> $sAvE
+  test "$debug" && echo "\"$@\" 2>&1 >> $sAvE"
+                          "$@"  2>&1 >> $sAvE
 elif test "$1" = "--repl"
 then         # stdout -> >$2, stderr -> stdout (without going to $2)
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>&1 > $sAvE"
-                         $@ 2>&1 > $sAvE
+  test "$debug" && echo "\"$@\" 2>&1 > $sAvE"
+                          "$@"  2>&1 > $sAvE
 else         # stderr -> stdout, caller can add >/dev/null to trash all
-  test "$debug" && echo "$@ 2>&1"
-                         $@ 2>&1
+  test "$debug" && echo "\"$@\" 2>&1"
+                          "$@"  2>&1
 fi    #
 sTaTuS=$?
 if test $sTaTuS -ne 0

--- a/smpe/bld/smpe-service.sh
+++ b/smpe/bld/smpe-service.sh
@@ -42,23 +42,23 @@ test "$debug" && echo
 if test "$1" = "--null"
 then         # stdout -> null, stderr -> stdout (without going to null)
   shift
-  test "$debug" && echo "$@ 2>&1 >/dev/null"
-                         $@ 2>&1 >/dev/null
+  test "$debug" && echo "\"$@\" 2>&1 >/dev/null"
+                          "$@"  2>&1 >/dev/null
 elif test "$1" = "--save"
 then         # stdout -> >>$2, stderr -> stdout (without going to $2)
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>&1 >> $sAvE"
-                         $@ 2>&1 >> $sAvE
+  test "$debug" && echo "\"$@\" 2>&1 >> $sAvE"
+                          "$@"  2>&1 >> $sAvE
 elif test "$1" = "--repl"
 then         # stdout -> >$2, stderr -> stdout (without going to $2)
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>&1 > $sAvE"
-                         $@ 2>&1 > $sAvE
+  test "$debug" && echo "\"$@\" 2>&1 > $sAvE"
+                          "$@"  2>&1 > $sAvE
 else         # stderr -> stdout, caller can add >/dev/null to trash all
-  test "$debug" && echo "$@ 2>&1"
-                         $@ 2>&1
+  test "$debug" && echo "\"$@\" 2>&1"
+                          "$@"  2>&1
 fi    #
 sTaTuS=$?
 if test $sTaTuS -ne 0

--- a/smpe/bld/smpe-split.sh
+++ b/smpe/bld/smpe-split.sh
@@ -969,23 +969,23 @@ test "$debug" && echo
 if test "$1" = "--null"
 then         # stdout -> null, stderr -> stdout (without going to null)
   shift
-  test "$debug" && echo "$@ 2>&1 >/dev/null"
-                         $@ 2>&1 >/dev/null
+  test "$debug" && echo "\"$@\" 2>&1 >/dev/null"
+                          "$@"  2>&1 >/dev/null
 elif test "$1" = "--save"
 then         # stdout -> >>$2, stderr -> stdout (without going to $2)
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>&1 >> $sAvE"
-                         $@ 2>&1 >> $sAvE
+  test "$debug" && echo "\"$@\" 2>&1 >> $sAvE"
+                          "$@"  2>&1 >> $sAvE
 elif test "$1" = "--repl"
 then         # stdout -> >$2, stderr -> stdout (without going to $2)
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>&1 > $sAvE"
-                         $@ 2>&1 > $sAvE
+  test "$debug" && echo "\"$@\" 2>&1 > $sAvE"
+                          "$@"  2>&1 > $sAvE
 else         # stderr -> stdout, caller can add >/dev/null to trash all
-  test "$debug" && echo "$@ 2>&1"
-                         $@ 2>&1
+  test "$debug" && echo "\"$@\" 2>&1"
+                          "$@"  2>&1
 fi    #
 sTaTuS=$?
 if test $sTaTuS -ne 0

--- a/smpe/pax/zowe-install-smpe.sh
+++ b/smpe/pax/zowe-install-smpe.sh
@@ -147,23 +147,23 @@ test "$debug" && echo
 if test "$1" = "--null"
 then         # stdout -> null, stderr -> stdout (without going to null)
   shift
-  test "$debug" && echo "$@ 2>&1 >/dev/null"
-                         $@ 2>&1 >/dev/null
+  test "$debug" && echo "\"$@\" 2>&1 >/dev/null"
+                          "$@"  2>&1 >/dev/null
 elif test "$1" = "--save"
 then         # stdout -> >>$2, stderr -> stdout (without going to $2)
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>&1 >> $sAvE"
-                         $@ 2>&1 >> $sAvE
+  test "$debug" && echo "\"$@\" 2>&1 >> $sAvE"
+                          "$@"  2>&1 >> $sAvE
 elif test "$1" = "--repl"
 then         # stdout -> >$2, stderr -> stdout (without going to $2)
   sAvE=$2
   shift 2
-  test "$debug" && echo "$@ 2>&1 > $sAvE"
-                         $@ 2>&1 > $sAvE
+  test "$debug" && echo "\"$@\" 2>&1 > $sAvE"
+                          "$@"  2>&1 > $sAvE
 else         # stderr -> stdout, caller can add >/dev/null to trash all
-  test "$debug" && echo "$@ 2>&1"
-                         $@ 2>&1
+  test "$debug" && echo "\"$@\" 2>&1"
+                          "$@"  2>&1
 fi    #
 sTaTuS=$?
 if test $sTaTuS -ne 0


### PR DESCRIPTION
- use double quotes in _cmd()
- moved ussI from install: to split: as it is no longer used in install.sh