### PR TITLE
Add sso auth plugin by default

### DIFF
--- a/files/zlux/config/allowedPlugins.json
+++ b/files/zlux/config/allowedPlugins.json
@@ -37,6 +37,10 @@
       "versions": ["*"]
     },
     {
+      "identifier": "org.zowe.zlux.auth.safsso",
+      "versions": ["*"]
+    },
+    {
       "identifier": "org.zowe.zlux.bootstrap",
       "versions": ["*"]
     },

--- a/files/zlux/config/plugins/org.zowe.zlux.auth.safsso.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.auth.safsso.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "org.zowe.zlux.auth.safsso",
+  "pluginLocation": "../../zlux-server-framework/plugins/sso-auth"
+}

--- a/files/zlux/config/plugins/org.zowe.zlux.auth.zss.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.auth.zss.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "org.zowe.zlux.auth.zss",
-  "pluginLocation": "../../zss-auth"
-}

--- a/files/zlux/config/zluxserver.json
+++ b/files/zlux/config/zluxserver.json
@@ -46,7 +46,7 @@
 
   "dataserviceAuthentication": {
     //this specifies the default authentication type for dataservices that didn't specify which type to use. These dataservices therefore should not expect a particular type of authentication to be used.
-    "defaultAuthentication": "zss",
+    "defaultAuthentication": "saf",
     //enable this to use role-based access control (RBAC) for Zowe dataservice endpoints
     "rbac": false,
     
@@ -60,9 +60,9 @@
       // "plugins": ["org.zowe.zlux.auth.zosmf"]
       //},
 
-      "zss": {
-        "plugins": ["org.zowe.zlux.auth.zss"]
-      } 
+      "saf": {
+        "plugins": ["org.zowe.zlux.auth.safsso"]
+      }
       
     }
   }


### PR DESCRIPTION
sso-auth plugin is a combination of apiml-auth and zss-auth, making them redundant. apiml also handles zosmf auth due to their sso integration. This PR also includes the changes from the last release, which was done in the rc branch and staging had not had those changes back-ported, where the zosmf auth & proxy were removed since apiml-auth had made them redundant. So, this is an auth plugin consolidation PR.