### PR TITLE
Update default plugins to use ROOT_DIR relative path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Zowe Installer will be documented in this file.
 
 ## Recent Changes
 
+- Edit default plugin references to point to $ROOT_DIR env var
+
 2020-05-08 Timothy Gerstel <tgerstel@rocketsoftware.com>
 
   - Set up SSO in a standard install of Zowe via new environment variables set

--- a/files/zlux/config/plugins/org.zowe.configjs.json
+++ b/files/zlux/config/plugins/org.zowe.configjs.json
@@ -1,4 +1,5 @@
 {
   "identifier": "org.zowe.configjs",
-  "pluginLocation": "../../zlux-server-framework/plugins/config"
+  "pluginLocation": "components/app-server/share/zlux-server-framework/plugins/config",
+  "relativeTo": "$ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.editor.json
+++ b/files/zlux/config/plugins/org.zowe.editor.json
@@ -1,4 +1,5 @@
 {
   "identifier": "org.zowe.editor",
-  "pluginLocation": "../../zlux-editor"
+  "pluginLocation": "components/app-server/share/zlux-editor",
+  "relativeTo": "$ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.terminal.proxy.json
+++ b/files/zlux/config/plugins/org.zowe.terminal.proxy.json
@@ -1,4 +1,5 @@
 {
   "identifier": "org.zowe.terminal.proxy",
-  "pluginLocation": "../../zlux-server-framework/plugins/terminal-proxy"
+  "pluginLocation": "components/app-server/share/zlux-server-framework/plugins/terminal-proxy",
+  "relativeTo": "$ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.terminal.tn3270.json
+++ b/files/zlux/config/plugins/org.zowe.terminal.tn3270.json
@@ -1,4 +1,5 @@
 {
   "identifier": "org.zowe.terminal.tn3270",
-  "pluginLocation": "../../tn3270-ng2"
+  "pluginLocation": "components/app-server/share/tn3270-ng2",
+  "relativeTo": "$ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.terminal.vt.json
+++ b/files/zlux/config/plugins/org.zowe.terminal.vt.json
@@ -1,4 +1,5 @@
 {
   "identifier": "org.zowe.terminal.vt",
-  "pluginLocation": "../../vt-ng2"
+  "pluginLocation": "components/app-server/share/vt-ng2",
+  "relativeTo": "$ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.appmanager.app.propview.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.appmanager.app.propview.json
@@ -1,4 +1,5 @@
 {
   "identifier": "org.zowe.zlux.appmanager.app.propview",
-  "pluginLocation": "../../zlux-app-manager/system-apps/app-prop-viewer"
+  "pluginLocation": "components/app-server/share/zlux-app-manager/system-apps/app-prop-viewer",
+  "relativeTo": "$ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.auth.safsso.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.auth.safsso.json
@@ -1,4 +1,5 @@
 {
   "identifier": "org.zowe.zlux.auth.safsso",
-  "pluginLocation": "../../zlux-server-framework/plugins/sso-auth"
+  "pluginLocation": "components/app-server/share/zlux-server-framework/plugins/sso-auth",
+  "relativeTo": "$ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.bootstrap.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.bootstrap.json
@@ -1,4 +1,5 @@
 {
   "identifier": "org.zowe.zlux.bootstrap",
-  "pluginLocation": "../../zlux-app-manager/bootstrap"
+  "pluginLocation": "components/app-server/share/zlux-app-manager/bootstrap",
+  "relativeTo": "$ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.logger.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.logger.json
@@ -1,4 +1,5 @@
 {
   "identifier": "org.zowe.zlux.logger",
-  "pluginLocation": "../../zlux-shared/src/logging"
+  "pluginLocation": "components/app-server/share/zlux-shared/src/logging",
+  "relativeTo": "$ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.ng2desktop.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.ng2desktop.json
@@ -1,4 +1,5 @@
 {
   "identifier": "org.zowe.zlux.ng2desktop",
-  "pluginLocation": "../../zlux-app-manager/virtual-desktop"
+  "pluginLocation": "components/app-server/share/zlux-app-manager/virtual-desktop",
+  "relativeTo": "$ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.ng2desktop.settings.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.ng2desktop.settings.json
@@ -1,4 +1,5 @@
 {
   "identifier": "org.zowe.zlux.ng2desktop.settings",
-  "pluginLocation": "../../zlux-app-manager/system-apps/system-settings-preferences"
+  "pluginLocation": "components/app-server/share/zlux-app-manager/system-apps/system-settings-preferences",
+  "relativeTo": "$ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.sample.angular.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.sample.angular.json
@@ -1,4 +1,5 @@
 {
   "identifier": "org.zowe.zlux.sample.angular",
-  "pluginLocation": "../../sample-angular-app"
+  "pluginLocation": "components/app-server/share/sample-angular-app",
+  "relativeTo": "$ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.sample.iframe.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.sample.iframe.json
@@ -1,4 +1,5 @@
 {
   "identifier": "org.zowe.zlux.sample.iframe",
-  "pluginLocation": "../../sample-iframe-app"
+  "pluginLocation": "components/app-server/share/sample-iframe-app",
+  "relativeTo": "$ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.sample.react.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.sample.react.json
@@ -1,4 +1,5 @@
 {
   "identifier": "org.zowe.zlux.sample.react",
-  "pluginLocation": "../../sample-react-app"
+  "pluginLocation": "components/app-server/share/sample-react-app",
+  "relativeTo": "$ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zosmf.workflows.json
+++ b/files/zlux/config/plugins/org.zowe.zosmf.workflows.json
@@ -1,5 +1,6 @@
 {
   "identifier": "org.zowe.zosmf.workflows",
-  "pluginLocation": "../../zlux-workflow"
+  "pluginLocation": "components/app-server/share/zlux-workflow",
+  "relativeTo": "$ROOT_DIR"
 }
 

--- a/files/zlux/config/zluxserver.json
+++ b/files/zlux/config/zluxserver.json
@@ -12,7 +12,7 @@
       "server": {
         "hostname": "localhost",
         "port": 10011,
-        "isHttps": false
+        "isHttps": true
       },
       "enabled": false
     }
@@ -44,16 +44,10 @@
     //enable this to use role-based access control (RBAC) for Zowe dataservice endpoints
     "rbac": false,
     
-    //each authentication type may have more than one implementing plugin. define defaults and fallbacks below as well
-    //any types that have no implementers are ignored, and any implementations specified here that are not known to the server are also ignored.
+    //each authentication type may have more than one implementing plugin, but the specification below just describes the priority of them. Every one that is found in the pluginsDir is loaded.
     "implementationDefaults": {
       //each type has an object which describes which implementation to use based on some criteria to find which is best for the task. For now, just "plugins" will
       //be used to state that you want a particular plugin.
-      //"zosmf": {
-      // zosmf plugin needs to be configured to target a zosmf instance. configure before using.
-      // "plugins": ["org.zowe.zlux.auth.zosmf"]
-      //},
-
       "saf": {
         "plugins": ["org.zowe.zlux.auth.safsso"]
       }

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -52,8 +52,8 @@
       "artifact": "*.pax"
     },
     "org.zowe.zss": {
-      "version": "~1.12.0-STAGING",
-      "artifact": "*.pax"
+      "version": "1.12.0-PR-182",
+      "artifact": "zss-1.12.0-pr-182-1-20200513223409.pax"
     },
     "org.zowe.explorer.jobs": {
       "version": "~1.0.0-STAGING",

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -13,7 +13,7 @@
   "binaryDependencies": {
     "org.zowe.zlux.zlux-core": {
       "version": "1.12.0-212-S-123-S-S-S",
-      "artifact": "zlux-core-1.12.0-20200513.174750.pax"
+      "artifact": "zlux-core-1.12.0-20200513.191055.pax"
     },
     "org.zowe.zlux.zss-auth": {
       "version": "~1.12.0-STAGING",

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -12,47 +12,47 @@
   },
   "binaryDependencies": {
     "org.zowe.zlux.zlux-core": {
-      "version": "~1.11.0-STAGING",
-      "artifact": "*.pax"
+      "version": "1.12.0-212-S-123-S-S-S",
+      "artifact": "zlux-core-1.12.0-20200512.221326.pax"
     },
     "org.zowe.zlux.zss-auth": {
-      "version": "~1.11.0-STAGING",
+      "version": "~1.12.0-STAGING",
       "artifact": "*.pax"
     },
     "org.zowe.zlux.sample-angular-app": {
-      "version": "~1.11.0-STAGING",
+      "version": "~1.12.0-STAGING",
       "artifact": "*.pax"
     },
     "org.zowe.zlux.sample-iframe-app": {
-      "version": "~1.11.0-STAGING",
+      "version": "~1.12.0-STAGING",
       "artifact": "*.pax"
     },
     "org.zowe.zlux.sample-react-app": {
-      "version": "~1.11.0-STAGING",
+      "version": "~1.12.0-STAGING",
       "artifact": "*.pax"
     },
     "org.zowe.zlux.tn3270-ng2": {
-      "version": "~1.11.0-STAGING",
+      "version": "~1.12.0-STAGING",
       "artifact": "*.pax"
     },
     "org.zowe.zlux.vt-ng2": {
-      "version": "~1.11.0-STAGING",
+      "version": "~1.12.0-STAGING",
       "artifact": "*.pax"
     },
     "org.zowe.zlux.zlux-editor": {
-      "version": "~1.11.0-STAGING",
+      "version": "~1.12.0-STAGING",
       "artifact": "*.pax"
     },
     "org.zowe.zlux.zlux-workflow": {
-      "version": "~1.11.0-STAGING",
+      "version": "~1.12.0-STAGING",
       "artifact": "*.pax"
     },
     "org.zowe.zlux.zosmf-auth": {
-      "version": "~1.11.0-STAGING",
+      "version": "~1.12.0-STAGING",
       "artifact": "*.pax"
     },
     "org.zowe.zss": {
-      "version": "~1.11.0-STAGING",
+      "version": "~1.12.0-STAGING",
       "artifact": "*.pax"
     },
     "org.zowe.explorer.jobs": {

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -13,7 +13,7 @@
   "binaryDependencies": {
     "org.zowe.zlux.zlux-core": {
       "version": "1.12.0-212-S-123-S-S-S",
-      "artifact": "zlux-core-1.12.0-20200512.221326.pax"
+      "artifact": "zlux-core-1.12.0-20200513.174750.pax"
     },
     "org.zowe.zlux.zss-auth": {
       "version": "~1.12.0-STAGING",


### PR DESCRIPTION
Resolves https://github.com/zowe/zowe-install-packaging/issues/1245

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [x] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Relevant issues
Depends upon https://github.com/zowe/zlux-server-framework/pull/212

#### Changes proposed in this PR
Uses https://github.com/zowe/zlux-server-framework/pull/212 to ensure that the built-in plugins always point to the ROOT_DIR of your Zowe install, wherever that is. An update script is needed to perform this one-time switch, which is in https://github.com/zowe/zlux-app-server/pull/123

#### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No