### PR TITLE
incorrect "."

### DIFF
--- a/scripts/utils/validate-directory-is-writable.sh
+++ b/scripts/utils/validate-directory-is-writable.sh
@@ -13,7 +13,7 @@
 DIRECTORY=$1
 USERID=`whoami`
 
-$(. . ${ROOT_DIR}/scripts/utils/validate-directory-is-accessible.sh)
+$(. ${ROOT_DIR}/scripts/utils/validate-directory-is-accessible.sh)
 AUTH_RETURN_CODE=$?
 if [[ $AUTH_RETURN_CODE == "0" ]];
 then	


### PR DESCRIPTION
- [x] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Relevant issues

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path below.-->

#### Does this PR do something the person installing Zowe should know about?

no
---
* Affected function: _general area of interest_ *

---
* Description: fix for validate-directory-is-writable.sh: line 16: .: .: is a directory *

---
* Part: _name of customizable file involved_  *

---
PR fixes this error message
```
/root/zowe/1.7.0/scripts/utils/validate-directory-is-writable.sh: line 16: .: .: is a directory
```



#### Other information

