### PR TITLE
Added export __UNTAGGED_READ_MODE=v6 to Zowe startup

### DIFF
--- a/scripts/run-zowe.template.sh
+++ b/scripts/run-zowe.template.sh
@@ -89,6 +89,9 @@ then
   export NODE_HOME={{node_home}}
 fi
 
+# Workaround Fix for node 8.16.1 that requires compatability mode for untagged files
+export __UNTAGGED_READ_MODE=V6
+
 DIR=`dirname $0`
 
 if [[ $LAUNCH_COMPONENT_GROUPS == *"DESKTOP"* ]]


### PR DESCRIPTION
Signed-off-by: Joe-Winchester <winchest@uk.ibm.com>

Apply same update of https://github.com/zowe/zowe-install-packaging/pull/819 on staging.