### PR TITLE
Trim list of auth plugins to just use zss, apiml(which includes zosmf)

### DIFF
--- a/files/zlux/config/plugins/org.zowe.zlux.auth.trivial.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.auth.trivial.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "org.zowe.zlux.auth.trivial",
-  "pluginLocation": "../../zlux-server-framework/plugins/trivial-auth"
-}

--- a/files/zlux/config/plugins/org.zowe.zlux.proxy.zosmf.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.proxy.zosmf.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "org.zowe.zlux.proxy.zosmf",
-  "pluginLocation": "../../zosmf-auth/proxy"
-}

--- a/files/zlux/config/plugins/org.zowe.zosmf.workflows.json
+++ b/files/zlux/config/plugins/org.zowe.zosmf.workflows.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "org.zowe.zosmf.workflows",
-  "pluginLocation": "../../zlux-workflow"
-}

--- a/files/zlux/config/zluxserver.json
+++ b/files/zlux/config/zluxserver.json
@@ -55,10 +55,10 @@
     "implementationDefaults": {
       //each type has an object which describes which implementation to use based on some criteria to find which is best for the task. For now, just "plugins" will
       //be used to state that you want a particular plugin.
-      "zosmf": {
+      //"zosmf": {
       // zosmf plugin needs to be configured to target a zosmf instance. configure before using.
       // "plugins": ["org.zowe.zlux.auth.zosmf"]
-      },
+      //},
 
       "zss": {
         "plugins": ["org.zowe.zlux.auth.zss"]


### PR DESCRIPTION
Part of this was done in rc branch for v1.10 but did not end up in staging.
Now in staging, the app server will load security plugins even if they are not found in server.json. They only need to be specified in the plugins folder in the same way apps are. So, I'm commenting out the zosmf object and changing the setting to not make zosmf plugin included by default, as it was not used by default in the past and recent changes may have unintentionally included it. This should fix it.