### PR TITLE
Remove hardcoded /tmp use from scripts

### DIFF
--- a/bin/apiml_cm.sh
+++ b/bin/apiml_cm.sh
@@ -65,7 +65,7 @@ ALIAS="alias"
 CERTIFICATE="no-certificate-specified"
 
 if [ -z ${TEMP_DIR+x} ]; then
-    TEMP_DIR=/tmp
+    TEMP_DIR=${TMPDIR:-/tmp}
 fi
 
 function pkeytool {

--- a/install/zowe-check-prereqs.sh
+++ b/install/zowe-check-prereqs.sh
@@ -178,6 +178,9 @@ else
   echo OK
 fi
 
+if [ -z ${TEMP_DIR+x} ]; then
+    TEMP_DIR=${TMPDIR:-/tmp}
+fi
 
 
 # 1- RDEFINE OPERCMDS MVS.START.** UACC(NONE)
@@ -189,7 +192,7 @@ match_profile ()
 {
   className=$1    # the CLASS containing all the profiles that user can access
   profileName=$2  # the profile that we want to match in that list
-  tsocmd "search class($className) user($userid)" 2> /dev/null |sed 's/\(.*\) .*/\1/' > /tmp/find_profile.out
+  tsocmd "search class($className) user($userid)" 2> /dev/null |sed 's/\(.*\) .*/\1/' > $TEMP_DIR/find_profile.out
   while read string 
   do
     
@@ -202,7 +205,7 @@ match_profile ()
 
         if [[ $r = '*' ]]
         then
-          rm        /tmp/find_profile.out
+          rm        $TEMP_DIR/find_profile.out
           return 0  # asterisk matches rest of string
         fi
 
@@ -216,13 +219,13 @@ match_profile ()
 
     if [[ $i -eq $l ]]
     then
-      rm        /tmp/find_profile.out
+      rm        $TEMP_DIR/find_profile.out
       return 0  # whole string matched
     fi
 
 
-  done <    /tmp/find_profile.out
-  rm        /tmp/find_profile.out
+  done <    $TEMP_DIR/find_profile.out
+  rm        $TEMP_DIR/find_profile.out
   return 1    # no strings matched
 }
 

--- a/scripts/utils/zowe-copy-to-JES.sh
+++ b/scripts/utils/zowe-copy-to-JES.sh
@@ -41,6 +41,10 @@ script_exit(){
 # identify this script
 SCRIPT="$(basename $0)"
 
+if [ -z ${TEMP_DIR+x} ]; then
+    TEMP_DIR=${TMPDIR:-/tmp}
+fi
+
 LOG_FILE=~/${SCRIPT}-`date +%Y-%m-%d-%H-%M-%S`.log
 touch $LOG_FILE
 chmod a+rw $LOG_FILE
@@ -143,18 +147,18 @@ else
   sed -e "s/ZWES.SISLOAD/${loadlib}/g" \
       -e "s/ZWES.SISSAMP/${parmlib}/g" \
       -e "s/zis-loadlib/${loadlib}/g" \
-      "//'$samplib($Imember)'" > /tmp/$samplib.$Imember.jcl
+      "//'$samplib($Imember)'" > $TEMP_DIR/$samplib.$Imember.jcl
   if [[ $? -ne 0 ]]
   then
-    echo Failed to edit "$samplib($Imember)" into /tmp/$samplib.$Imember.jcl | tee -a ${LOG_FILE}
+    echo Failed to edit "$samplib($Imember)" into $TEMP_DIR/$samplib.$Imember.jcl | tee -a ${LOG_FILE}
     script_exit 8
   else
     echo Edited "$samplib($Imember)" 
   fi
-  cp /tmp/$samplib.$Imember.jcl "//'$templib($Imember)'"
+  cp $TEMP_DIR/$samplib.$Imember.jcl "//'$templib($Imember)'"
   if [[ $? -ne 0 ]]
   then
-    echo Failed to copy /tmp/$samplib.$Imember.jcl into "$templib($Imember)" | tee -a ${LOG_FILE}
+    echo Failed to copy $TEMP_DIR/$samplib.$Imember.jcl into "$templib($Imember)" | tee -a ${LOG_FILE}
     script_exit 8
   else
     echo Copied into "$templib($Imember)"   


### PR DESCRIPTION
<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [x] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Relevant issues
<!-- Link to a relevant GitHub issue if any. If this PR applies to multiple issues, preface each issue reference with the "Fixes" keyword. For example, Fixes #123, Fixes #456. -->
Fixes #799 

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
- Added TEMP_DIR variable in scripts to use instead of /tmp.
- TEMP_DIR variable is derived from TMPDIR USS variable or by default, /tmp.

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path below.-->

#### Does this PR do something the person installing Zowe should know about?

<!-- Is this a fix or a feature that changes customizable files (e.g. configuration files, sample JCL, etc),
product requirements, or other installation or configuration related area? If so, please fill out the template below. 
There is no need to report the need to restart the servers to activate the change. Note that the provided text will be formatted in 64-character lines, and that round brackets, ( and ), must always be used in matching pairs. -->
It changes the temp directory used by the following scripts:
- apiml_cm.sh
- zowe-verify.sh
- zowe-check-prereqs.sh
- zowe-copy-to-JES.sh
---
**Affected function: _general area of interest_**
- Install and post-install verification scripts.
