### PR TITLE
move nightly build to 2am

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -51,7 +51,7 @@ node('ibm-jenkins-slave-nvm') {
 
   // we want to run daily on master branch
   if (isStagingBranch) {
-    pipeline.addBuildOption(pipelineTriggers([cron("TZ=America/New_York\nH 1 * * *")]))
+    pipeline.addBuildOption(pipelineTriggers([cron("TZ=America/New_York\nH 2 * * *")]))
   }
 
   pipeline.setup(


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

Try to avoid network failure for nightly build.