### PR TITLE
XMEM serve must use SZWEAUTH

### DIFF
--- a/scripts/utils/zowe-copy-to-JES.sh
+++ b/scripts/utils/zowe-copy-to-JES.sh
@@ -137,14 +137,18 @@ then
   script_exit 6
 fi
 
-echo Check name of ${input_member} PROC | tee -a ${LOG_FILE}
-cat "//'$samplib(${input_member})'" | grep -i "^//${input_member} *PROC" 1>> $LOG_FILE 2>> $LOG_FILE
-if [[ $? -ne 0 ]]
-then
-  echo Did not find PROC name \"${input_member}\" in "$samplib(${input_member})" | tee -a ${LOG_FILE}
-  echo PROC statement is : | tee -a ${LOG_FILE}
-  cat "//'$samplib(${input_member})'" | grep "^//[^ *][^ ]*  *PROC" | tee -a ${LOG_FILE}
-fi
+# https://github.com/zowe/zowe-install-packaging/issues/1550
+# Comment out this test for now, and revisit later.
+# Intend is the ensure we have the correct codepage.
+# TODO Move to build pipeline and test for // as first chars of first line.
+#echo Check name of ${input_member} PROC | tee -a ${LOG_FILE}
+#cat "//'$samplib(${input_member})'" | grep -i "^//${input_member} *PROC" 1>> $LOG_FILE 2>> $LOG_FILE
+#if [[ $? -ne 0 ]]
+#then
+#  echo Did not find PROC name \"${input_member}\" in "$samplib(${input_member})" | tee -a ${LOG_FILE}
+#  echo PROC statement is : | tee -a ${LOG_FILE}
+#  cat "//'$samplib(${input_member})'" | grep "^//[^ *][^ ]*  *PROC" | tee -a ${LOG_FILE}
+#fi
 
 if [[ $# -eq 4 ]]
 then

--- a/scripts/utils/zowe-install-xmem.sh
+++ b/scripts/utils/zowe-install-xmem.sh
@@ -7,7 +7,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-# Copyright Contributors to the Zowe Project. 2019, 2020
+# Copyright IBM Corporation 2019, 2020
 #######################################################################
 
 # Function: Copy cross-memory server artefacts to the required locations

--- a/scripts/utils/zowe-install-xmem.sh
+++ b/scripts/utils/zowe-install-xmem.sh
@@ -72,14 +72,16 @@ USER=${LOGNAME:-{userid}}
 echo Parameters supplied were $@ >> ${LOG_FILE}
 echo "Some required parameters were not supplied:${missing_parms}"
 cat <<EndOfUsage
+
 Usage  $SCRIPT -d <dataSetPrefix> [-a <parmlib>] [-r <proclib>]
+
 -d  Data set prefix of source library SZWESAMP, e.g. ${USER}.ZWE.
--a  DSN of target PARMLIB where the configuration will be placed, e.g.
-    ${USER}.ZWE.CUST.PARMLIB. If ommited then the sample 
-    ${dataSetPrefix}.SZWESAMP(ZWESIP00) will be used.
--r  DSN of target PROCLIB where started task JCL will be placed, e.g.
-    USER.PROCLIB. If ommited then the PROCLIB will be selected from the
-    active JES PROCLIB concatenation.
+-a  (optional) DSN of target PARMLIB where the configuration will be 
+    placed, e.g. ${USER}.ZWE.CUST.PARMLIB. If ommited then the sample 
+    {dataSetPrefix}.SZWESAMP(ZWESIP00) will be used.
+-r  (optional) DSN of target PROCLIB where started task JCL will be 
+    placed, e.g. USER.PROCLIB. If ommited then the PROCLIB will be 
+    selected from the active JES PROCLIB concatenation.
 EndOfUsage
 script_exit 1
 fi

--- a/scripts/utils/zowe-install-xmem.sh
+++ b/scripts/utils/zowe-install-xmem.sh
@@ -75,7 +75,7 @@ echo Parameters supplied were $@ >> ${LOG_FILE}
 echo "Some required parameters were not supplied:${missing_parms}"
 cat <<EndOfUsage
 
-Usage  $SCRIPT -d <dataSetPrefix> [-a <parmlib>] [-r <proclib>]
+Usage  $SCRIPT -d <hlq> [-a <parmlib>] [-r <proclib>] [-l <logDir>]
 
 -d  Data set prefix of source library SZWESAMP, e.g. ${USER}.ZWE.
 -a  (optional) DSN of an existing target PARMLIB where the configuration 
@@ -84,6 +84,9 @@ Usage  $SCRIPT -d <dataSetPrefix> [-a <parmlib>] [-r <proclib>]
 -r  (optional) DSN of an existing target PROCLIB where started task JCL 
     will be placed, e.g. USER.PROCLIB. If ommited then the PROCLIB will 
     be selected from the active JES PROCLIB concatenation.
+-l  (optional) Directory where to place the log file. If ommited then
+    the log file will be placed in /global/zowe/logs. If it is not 
+    writeable then ~/zowe/logs is used as directory.
 EndOfUsage
 script_exit 1
 fi

--- a/scripts/utils/zowe-install-xmem.sh
+++ b/scripts/utils/zowe-install-xmem.sh
@@ -46,6 +46,7 @@ fi
 
 # identify this script
 SCRIPT="$(basename $0)"
+here=$(cd $(dirname $0);pwd)   # script location
 
 . ${ZOWE_ROOT_DIR}/bin/utils/setup-log-dir.sh
 set_install_log_directory ${LOG_DIRECTORY}
@@ -77,8 +78,8 @@ Usage  $SCRIPT -d <dataSetPrefix> [-a <parmlib>] [-r <proclib>]
 
 -d  Data set prefix of source library SZWESAMP, e.g. ${USER}.ZWE.
 -a  (optional) DSN of an existing target PARMLIB where the configuration 
-    will be placed, e.g. ${USER}.ZWE.CUST.PARMLIB. If ommited then the 
-    sample {dataSetPrefix}.SZWESAMP(ZWESIP00) will be used.
+    file will be placed, e.g. ${USER}.ZWE.CUST.PARMLIB. If ommited 
+    then the sample {dataSetPrefix}.SZWESAMP(ZWESIP00) will be used.
 -r  (optional) DSN of an existing target PROCLIB where started task JCL 
     will be placed, e.g. USER.PROCLIB. If ommited then the PROCLIB will 
     be selected from the active JES PROCLIB concatenation.
@@ -161,10 +162,24 @@ ZWEXASTC=ZWESASTC  # for ZWESAUX
 ZWEXMSTC=ZWESISTC  # for ZWESIS01
 
 # the extra parms ${authlib} ${parmlib} are used to replace DSNs in PROCLIB members
-./zowe-copy-to-JES.sh -s ${samplib} -i ${ZWEXASTC} -r ${proclib} -o ${ZWEXASTC} -b ${authlib} -a ${parmlib} -f ${LOG_FILE}
+$here/zowe-copy-to-JES.sh \
+  -s ${samplib} \
+  -i ${ZWEXASTC} \
+  -r ${proclib} \
+  -o ${ZWEXASTC} \
+  -b ${authlib} \
+  -a ${parmlib} \
+  -f ${LOG_FILE}
 aux_rc=$?
 echo "ZWEXASTC rc from zowe-copy-to-JES.sh is ${aux_rc}" >> ${LOG_FILE}
-./zowe-copy-to-JES.sh -s ${samplib} -i ${ZWEXMSTC} -r ${proclib} -o ${ZWEXMSTC} -b ${authlib} -a ${parmlib} -f ${LOG_FILE}
+$here/zowe-copy-to-JES.sh \
+  -s ${samplib} \
+  -i ${ZWEXMSTC} \
+  -r ${proclib} \
+  -o ${ZWEXMSTC} \
+  -b ${authlib} \
+  -a ${parmlib} \
+  -f ${LOG_FILE}
 xmem_rc=$?
 echo "ZWEXMSTC rc from zowe-copy-to-JES.sh is ${xmem_rc}" >> ${LOG_FILE}
 

--- a/scripts/utils/zowe-install-xmem.sh
+++ b/scripts/utils/zowe-install-xmem.sh
@@ -76,12 +76,12 @@ cat <<EndOfUsage
 Usage  $SCRIPT -d <dataSetPrefix> [-a <parmlib>] [-r <proclib>]
 
 -d  Data set prefix of source library SZWESAMP, e.g. ${USER}.ZWE.
--a  (optional) DSN of target PARMLIB where the configuration will be 
-    placed, e.g. ${USER}.ZWE.CUST.PARMLIB. If ommited then the sample 
-    {dataSetPrefix}.SZWESAMP(ZWESIP00) will be used.
--r  (optional) DSN of target PROCLIB where started task JCL will be 
-    placed, e.g. USER.PROCLIB. If ommited then the PROCLIB will be 
-    selected from the active JES PROCLIB concatenation.
+-a  (optional) DSN of an existing target PARMLIB where the configuration 
+    will be placed, e.g. ${USER}.ZWE.CUST.PARMLIB. If ommited then the 
+    sample {dataSetPrefix}.SZWESAMP(ZWESIP00) will be used.
+-r  (optional) DSN of an existing target PROCLIB where started task JCL 
+    will be placed, e.g. USER.PROCLIB. If ommited then the PROCLIB will 
+    be selected from the active JES PROCLIB concatenation.
 EndOfUsage
 script_exit 1
 fi

--- a/scripts/utils/zowe-install-xmem.sh
+++ b/scripts/utils/zowe-install-xmem.sh
@@ -68,17 +68,18 @@ fi
 
 if [[ -n ${missing_parms} ]]
 then
+USER=${LOGNAME:-{userid}}
 echo Parameters supplied were $@ >> ${LOG_FILE}
 echo "Some required parameters were not supplied:${missing_parms}"
 cat <<EndOfUsage
-Usage  $SCRIPT -d <dataSetPrefix> -a <parmlib> [-r <proclib>]
-Opt flag    Parm name     Value e.g.              Meaning
---------    ---------     ----------              -------
-   -d       dataSetPrefix {userid}.ZWE            Data set prefix of source library .SZWESAMP where members ZWESASTC, ZWESIP00 and ZWESISTC are located.
-   -a       parmlib       {hlq}.ZIS.PARMLIB       DSN of target PARMLIB where member ZWESIP00 will be placed.
-                          (ommited)               ${dataSetPrefix}.SZWESAMP(ZWESIP00) will be used.
-   -r       proclib       USER.PROCLIB            DSN of target PROCLIB where members ZWESASTC and ZWESISTC will be placed.
-                          (omitted)               PROCLIB will be selected from JES PROCLIB concatenation.
+Usage  $SCRIPT -d <dataSetPrefix> [-a <parmlib>] [-r <proclib>]
+-d  Data set prefix of source library SZWESAMP, e.g. ${USER}.ZWE.
+-a  DSN of target PARMLIB where the configuration will be placed, e.g.
+    ${USER}.ZWE.CUST.PARMLIB. If ommited then the sample 
+    ${dataSetPrefix}.SZWESAMP(ZWESIP00) will be used.
+-r  DSN of target PROCLIB where started task JCL will be placed, e.g.
+    USER.PROCLIB. If ommited then the PROCLIB will be selected from the
+    active JES PROCLIB concatenation.
 EndOfUsage
 script_exit 1
 fi

--- a/scripts/utils/zowe-install-xmem.sh
+++ b/scripts/utils/zowe-install-xmem.sh
@@ -1,32 +1,27 @@
 #!/bin/sh
-################################################################################
-# This program and the accompanying materials are made available under the terms of the
-# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+#######################################################################
+# This program and the accompanying materials are made available
+# under the terms of the Eclipse Public License v2.0 which
+# accompanies this distribution, and is available at
 # https://www.eclipse.org/legal/epl-v20.html
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-# Copyright IBM Corporation 2019, 2020
-################################################################################
+# Copyright Contributors to the Zowe Project. 2019, 2020
+#######################################################################
 
 # Function: Copy cross-memory server artefacts to the required locations
-# ZWE.SZWEAUTH:
-#
-#     ZWESAUX   --> LOADLIB
-#     ZWESIS01  --> LOADLIB
-#
 # ZWE.SZWESAMP:
 #
 #     ZWESASTC  --> PROCLIB
-#     ZWESIP00  --> PARMLIB
+#     ZWESIP00  --> PARMLIB (optional)
 #     ZWESISTC  --> PROCLIB
 
 # Needs ./zowe-copy-to-JES.sh for PROCLIB
 
-while getopts "a:b:d:l:r:" opt; do
+while getopts "a:d:l:r:" opt; do
   case $opt in
     a) parmlib=$OPTARG;;
-    b) loadlib=$OPTARG;;
     d) data_set_prefix=$OPTARG;;
     l) LOG_DIRECTORY=$OPTARG;;
     r) proclib=$OPTARG;;
@@ -66,56 +61,53 @@ if [[ -z ${data_set_prefix} ]]
 then
   missing_parms=${missing_parms}" -d"
 fi
-if [[ -z ${loadlib} ]]
-then
-  missing_parms=${missing_parms}" -b"
-fi
-if [[ -z ${parmlib} ]]
-then
-  missing_parms=${missing_parms}" -a"
-fi
+#if [[ -z ${parmlib} ]]  # default is SZWESAMP
+#then
+#  missing_parms=${missing_parms}" -a"
+#fi
 
 if [[ -n ${missing_parms} ]]
 then
 echo Parameters supplied were $@ >> ${LOG_FILE}
 echo "Some required parameters were not supplied:${missing_parms}"
 cat <<EndOfUsage
-Usage  $SCRIPT -d <dataSetPrefix> -b <loadlib> -a <parmlib> [-r <proclib>]
+Usage  $SCRIPT -d <dataSetPrefix> -a <parmlib> [-r <proclib>]
 Opt flag    Parm name     Value e.g.              Meaning
 --------    ---------     ----------              -------
-   -d       dataSetPrefix {userid}.ZWE            Data set prefix of source library .SZWEAUTH where members ZWESIS01,ZWESAUX are located
-                                                    and of source library .SZWESAMP where members ZWESASTC, ZWESIP00 and ZWESISTC are located.
-   -b       loadlib       {hlq}.ZIS.SZISLOAD      DSN of target LOADLIB where members ZWESIS01,ZWESAUX will be placed. 
-                            
-   -a       parmlib       {hlq}.ZIS.PARMLIB       DSN of target PARMLIB where member ZWESIP00 will be placed. 
-          
-   -r       proclib       USER.PROCLIB            DSN of target PROCLIB where members ZWESASTC and ZWESISTC will be placed. 
+   -d       dataSetPrefix {userid}.ZWE            Data set prefix of source library .SZWESAMP where members ZWESASTC, ZWESIP00 and ZWESISTC are located.
+   -a       parmlib       {hlq}.ZIS.PARMLIB       DSN of target PARMLIB where member ZWESIP00 will be placed.
+                          (ommited)               ${dataSetPrefix}.SZWESAMP(ZWESIP00) will be used.
+   -r       proclib       USER.PROCLIB            DSN of target PROCLIB where members ZWESASTC and ZWESISTC will be placed.
                           (omitted)               PROCLIB will be selected from JES PROCLIB concatenation.
 EndOfUsage
 script_exit 1
 fi
 
 authlib=`echo ${data_set_prefix}.SZWEAUTH | tr '[:lower:]' '[:upper:]'`
-loadlib=`echo ${loadlib} | tr '[:lower:]' '[:upper:]'`
 samplib=`echo ${data_set_prefix}.SZWESAMP | tr '[:lower:]' '[:upper:]'`
-parmlib=`echo ${parmlib} | tr '[:lower:]' '[:upper:]'`
- 
+
+if [[ -z ${parmlib} ]]
+then
+  parmlib=$samplib
+else
+  parmlib=`echo ${parmlib} | tr '[:lower:]' '[:upper:]'`
+fi
+
 if [[ -z ${proclib} ]]
 then
   proclib=auto
 else
   proclib=`echo ${proclib} | tr '[:lower:]' '[:upper:]'`
-fi 
+fi
 
 echo    "authlib =" $authlib >> $LOG_FILE
-echo    "loadlib =" $loadlib >> $LOG_FILE
 echo    "samplib =" $samplib >> $LOG_FILE
 echo    "parmlib =" $parmlib >> $LOG_FILE
 echo    "proclib =" $proclib >> $LOG_FILE
 
-for dsname in $authlib $loadlib $samplib $parmlib $proclib
+for dsname in $authlib $samplib $parmlib $proclib
 do
-  if [[ $proclib = auto ]] 
+  if [[ $proclib = auto ]]
   then
     continue  # do not check DSN=auto
   fi
@@ -134,32 +126,7 @@ do
   fi
 done
 
-# AUTHLIB  - - - - - - - - - - - - - - - - 
-ZWESAUX=ZWESAUX
-ZWESIS01=ZWESIS01
-
-for loadmodule in $ZWESAUX $ZWESIS01
-do 
-
-  tsocmd listds "'$authlib' members" 2>> $LOG_FILE | grep "  $loadmodule$" 1>> $LOG_FILE 2>> $LOG_FILE
-  if [[ $? -ne 0 ]]
-  then
-    echo $loadmodule not found in \"$authlib\" | tee -a ${LOG_FILE}
-    script_exit 5
-  fi
-
-  echo "Copying load module ${loadmodule}" | tee -a ${LOG_FILE}
-  if cp -X "//'${authlib}(${loadmodule})'"  "//'${loadlib}(${loadmodule})'" 
-  then
-    echo "Info:  module ${loadmodule} has been successfully copied to dataset ${loadlib}" | tee -a ${LOG_FILE}
-    rc=0
-  else
-    echo "Error:  module ${loadmodule} has not been copied to dataset ${loadlib}" | tee -a ${LOG_FILE}
-    script_exit 6
-  fi
-done
-
-# PARMLIB  - - - - - - - - - - - - - - - - 
+# PARMLIB  - - - - - - - - - - - - - - - -
 # parmlib       {hlq}.ZIS.PARMLIB       DSN of target PARMLIB where member ZWEXMP00 goes
 # The suffix (last 2 digits) can be adjusted in the STC JCL, but the prefix must be ZWESIP
 ZWEXMP00=ZWESIP00  # for ZWESIS01
@@ -170,26 +137,31 @@ ZWEXMP00=ZWESIP00  # for ZWESIS01
     script_exit 7
   fi
 
-  echo "Copying SAMPLIB member ${ZWEXMP00}" | tee -a ${LOG_FILE}
-  if cp "//'${samplib}(${ZWEXMP00})'"  "//'${parmlib}(${ZWEXMP00})'" 
+  if [[ $samplib = $parmlib ]]
   then
-    echo "Info:  member ${ZWEXMP00} has been successfully copied to dataset ${parmlib}" | tee -a ${LOG_FILE}
-    # rc=0
+    echo "Using SAMPLIB member ${samplib}(${ZWEXMP00})" | tee -a ${LOG_FILE}
   else
-    echo "Error:  member ${ZWEXMP00} has not been copied to dataset ${parmlib}" | tee -a ${LOG_FILE}
-    echo "Check if PARMLIB dataset ${parmlib} is in use by xmem server or another job or user" | tee -a ${LOG_FILE}
-    script_exit 8
+    echo "Copying SAMPLIB member ${ZWEXMP00}" | tee -a ${LOG_FILE}
+    if cp "//'${samplib}(${ZWEXMP00})'"  "//'${parmlib}(${ZWEXMP00})'"
+    then
+      echo "Info:  member ${ZWEXMP00} has been successfully copied to dataset ${parmlib}" | tee -a ${LOG_FILE}
+      # rc=0
+    else
+      echo "Error:  member ${ZWEXMP00} has not been copied to dataset ${parmlib}" | tee -a ${LOG_FILE}
+      echo "Check if PARMLIB dataset ${parmlib} is in use by xmem server or another job or user" | tee -a ${LOG_FILE}
+      script_exit 8
+    fi
   fi
 
-# PROCLIB  - - - - - - - - - - - - - - - - 
+# PROCLIB  - - - - - - - - - - - - - - - -
 ZWEXASTC=ZWESASTC  # for ZWESAUX
 ZWEXMSTC=ZWESISTC  # for ZWESIS01
 
-# the extra parms ${loadlib} ${parmlib} are used to replace DSNs in PROCLIB members
-./zowe-copy-to-JES.sh -s ${samplib} -i ${ZWEXASTC} -r ${proclib} -o ${ZWEXASTC} -b ${loadlib} -a ${parmlib} -f ${LOG_FILE}
+# the extra parms ${authlib} ${parmlib} are used to replace DSNs in PROCLIB members
+./zowe-copy-to-JES.sh -s ${samplib} -i ${ZWEXASTC} -r ${proclib} -o ${ZWEXASTC} -b ${authlib} -a ${parmlib} -f ${LOG_FILE}
 aux_rc=$?
 echo "ZWEXASTC rc from zowe-copy-to-JES.sh is ${aux_rc}" >> ${LOG_FILE}
-./zowe-copy-to-JES.sh -s ${samplib} -i ${ZWEXMSTC} -r ${proclib} -o ${ZWEXMSTC} -b ${loadlib} -a ${parmlib} -f ${LOG_FILE}
+./zowe-copy-to-JES.sh -s ${samplib} -i ${ZWEXMSTC} -r ${proclib} -o ${ZWEXMSTC} -b ${authlib} -a ${parmlib} -f ${LOG_FILE}
 xmem_rc=$?
 echo "ZWEXMSTC rc from zowe-copy-to-JES.sh is ${xmem_rc}" >> ${LOG_FILE}
 

--- a/scripts/utils/zowe-install-xmem.sh
+++ b/scripts/utils/zowe-install-xmem.sh
@@ -46,7 +46,8 @@ fi
 
 # identify this script
 SCRIPT="$(basename $0)"
-here=$(cd $(dirname $0);pwd)   # script location
+# sub-scripts expect the current directory matches their location
+cd ${ZOWE_ROOT_DIR}/scripts/utils   
 
 . ${ZOWE_ROOT_DIR}/bin/utils/setup-log-dir.sh
 set_install_log_directory ${LOG_DIRECTORY}
@@ -162,7 +163,7 @@ ZWEXASTC=ZWESASTC  # for ZWESAUX
 ZWEXMSTC=ZWESISTC  # for ZWESIS01
 
 # the extra parms ${authlib} ${parmlib} are used to replace DSNs in PROCLIB members
-$here/zowe-copy-to-JES.sh \
+./zowe-copy-to-JES.sh \
   -s ${samplib} \
   -i ${ZWEXASTC} \
   -r ${proclib} \
@@ -172,7 +173,7 @@ $here/zowe-copy-to-JES.sh \
   -f ${LOG_FILE}
 aux_rc=$?
 echo "ZWEXASTC rc from zowe-copy-to-JES.sh is ${aux_rc}" >> ${LOG_FILE}
-$here/zowe-copy-to-JES.sh \
+./zowe-copy-to-JES.sh \
   -s ${samplib} \
   -i ${ZWEXMSTC} \
   -r ${proclib} \


### PR DESCRIPTION
<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [x] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Relevant issues
<!-- Link to a relevant GitHub issue if any. If this PR applies to multiple issues, preface each issue reference with the "Fixes" keyword. For example, Fixes #123, Fixes #456. -->

Fixes #1547, Fixes #1550 

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
1547
- stop copying SZWEAUTH and use the real thing
- make PARMLIB optional (SZWESAMP is default)
- do not assume script is called from within scripts/utils
1550
- comment out PROC test

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path below.-->

#### Does this PR do something the person installing Zowe should know about?

<!-- Is this a fix or a feature that changes customizable files (e.g. configuration files, sample JCL, etc),
product requirements, or other installation or configuration related area? If so, please fill out the template below. 
There is no need to report the need to restart the servers to activate the change. Note that the provided text will be formatted in 64-character lines, and that round brackets, ( and ), must always be used in matching pairs. -->

---
* Affected function: _general area of interest_ *
STC JCL
---
* Description: _1 line description_ *
update data set names in STC 
---
* Part: _name of customizable file involved_  *
SZWESAMP(ZWESASTC, ZWESISTC)

---
Before Zowe 1.14, the zowe-install-xmem.sh setup script copied
the SZWEAUTH load library and created started task JCLs
ZWESASTC and ZWESISTC that reference this copy. The related
configuration documentation instructed you to APF authorize this
copied data set.
From Zowe 1.14 on, the ZWESASTC and ZWESISTC started tasks are
expected to use load library SZWEAUTH itself, not a (possibly 
outdated) copy.

Update your active ZWESASTC and ZWESISTC PROCLIB members to use
//STEPLIB  DD DISP=SHR,DSN={zowe_hlq}.SZWEAUTH.
Also update your active PARMLIB(PROGxx) member to make 
{zowe_hlq}.SZWEAUTH APF authorized.
APF ADD DSN={zowe_hlq}.SZWEAUTH  SMS
You can dynamically mark the SZWEAUTH libary as APF authorized 
(until next IPL) using an operator command
SETPROG APF ADD,DSN={zowe_hlq}.SZWEAUTH,SMS


#### Is there a related doc issue or Pull Request? 
<!-- Link to a relevant documentation issue or Pull Request if any. -->

Doc issue/PR number: 
https://github.com/zowe/docs-site/issues/1328

#### Other information

