### PR TITLE
Remove a plugin from default config

### DIFF
--- a/files/zlux/config/plugins/org.zowe.zlux.proxy.zosmf.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.proxy.zosmf.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "org.zowe.zlux.proxy.zosmf",
-  "pluginLocation": "../../zosmf-auth/proxy"
-}


### PR DESCRIPTION
Remove proxy from default as it requires configuration and is made redundant by apiml & apiml-auth.
Why do this? Because https://github.com/zowe/zlux/issues/398
It was missed that the zosmf-auth repo comprised 2 plugins: the auth and the proxy. The proxy was the one generating the "needs configuration" warning, so it should be removed but was missed.