### PR TITLE
zip 1284 - Make dataset scripts listen to rc of called script

### DIFF
--- a/scripts/utils/zowe-install-proc.sh
+++ b/scripts/utils/zowe-install-proc.sh
@@ -83,6 +83,7 @@ do
 done
 
 ./zowe-copy-to-JES.sh -s ${samplib} -i ${input_member} -r ${proclib} -o ${output_member} -l ${LOG_DIRECTORY}
-echo "rc from zowe-copy-to-JES.sh is $?" >> ${LOG_FILE}
+rc=$?
+echo "rc from zowe-copy-to-JES.sh is ${rc}" >> ${LOG_FILE}
 
-script_exit 0
+script_exit ${rc}

--- a/scripts/utils/zowe-install-xmem.sh
+++ b/scripts/utils/zowe-install-xmem.sh
@@ -185,6 +185,14 @@ ZWEXMSTC=ZWESISTC  # for ZWESIS01
 
 # the extra parms ${loadlib} ${parmlib} are used to replace DSNs in PROCLIB members
 ./zowe-copy-to-JES.sh -s ${samplib} -i ${ZWEXASTC} -r ${proclib} -o ${ZWEXASTC} -b ${loadlib} -a ${parmlib} -l ${LOG_DIRECTORY}
+aux_rc=$?
+echo "ZWEXASTC rc from zowe-copy-to-JES.sh is ${aux_rc}" >> ${LOG_FILE}
 ./zowe-copy-to-JES.sh -s ${samplib} -i ${ZWEXMSTC} -r ${proclib} -o ${ZWEXMSTC} -b ${loadlib} -a ${parmlib} -l ${LOG_DIRECTORY}
+xmem_rc=$?
+echo "ZWEXMSTC rc from zowe-copy-to-JES.sh is ${xmem_rc}" >> ${LOG_FILE}
 
-script_exit 0
+if [[ ${xmem_rc} -ne 0 ]]
+then
+ script_exit ${xmem_rc}
+fi
+script_exit ${aux_rc}


### PR DESCRIPTION
Signed-off-by: stevenhorsman <steven@uk.ibm.com>

#### PR type
- [X] Bugfix 

#### Relevant issues
Fixes #1284 

#### Changes proposed in this PR
- update zowe-install-proc and zowe-install-xmem so that they reflect whether the internal call to copy-to-jes failed