### PR TITLE
Move log into temp and relocate if r/o

### DIFF
--- a/install/zowe-install.sh
+++ b/install/zowe-install.sh
@@ -56,11 +56,18 @@ separator() {
 }
 separator
 
-# Create a log file with the year and time.log in a log folder 
-# that scripts can echo to and can be written to by scripts to diagnose any install 
-# problems.  
+# Create a temp directory to be a working directory for sed replacements and logs, if install_dir is read-only then put it in ${TMPDIR}/'/tmp\'
+if [[ -w "${$INSTALL_DIR}" ]]
+then
+  export TEMP_DIR=$INSTALL_DIR/temp_"`date +%Y-%m-%d`"
+else
+  export TEMP_DIR=${TMPDIR:-/tmp}/zowe_"`date +%Y-%m-%d`"
+fi
+mkdir -p $TEMP_DIR
 
-export LOG_DIR=$INSTALL_DIR/log
+# Create a log file with the year and time.log in a log folder 
+# that scripts can echo to and can be written to by scripts to diagnose any install problems.  
+export LOG_DIR=$TEMP_DIR/log
 # Make the log directory if needed - first time through - subsequent installs create new .log files
 if [[ ! -d $LOG_DIR ]]; then
     mkdir -p $LOG_DIR
@@ -127,10 +134,6 @@ chmod a+rx $ZOWE_ROOT_DIR
 # copy manifest.json to root folder
 cp "$INSTALL_DIR/manifest.json" "$ZOWE_ROOT_DIR"
 chmod 750 "${ZOWE_ROOT_DIR}/manifest.json"
-
-# Create a temp directory to be a working directory for sed replacements
-export TEMP_DIR=$INSTALL_DIR/temp_"`date +%Y-%m-%d`"
-mkdir -p $TEMP_DIR
 
 # Install the API Mediation Layer
 . $INSTALL_DIR/scripts/zowe-install-api-mediation.sh

--- a/install/zowe-install.sh
+++ b/install/zowe-install.sh
@@ -57,9 +57,9 @@ separator() {
 separator
 
 # Create a temp directory to be a working directory for sed replacements and logs, if install_dir is read-only then put it in ${TMPDIR}/'/tmp\'
-if [[ -w "${$INSTALL_DIR}" ]]
+if [[ -w "${INSTALL_DIR}" ]]
 then
-  export TEMP_DIR=$INSTALL_DIR/temp_"`date +%Y-%m-%d`"
+  export TEMP_DIR=${INSTALL_DIR}/temp_"`date +%Y-%m-%d`"
 else
   export TEMP_DIR=${TMPDIR:-/tmp}/zowe_"`date +%Y-%m-%d`"
 fi

--- a/install/zowe-install.sh
+++ b/install/zowe-install.sh
@@ -64,18 +64,13 @@ else
   export TEMP_DIR=${TMPDIR:-/tmp}/zowe_"`date +%Y-%m-%d`"
 fi
 mkdir -p $TEMP_DIR
+chmod a+rwx $TEMP_DIR 
 
 # Create a log file with the year and time.log in a log folder 
 # that scripts can echo to and can be written to by scripts to diagnose any install problems.  
-export LOG_DIR=$TEMP_DIR/log
-# Make the log directory if needed - first time through - subsequent installs create new .log files
-if [[ ! -d $LOG_DIR ]]; then
-    mkdir -p $LOG_DIR
-    chmod a+rwx $LOG_DIR 
-fi
 # Make the log file (unique assuming there is only one install per second)
 export LOG_FILE="`date +%Y-%m-%d-%H-%M-%S`.log"
-LOG_FILE=$LOG_DIR/$LOG_FILE
+LOG_FILE=$TEMP_DIR/$LOG_FILE
 touch $LOG_FILE
 chmod a+rw $LOG_FILE
 


### PR DESCRIPTION
Signed-off-by: stevenhorsman <steven@uk.ibm.com>
Fixes #752 

#### Changes proposed in this PR
Move the install_log file into the temp directory and if the install_directory is not writeable relocate our temp file to ${TMPDIR:-/tmp}