### PR TITLE
Copy install app on instance creation

### DIFF
--- a/bin/zowe-configure-instance.sh
+++ b/bin/zowe-configure-instance.sh
@@ -165,6 +165,9 @@ else
   create_new_instance
 fi
 
+#Make install-app.sh present per-instance for convenience
+cp ${ZOWE_ROOT_DIR}/components/app-server/share/zlux-app-server/bin/install-app.sh ${INSTANCE_DIR}/bin/install-app.sh
+
 cat <<EOF >${INSTANCE_DIR}/bin/read-instance.sh
 # Requires INSTANCE_DIR to be set
 # Read in properties by executing, then export all the keys so we don't need to shell share


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
- [x] Bugfix

#### Relevant issues
Fixes https://github.com/zowe/zlux/issues/362

#### Changes proposed in this PR
`install-app.sh` Can be used where it lives in the app-server code, but it needs environment variables or extra parameters to work properly there. Instead, `install-app.sh` is meant to exist in the instance directory so it can read the instance files to find where plugins should be placed. So, when an instance is created it should be copied into the bin folder for ease of use.
#### Does this PR introduce a breaking change?
- [x] No