### PR TITLE
Put ZSS in an independent launch group (backward-compatible)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
 
+## `1.16.0`
+
+### New features and enhancements
+- ZSS can now be started completely independent from the Application Framework server by specifying the LAUNCH_COMPONENT_GROUP "ZSS". If not specified but DESKTOP is, zss will still be included as a prereq to app-server.
+
 ## `1.14.0`
 
 ### New features and enhancements

--- a/bin/internal/run-zowe.sh
+++ b/bin/internal/run-zowe.sh
@@ -97,10 +97,27 @@ then
   LAUNCH_COMPONENTS=api-mediation,files-api,jobs-api,explorer-jes,explorer-mvs,explorer-uss #TODO this is WIP - component ids not finalised at the moment
 fi
 
+if [ `uname` = "OS/390" ]; then
+  if [[ $LAUNCH_COMPONENT_GROUPS == *"ZSS"* ]]
+  then
+    LAUNCH_COMPONENTS=zss,${LAUNCH_COMPONENTS} #zss should run before app-server to reduce the polling period when app-server tries to find it.
+  fi
+fi
+
 #Explorers may be present, but have a prereq on gateway, not desktop
 if [[ $LAUNCH_COMPONENT_GROUPS == *"DESKTOP"* ]]
 then
-  LAUNCH_COMPONENTS=zss,app-server,${LAUNCH_COMPONENTS} #Make app-server the first component, so any extender plugins can use its config
+  #In each below, put app-server before other components, so any extender plugins can use its config
+  if [ `uname` = "OS/390" ]; then
+    if [[ $LAUNCH_COMPONENTS == *"zss"* ]]
+    then
+      LAUNCH_COMPONENTS=app-server,${LAUNCH_COMPONENTS}
+    else
+      LAUNCH_COMPONENTS=zss,app-server,${LAUNCH_COMPONENTS}
+    fi
+  else
+    LAUNCH_COMPONENTS=app-server,${LAUNCH_COMPONENTS}
+  fi
   PLUGINS_DIR=${WORKSPACE_DIR}/app-server/plugins
 fi
 


### PR DESCRIPTION
This allows for ZSS to be started without the desktop by specifying LAUNCH_COMPONENT_GROUPS=ZSS
The default of `LAUNCH_COMPONENT_GROUPS=DESKTOP,GATEWAY` will still work, as ZSS is added if DESKTOP is requested and ZSS is not seen in the list.

Why do this? Primarily due to Docker, we want to make it easy to turn on just ZSS in that case.

How to test? If ZSS started twice, there would be 2 zssServer log files in the logs folder. It should only start once even if requested by both GROUP ZSS & DESKTOP.


- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 

- [x] Feature <!-- non-breaking change which adds functionality -->


#### Changes proposed in this PR
The relationship between ZSS and app-server were not fully exposed previously. In order to use ZSS, you had to also have app-server running. But, this is not really how it works. I'm moving ZSS into its own component group so that it can be started independently, but only if people specify that. If they dont, and just continue to specify DESKTOP, then zss should still load as a prereq to app-server. Additionally, zss is not present on Docker, so I do not put it into the list if this script is not running on z/os.

#### Does this PR introduce a breaking change?

- [x] No

The documentation should be amended to explain this option to have ZSS without app-server, although I don't think it will be necessary for most all-zos installs, it will be useful for docker users.