### PR TITLE
bump to v1.12.0. we can release hotfix from master if we need to

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -1,6 +1,6 @@
 {
   "name": "Zowe",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Zowe is an open source project created to host technologies that benefit the Z platform from all members of the Z community (Integrated Software Vendors, System Integrators and z/OS consumers). Zowe, like Mac or Windows, comes with a set of APIs and OS capabilities that applications build on and also includes some applications out of the box. Zowe offers modern interfaces to interact with z/OS and allows you to work with z/OS in a way that is similar to what you experience on cloud platforms today. You can use these interfaces as delivered or through plug-ins and extensions that are created by clients or third-party vendors.",
   "license": "EPL-2.0",
   "homepage": "https://zowe.org",


### PR DESCRIPTION
Prepare for v1.12.0 release on staging branch. We can release hotfix (v1.11.1 for example) from master if we need to.