### PR TITLE
not sure why off-synced, but this should be synced with `playbooks/ro…

### DIFF
--- a/playbooks/roles/configure/tasks/install_xmem_server.yml
+++ b/playbooks/roles/configure/tasks/install_xmem_server.yml
@@ -20,7 +20,7 @@
     dataset: "{{ zowe_xmem_parmlib }}"
 
 - name: Create {{ zowe_xmem_parmlib }}
-  raw: tsocmd "allocate da('{{ zowe_xmem_parmlib }}') dsntype(pds) dsorg(po) recfm(f,b) lrecl(80) blksize(23440) dir(64) space(10,2) tracks new"
+  raw: tsocmd "allocate da('{{ zowe_xmem_parmlib }}') dsntype(library) dsorg(po) recfm(f,b) lrecl(80) blksize(23440) dir(64) space(10,2) tracks new"
   when: not dataset_exists
 
 # ============================================================================


### PR DESCRIPTION
…les/configfmid/tasks/install_xmem_server.yml`

Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [x] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Relevant issues

Fixes https://github.com/zowe/zowe-install-packaging/issues/1379

#### Changes proposed in this PR

- The creation of `zowe_xmem_parmlib` defined in `playbooks/roles/configure/tasks/install_xmem_server.yml` should be synced with `playbooks/roles/configfmid/tasks/install_xmem_server.yml` because this is way how we want to prepare parmlib no matter for PTF or FMID.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Other information

This change won't take effect except for manually delete the parmlib on server. The automation won't delete parmlib during install test, but only delete members of parmlib. The creation of new parmlib only happens when it's completely deleted.