### PR TITLE
Bugfix/read instance

### DIFF
--- a/bin/internal/run-zowe.sh
+++ b/bin/internal/run-zowe.sh
@@ -54,7 +54,13 @@ WORKSPACE_DIR=${INSTANCE_DIR}/workspace
 mkdir -p ${WORKSPACE_DIR}
 
 # Read in configuration
-. ${INSTANCE_DIR}/bin/internal/read-instance.sh
+if [ -e "${INSTANCE_DIR}/bin/internal/read-instance.sh" ]
+then
+  . ${INSTANCE_DIR}/bin/internal/read-instance.sh
+else
+  . ${INSTANCE_DIR}/bin/read-instance.sh
+fi
+
 # TODO - in for backwards compatibility, remove once naming conventions finalised and sorted #870
 ZOWE_APIM_GATEWAY_PORT=$GATEWAY_PORT
 ZOWE_IPADDRESS=$ZOWE_IP_ADDRESS

--- a/bin/zowe-setup-certificates.sh
+++ b/bin/zowe-setup-certificates.sh
@@ -144,7 +144,11 @@ if [[ "${VERIFY_CERTIFICATES}" == "true" ]]; then
   echo "apiml_cm.sh --action trust-zosmf returned: $RC" >> $LOG_FILE
   if [ "$RC" -ne "0" ]; then
       (>&2 echo "apiml_cm.sh --action trust-zosmf has failed. See $LOG_FILE for more details")
-      (>&2 echo "WARNING: z/OSMF is not trusted by the API Mediation Layer. Follow instructions in Zowe documentation about manual steps to trust z/OSMF")
+      (>&2 echo "ERROR: z/OSMF is not trusted by the API Mediation Layer. Make sure ZOWE_ZOSMF_HOST and ZOWE_ZOSMF_PORT variables define the desired z/OSMF instance.")
+      (>&2 echo "ZOWE_ZOSMF_HOST=${ZOWE_ZOSMF_HOST}   ZOWE_ZOSMF_PORT=${ZOWE_ZOSMF_PORT}")
+      (>&2 echo "You can also specify z/OSMF certificate explicitly in the ZOSMF_CERTIFICATE environmental variable in the zowe-setup-certificates.env file.")
+      echo "</zowe-setup-certificates.sh>" >> $LOG_FILE
+      exit 1
   fi
 fi
 echo "Creating certificates and keystores... DONE"


### PR DESCRIPTION
Fixes the case in which you have a 1.8 instance and you point it to 1.9 content, where the script for reading instances was expected to be in a new location.