### PR TITLE
move 2 hours earlier

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -51,7 +51,7 @@ node('ibm-jenkins-slave-nvm') {
 
   // we want to run daily on master branch
   if (isStagingBranch) {
-    pipeline.addBuildOption(pipelineTriggers([cron("TZ=America/New_York\nH 23 * * *")]))
+    pipeline.addBuildOption(pipelineTriggers([cron("TZ=America/New_York\nH 21 * * *")]))
   }
 
   pipeline.setup(


### PR DESCRIPTION
The nightly build had been failing for 3 days in a row. The failure is caused by network issue, at the stage of uploading raw contents to z/OS and packaging.

It looks not too bad during the day.

This PR moves the schedule 2 hours earlier and see if we can avoid the network failure.