### PR TITLE
fix variable name in zowe-install-iframe-plugin.sh

### DIFF
--- a/bin/utils/zowe-install-iframe-plugin.sh
+++ b/bin/utils/zowe-install-iframe-plugin.sh
@@ -39,7 +39,7 @@ if ! [ -f "$5" ]; then
 fi
 
 if ! [ -z "$PLUGIN_DIR_OVERRIDE" ]; then
-  PLUGIN_FOLDER=$PLUGIN_DIR_OVERRIDE
+  PLUGIN_DIR=$PLUGIN_DIR_OVERRIDE
 fi
 
 # remove any previous plugin files
@@ -65,7 +65,7 @@ cat <<EOF >$PLUGIN_DIR/web/index.html
     </body>
 </html>
 EOF
-chtag -tc 1047 $PLUGIN_FOLDER/web/index.html
+chtag -tc 1047 $PLUGIN_DIR/web/index.html
 
 cat <<EOF >$PLUGIN_DIR/pluginDefinition.json
 {
@@ -91,7 +91,7 @@ cat <<EOF >$PLUGIN_DIR/pluginDefinition.json
   }
 }
 EOF
-chtag -tc 1047 $PLUGIN_FOLDER/pluginDefinition.json
+chtag -tc 1047 $PLUGIN_DIR/pluginDefinition.json
 
 chmod -R a+rx $PLUGIN_DIR
 ${INSTANCE_DIR}/bin/install-app.sh $PLUGIN_DIR


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [x] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Relevant issues

There are several lines show in `STDERR` log:

```
chtag: FSUM6180 file "/web/index.html": EDC5129I No such file or directory. (errno2=0x0594003D)
chtag: FSUM6180 file "/pluginDefinition.json": EDC5129I No such file or directory. (errno2=0x053B006C)
chtag: FSUM6180 file "/web/index.html": EDC5129I No such file or directory. (errno2=0x0594003D)
chtag: FSUM6180 file "/pluginDefinition.json": EDC5129I No such file or directory. (errno2=0x053B006C)
chtag: FSUM6180 file "/web/index.html": EDC5129I No such file or directory. (errno2=0x0594003D)
chtag: FSUM6180 file "/pluginDefinition.json": EDC5129I No such file or directory. (errno2=0x053B006C)
chtag: FSUM6180 file "/web/index.html": EDC5129I No such file or directory. (errno2=0x0594003D)
chtag: FSUM6180 file "/pluginDefinition.json": EDC5129I No such file or directory. (errno2=0x053B006C)
```

Which makes me believe `PLUGIN_FOLDER` is a typo of `PLUGIN_DIR`.

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
- Replace `PLUGIN_FOLDER` with `PLUGIN_DIR`

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path below.-->

#### Does this PR do something the person installing Zowe should know about?

<!-- Is this a fix or a feature that changes customizable files (e.g. configuration files, sample JCL, etc),
product requirements, or other installation or configuration related area? If so, please fill out the template below. 
There is no need to report the need to restart the servers to activate the change. Note that the provided text will be formatted in 64-character lines, and that round brackets, ( and ), must always be used in matching pairs. -->

---
* Affected function: _general area of interest_ *

---
* Description: _1 line description_ *

---
* Part: _name of customizable file involved_  *

---
_multi-line description_

#### Is there a related doc issue or Pull Request? 
<!-- Link to a relevant documentation issue or Pull Request if any. -->

Doc issue/PR number: 

#### Other information

This change is validated with test https://wash.zowe.org:8443/job/zowe-install-test/job/staging/847/console, and `STC05883.STDERR` is confirmed to be empty. The test failed because of gateway is not started.
