### PR TITLE
Update default headers for x-frame-options

### DIFF
--- a/files/zlux/config/zluxserver.json
+++ b/files/zlux/config/zluxserver.json
@@ -15,6 +15,12 @@
         "isHttps": false
       },
       "enabled": false
+    },
+    "headers": {
+      "X-frame-Options": {
+        "override": true,
+        "value": "sameorigin"
+      }
     }
   },
   "agent": {


### PR DESCRIPTION
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [x] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Relevant issues
Identical purpose to https://github.com/zowe/zlux-app-server/pull/104 but applied to our release config, not our dev config.

#### Changes proposed in this PR
This changes the default app-server config to set the x-frame-options header to "sameorigin", preventing framing of apps at other domains, by default

#### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
This has been tested in dev config, so nothing new here except that it would be applied to release code.