### PR TITLE
Add keyring utilities source dependency

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -335,6 +335,14 @@
       }]
     },
     {
+      "componentGroup": "Keyring Utilities",
+      "entries": [{
+        "repository": "keyring-utilities",
+        "tag": "v1.0.3",
+        "destinations": ["Zowe PAX"]
+      }]
+    },
+    {
       "componentGroup": "Zowe Visual Studio Code Extension",
       "entries": [{
         "repository": "vscode-extension-for-zowe",

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -338,7 +338,7 @@
       "componentGroup": "Keyring Utilities",
       "entries": [{
         "repository": "keyring-utilities",
-        "tag": "v1.0.3",
+        "tag": "master",
         "destinations": ["Zowe PAX"]
       }]
     },


### PR DESCRIPTION
I'm been informed that a bunch of our components are pulling in the keyring-utilites repo, so I figured they are supposed to be in the source scans