### PR TITLE
WIP: Add log directory parameter option

### DIFF
--- a/bin/zowe-setup-certificates.sh
+++ b/bin/zowe-setup-certificates.sh
@@ -14,17 +14,31 @@
 #                       that will be also used to secure newly generated keystores for API Mediation.
 # - ZOWE_USER_ID - zowe user id to set up ownership of the generated certificates
 
+while getopts "l:" opt; do
+  case $opt in
+    l) LOG_DIRECTORY=$OPTARG;;
+    \?)
+      echo "Invalid option: -$opt" >&2
+      exit 1
+      ;;
+  esac
+done
+shift $(($OPTIND-1))
 
-# Set up logging
-LOG_DIR=${HOME}/zowe_certificate_setup_log
+# If log directory not specified on input default to home
+if [[ -z "${LOG_DIRECTORY}" ]]
+then
+  LOG_DIRECTORY=${HOME}/zowe_certificate_setup_log
+fi
+
 # Make the log directory if needed - first time through - subsequent installs create new .log files
-if [[ ! -d $LOG_DIR ]]; then
-    mkdir -p $LOG_DIR
-    chmod a+rwx $LOG_DIR 
+if [[ ! -d ${LOG_DIRECTORY} ]]; then
+    mkdir -p ${LOG_DIRECTORY}
+    chmod a+rwx ${LOG_DIRECTORY} 
 fi
 
 export LOG_FILE="certificate_config_`date +%Y-%m-%d-%H-%M-%S`.log"
-LOG_FILE=$LOG_DIR/$LOG_FILE
+LOG_FILE=${LOG_DIRECTORY}/$LOG_FILE
 touch $LOG_FILE
 chmod a+rw $LOG_FILE
 

--- a/install/zowe-install.sh
+++ b/install/zowe-install.sh
@@ -15,18 +15,15 @@ if [ $# -lt 4 ]; then
   exit 1
 fi
 
-while getopts "f:h:i:d" opt; do
+while getopts "h:i:l:d" opt; do
   case $opt in
     d) # enable debug mode
       # future use, accept parm to stabilize SMPE packaging
       #debug="-d"
       ;;
-    f) # override default value for LOG_FILE
-      # future use, issue 801, accept parm to stabilize SMPE packaging
-      #...="$OPTARG"
-      ;;
     h) DSN_PREFIX=$OPTARG;;
     i) INSTALL_TARGET=$OPTARG;;
+    l) LOG_DIRECTORY=$OPTARG;;
     \?)
       echo "Invalid option: -$opt" >&2
       exit 1
@@ -57,11 +54,14 @@ fi
 mkdir -p $TEMP_DIR
 chmod a+rwx $TEMP_DIR 
 
-# Create a log file with the year and time.log in a log folder 
-# that scripts can echo to and can be written to by scripts to diagnose any install problems.  
-# Make the log file (unique assuming there is only one install per second)
-export LOG_FILE="`date +%Y-%m-%d-%H-%M-%S`.log"
-LOG_FILE=$TEMP_DIR/$LOG_FILE
+# If log directory not specified on input default to temp (so install can be read-only)
+# Create a log file with the year and time.log in a log folder
+if [[ -z "${LOG_DIRECTORY}" ]]
+then
+  LOG_DIRECTORY=${TEMP_DIR}
+fi
+mkdir -p ${LOG_DIRECTORY}
+export LOG_FILE=${LOG_DIRECTORY}"/`date +%Y-%m-%d-%H-%M-%S`.log"
 touch $LOG_FILE
 chmod a+rw $LOG_FILE
 

--- a/scripts/utils/zowe-copy-to-JES.sh
+++ b/scripts/utils/zowe-copy-to-JES.sh
@@ -29,6 +29,16 @@
 # sed -e "s/zis-loadlib/${XMEM_LOADLIB}/g" \
 #     ${ZSS}/SAMPLIB/ZWESAUX > ${ZSS}/SAMPLIB/${XMEM_AUX_JCL}.tmp
 
+while getopts "l:" opt; do
+  case $opt in
+    l) LOG_DIRECTORY=$OPTARG;;
+    \?)
+      echo "Invalid option: -$opt" >&2
+      exit 1
+      ;;
+  esac
+done
+shift $(($OPTIND-1))
 
 script_exit(){
   tsocmd delete "'$clist'"   1>> $LOG_FILE 2>> $LOG_FILE
@@ -41,7 +51,14 @@ script_exit(){
 # identify this script
 SCRIPT="$(basename $0)"
 
-LOG_FILE=~/${SCRIPT}-`date +%Y-%m-%d-%H-%M-%S`.log
+# If log directory not specified on input default to home
+if [[ -z "${LOG_DIRECTORY}" ]]
+then
+  LOG_DIRECTORY=${HOME}
+fi
+mkdir -p ${LOG_DIRECTORY}
+
+LOG_FILE=${LOG_DIRECTORY}/${SCRIPT}-`date +%Y-%m-%d-%H-%M-%S`.log
 touch $LOG_FILE
 chmod a+rw $LOG_FILE
 

--- a/scripts/utils/zowe-copy-to-JES.sh
+++ b/scripts/utils/zowe-copy-to-JES.sh
@@ -29,16 +29,17 @@
 # sed -e "s/zis-loadlib/${XMEM_LOADLIB}/g" \
 #     ${ZSS}/SAMPLIB/ZWESAUX > ${ZSS}/SAMPLIB/${XMEM_AUX_JCL}.tmp
 
-while getopts "l:" opt; do
-  case $opt in
-    l) LOG_DIRECTORY=$OPTARG;;
-    \?)
-      echo "Invalid option: -$opt" >&2
-      exit 1
-      ;;
-  esac
-done
-shift $(($OPTIND-1))
+# zip #1157 - blocked by # zip #1156
+# while getopts "l:" opt; do
+#   case $opt in
+#     l) LOG_DIRECTORY=$OPTARG;;
+#     \?)
+#       echo "Invalid option: -$opt" >&2
+#       exit 1
+#       ;;
+#   esac
+# done
+# shift $(($OPTIND-1))
 
 script_exit(){
   tsocmd delete "'$clist'"   1>> $LOG_FILE 2>> $LOG_FILE

--- a/scripts/utils/zowe-install-proc.sh
+++ b/scripts/utils/zowe-install-proc.sh
@@ -12,16 +12,17 @@
 # Function: Copy Zowe server PROC from datasetPrefx.SZWESAMP(ZWESVSTC) to JES concatenation
 # Needs ./zowe-copy-to-JES.sh
 
-while getopts "l:" opt; do
-  case $opt in
-    l) LOG_DIRECTORY=$OPTARG;;
-    \?)
-      echo "Invalid option: -$opt" >&2
-      exit 1
-      ;;
-  esac
-done
-shift $(($OPTIND-1))
+# zip #1157 - blocked by # zip #1156
+# while getopts "l:" opt; do
+#   case $opt in
+#     l) LOG_DIRECTORY=$OPTARG;;
+#     \?)
+#       echo "Invalid option: -$opt" >&2
+#       exit 1
+#       ;;
+#   esac
+# done
+# shift $(($OPTIND-1))
 
 script_exit(){
   echo exit $1 >> ${LOG_FILE}
@@ -99,7 +100,7 @@ do
   fi
 done
 
-./zowe-copy-to-JES.sh $samplib $Imember $proclib $Omember -l ${LOG_DIRECTORY}
+./zowe-copy-to-JES.sh $samplib $Imember $proclib $Omember #-l ${LOG_DIRECTORY}
 echo "rc from zowe-copy-to-JES.sh is $?" >> $LOG_FILE
 
 script_exit 0

--- a/scripts/utils/zowe-install-proc.sh
+++ b/scripts/utils/zowe-install-proc.sh
@@ -11,6 +11,18 @@
 
 # Function: Copy Zowe server PROC from datasetPrefx.SZWESAMP(ZWESVSTC) to JES concatenation
 # Needs ./zowe-copy-to-JES.sh
+
+while getopts "l:" opt; do
+  case $opt in
+    l) LOG_DIRECTORY=$OPTARG;;
+    \?)
+      echo "Invalid option: -$opt" >&2
+      exit 1
+      ;;
+  esac
+done
+shift $(($OPTIND-1))
+
 script_exit(){
   echo exit $1 >> ${LOG_FILE}
   echo "</$SCRIPT>" >> ${LOG_FILE}
@@ -19,7 +31,14 @@ script_exit(){
 # identify this script
 SCRIPT="$(basename $0)"
 
-LOG_FILE=~/${SCRIPT}-`date +%Y-%m-%d-%H-%M-%S`.log
+# If log directory not specified on input default to home
+if [[ -z "${LOG_DIRECTORY}" ]]
+then
+  LOG_DIRECTORY=${HOME}
+fi
+mkdir -p ${LOG_DIRECTORY}
+
+LOG_FILE=${LOG_DIRECTORY}/${SCRIPT}-`date +%Y-%m-%d-%H-%M-%S`.log
 touch $LOG_FILE
 chmod a+rw $LOG_FILE
 
@@ -80,7 +99,7 @@ do
   fi
 done
 
-./zowe-copy-to-JES.sh $samplib $Imember $proclib $Omember
+./zowe-copy-to-JES.sh $samplib $Imember $proclib $Omember -l ${LOG_DIRECTORY}
 echo "rc from zowe-copy-to-JES.sh is $?" >> $LOG_FILE
 
 script_exit 0

--- a/scripts/utils/zowe-install-xmem.sh
+++ b/scripts/utils/zowe-install-xmem.sh
@@ -23,6 +23,17 @@
 
 # Needs ./zowe-copy-to-JES.sh for PROCLIB
 
+while getopts "l:" opt; do
+  case $opt in
+    l) LOG_DIRECTORY=$OPTARG;;
+    \?)
+      echo "Invalid option: -$opt" >&2
+      exit 1
+      ;;
+  esac
+done
+shift $(($OPTIND-1))
+
 script_exit(){
   echo exit $1 | tee -a ${LOG_FILE}
   echo "</$SCRIPT>" | tee -a ${LOG_FILE}
@@ -31,7 +42,14 @@ script_exit(){
 # identify this script
 SCRIPT="$(basename $0)"
 
-LOG_FILE=~/${SCRIPT}-`date +%Y-%m-%d-%H-%M-%S`.log
+# If log directory not specified on input default to home
+if [[ -z "${LOG_DIRECTORY}" ]]
+then
+  LOG_DIRECTORY=${HOME}
+fi
+mkdir -p ${LOG_DIRECTORY}
+
+LOG_FILE=${LOG_DIRECTORY}/${SCRIPT}-`date +%Y-%m-%d-%H-%M-%S`.log
 touch $LOG_FILE
 chmod a+rw $LOG_FILE
 
@@ -167,7 +185,7 @@ ZWEXASTC=ZWESASTC  # for ZWESAUX
 ZWEXMSTC=ZWESISTC  # for ZWESIS01
 
 # the extra parms ${loadlib} ${parmlib} are used to replace DSNs in PROCLIB members
-./zowe-copy-to-JES.sh $samplib $ZWEXASTC $proclib $ZWEXASTC  ${loadlib} ${parmlib}
-./zowe-copy-to-JES.sh $samplib $ZWEXMSTC $proclib $ZWEXMSTC  ${loadlib} ${parmlib}
+./zowe-copy-to-JES.sh $samplib $ZWEXASTC $proclib $ZWEXASTC  ${loadlib} ${parmlib} -l ${LOG_DIRECTORY}
+./zowe-copy-to-JES.sh $samplib $ZWEXMSTC $proclib $ZWEXMSTC  ${loadlib} ${parmlib} -l ${LOG_DIRECTORY}
 
 script_exit 0

--- a/scripts/utils/zowe-install-xmem.sh
+++ b/scripts/utils/zowe-install-xmem.sh
@@ -23,16 +23,17 @@
 
 # Needs ./zowe-copy-to-JES.sh for PROCLIB
 
-while getopts "l:" opt; do
-  case $opt in
-    l) LOG_DIRECTORY=$OPTARG;;
-    \?)
-      echo "Invalid option: -$opt" >&2
-      exit 1
-      ;;
-  esac
-done
-shift $(($OPTIND-1))
+# zip #1157 - blocked by # zip #1156
+# while getopts "l:" opt; do
+#   case $opt in
+#     l) LOG_DIRECTORY=$OPTARG;;
+#     \?)
+#       echo "Invalid option: -$opt" >&2
+#       exit 1
+#       ;;
+#   esac
+# done
+# shift $(($OPTIND-1))
 
 script_exit(){
   echo exit $1 | tee -a ${LOG_FILE}
@@ -185,7 +186,7 @@ ZWEXASTC=ZWESASTC  # for ZWESAUX
 ZWEXMSTC=ZWESISTC  # for ZWESIS01
 
 # the extra parms ${loadlib} ${parmlib} are used to replace DSNs in PROCLIB members
-./zowe-copy-to-JES.sh $samplib $ZWEXASTC $proclib $ZWEXASTC  ${loadlib} ${parmlib} -l ${LOG_DIRECTORY}
-./zowe-copy-to-JES.sh $samplib $ZWEXMSTC $proclib $ZWEXMSTC  ${loadlib} ${parmlib} -l ${LOG_DIRECTORY}
+./zowe-copy-to-JES.sh $samplib $ZWEXASTC $proclib $ZWEXASTC  ${loadlib} ${parmlib} #-l ${LOG_DIRECTORY}
+./zowe-copy-to-JES.sh $samplib $ZWEXMSTC $proclib $ZWEXMSTC  ${loadlib} ${parmlib} #-l ${LOG_DIRECTORY}
 
 script_exit 0

--- a/smpe/bld/smpe-install.sh
+++ b/smpe/bld/smpe-install.sh
@@ -164,7 +164,7 @@ echo "-- installing product in $stage & $mvsI"
 opts=""
 opts="$opts -h $mvsI"                          # target HLQ
 opts="$opts -i $stage"                         # target directory
-opts="$opts -f $log/$logFile"                  # install log
+opts="$opts -l $log"                           # install log
 test $removeInstall -eq 1 && opts="$opts -R"   # remove input when done
 _cmd $extract/$prodScript $debug $opts </dev/null
 


### PR DESCRIPTION
### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [X] Feature

#### Relevant issues
Fixes #1154 

#### Changes proposed in this PR
- Update zowe-install and zowe-setup-certificates.sh scripts to add new -l parameter to overwrite the log directory

#### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

#### Does this PR do something the person installing Zowe should know about?
-l (lowercase L) option added to install scripts to allow installer to overwrite default log directory location

#### Is there a related doc issue or Pull Request? 

Doc issue/PR number: https://github.com/zowe/docs-site/issues/1054