### PR TITLE
Add UNSTABLE result to Nightly build

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -132,7 +132,7 @@ node('ibm-jenkins-slave-nvm') {
       if (!sourceSmpeBuildInfo || !sourceSmpeBuildInfo['path']) {
         echo "Building new driver ..."
 
-        // run build
+        /* run build
         def build_result = build(
           job: '/zowe-install-packaging/staging',
           parameters: [
@@ -143,7 +143,7 @@ node('ibm-jenkins-slave-nvm') {
         echo "Build result: ${build_result.result}"
         if (build_result.result != 'SUCCESS') {
           error "Failed to build a new Zowe driver, check failure details at ${build_result.absoluteUrl}"
-        }
+        }*/
 
         // load build info
         sourceSmpeBuildInfo = pipeline.artifactory.getArtifact([
@@ -196,7 +196,7 @@ node('ibm-jenkins-slave-nvm') {
         def testParameters = [
           booleanParam(name: 'STARTED_BY_AUTOMATION', value: true),
           string(name: 'TEST_SCOPE', value: 'bundle: convenience build on multiple security systems'),
-          string(name: 'ZOWE_ARTIFACTORY_PATTERN', value: sourceRegBuildInfo.path),
+          string(name: 'ZOWE_ARTIFACTORY_PATTERN', value: sourceSmpeBuildInfo.path),
           string(name: 'ZOWE_ARTIFACTORY_BUILD', value: ''),
           string(name: 'INSTALL_TEST_DEBUG_INFORMATION', value: 'zowe-install-test:*'),
           string(name: 'SANITY_TEST_DEBUG_INFORMATION', value: 'zowe-sanity-test:*'),
@@ -222,6 +222,7 @@ node('ibm-jenkins-slave-nvm') {
         if (test_result.result != 'SUCCESS') {
           testRegBuildErrorUrl = test_result.absoluteUrl
           echo "Test failed on regular build ${sourceRegBuildInfo.path}, check failure details at ${test_result.absoluteUrl}"
+          currentBuild.result == 'UNSTABLE'
         }
       }
     },
@@ -279,6 +280,7 @@ node('ibm-jenkins-slave-nvm') {
         if (test_result.result != 'SUCCESS') {
           testSmpeBuildErrorUrl = test_result.absoluteUrl
           echo "Test failed on SMP/e build ${sourceSmpeBuildInfo.path}, check failure details at ${test_result.absoluteUrl}"
+          currentBuild.result == 'UNSTABLE'
         }
       }
     },

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -195,8 +195,8 @@ node('ibm-jenkins-slave-nvm') {
       } else {
         def testParameters = [
           booleanParam(name: 'STARTED_BY_AUTOMATION', value: true),
-          string(name: 'TEST_SCOPE', value: 'bundle: convenience build on multiple security systems'),
-          string(name: 'ZOWE_ARTIFACTORY_PATTERN', value: sourceSmpeBuildInfo.path),
+          string(name: 'TEST_SCOPE', value: 'bundle: convenience build on multiple 5ecurity systems'),
+          string(name: 'ZOWE_ARTIFACTORY_PATTERN', value: sourceRegBuildInfo.path),
           string(name: 'ZOWE_ARTIFACTORY_BUILD', value: ''),
           string(name: 'INSTALL_TEST_DEBUG_INFORMATION', value: 'zowe-install-test:*'),
           string(name: 'SANITY_TEST_DEBUG_INFORMATION', value: 'zowe-sanity-test:*'),
@@ -214,7 +214,7 @@ node('ibm-jenkins-slave-nvm') {
         //   testParameters.add(string(name: 'ZOWE_CLI_ARTIFACTORY_BUILD', value: ''))
         // }
         def test_result = build(
-            job: '/zowe-install-test/staging',
+            job: '/zowe-install-test/users/roavill2/add-fail-nightly',
             parameters: testParameters,
             propagate: false
           )
@@ -253,7 +253,7 @@ node('ibm-jenkins-slave-nvm') {
       } else {
         def testParameters = [
           booleanParam(name: 'STARTED_BY_AUTOMATION', value: true),
-          string(name: 'TEST_SCOPE', value: 'bundle: smpe ptf on multiple security systems'),
+          string(name: 'TEST_SCOPE', value: 'bundle: smpe ptf on multiple 5ecurity systems'),
           string(name: 'ZOWE_ARTIFACTORY_PATTERN', value: sourceSmpeBuildInfo.path),
           string(name: 'ZOWE_ARTIFACTORY_BUILD', value: ''),
           string(name: 'INSTALL_TEST_DEBUG_INFORMATION', value: 'zowe-install-test:*'),
@@ -272,7 +272,7 @@ node('ibm-jenkins-slave-nvm') {
         //   testParameters.add(string(name: 'ZOWE_CLI_ARTIFACTORY_BUILD', value: ''))
         // }
         def test_result = build(
-            job: '/zowe-install-test/staging',
+            job: '/zowe-install-test/users/roavill2/add-fail-nightly',
             parameters: testParameters,
             propagate: false
           )

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -16,7 +16,7 @@ node('ibm-jenkins-slave-nvm') {
   def SLACK_CHANNEL = '#zowe-build'
   def ZOWE_RELEASE_REPOSITORY = 'libs-release-local'
   def ZOWE_RELEASE_PATH = '/org/zowe/nightly'
-  def ZOWE_BUILD_NAME = 'zowe-install-packaging :: rc'
+  def ZOWE_BUILD_NAME = 'zowe-install-packaging :: staging'
   def ZOWE_BUILD_REPOSITORY = 'libs-snapshot-local'
   def ZOWE_CLI_RELEASE_PATH = '/org/zowe/nightly/cli'
   def ZOWE_CLI_BUILD_NAME = 'Zowe CLI Bundle :: master'
@@ -88,7 +88,7 @@ node('ibm-jenkins-slave-nvm') {
         long currentTimestampInt = currentTimestamp as Long
         def timeElapse = (currentTimestampInt * 1000 - buildTimestampInt) / (3600 * 1000)
         echo "Build #${buildNumber} is ${timeElapse} hours ago"
-        if (timeElapse < 1) { // how many hours we consider it's too old?
+        if (timeElapse < 22) { // how many hours we consider it's too old?
           echo "Will skip re-build."
           sourceSmpeBuildInfo = latestBuild
         } else {
@@ -132,7 +132,7 @@ node('ibm-jenkins-slave-nvm') {
       if (!sourceSmpeBuildInfo || !sourceSmpeBuildInfo['path']) {
         echo "Building new driver ..."
 
-        /* run build
+        // run build
         def build_result = build(
           job: '/zowe-install-packaging/staging',
           parameters: [
@@ -143,7 +143,7 @@ node('ibm-jenkins-slave-nvm') {
         echo "Build result: ${build_result.result}"
         if (build_result.result != 'SUCCESS') {
           error "Failed to build a new Zowe driver, check failure details at ${build_result.absoluteUrl}"
-        }*/
+        }
 
         // load build info
         sourceSmpeBuildInfo = pipeline.artifactory.getArtifact([
@@ -195,7 +195,7 @@ node('ibm-jenkins-slave-nvm') {
       } else {
         def testParameters = [
           booleanParam(name: 'STARTED_BY_AUTOMATION', value: true),
-          string(name: 'TEST_SCOPE', value: 'bundle: convenience build on multiple 5ecurity systems'),
+          string(name: 'TEST_SCOPE', value: 'bundle: convenience build on multiple security systems'),
           string(name: 'ZOWE_ARTIFACTORY_PATTERN', value: sourceRegBuildInfo.path),
           string(name: 'ZOWE_ARTIFACTORY_BUILD', value: ''),
           string(name: 'INSTALL_TEST_DEBUG_INFORMATION', value: 'zowe-install-test:*'),
@@ -214,7 +214,7 @@ node('ibm-jenkins-slave-nvm') {
         //   testParameters.add(string(name: 'ZOWE_CLI_ARTIFACTORY_BUILD', value: ''))
         // }
         def test_result = build(
-            job: '/zowe-install-test/users%2Froavill2%2Fadd-fail-nightly',
+            job: '/zowe-install-test/staging',
             parameters: testParameters,
             propagate: false
           )
@@ -253,7 +253,7 @@ node('ibm-jenkins-slave-nvm') {
       } else {
         def testParameters = [
           booleanParam(name: 'STARTED_BY_AUTOMATION', value: true),
-          string(name: 'TEST_SCOPE', value: 'bundle: smpe ptf on multiple 5ecurity systems'),
+          string(name: 'TEST_SCOPE', value: 'bundle: smpe ptf on multiple security systems'),
           string(name: 'ZOWE_ARTIFACTORY_PATTERN', value: sourceSmpeBuildInfo.path),
           string(name: 'ZOWE_ARTIFACTORY_BUILD', value: ''),
           string(name: 'INSTALL_TEST_DEBUG_INFORMATION', value: 'zowe-install-test:*'),
@@ -272,7 +272,7 @@ node('ibm-jenkins-slave-nvm') {
         //   testParameters.add(string(name: 'ZOWE_CLI_ARTIFACTORY_BUILD', value: ''))
         // }
         def test_result = build(
-            job: '/zowe-install-test/users%2Froavill2%2Fadd-fail-nightly',
+            job: '/zowe-install-test/staging',
             parameters: testParameters,
             propagate: false
           )
@@ -288,7 +288,7 @@ node('ibm-jenkins-slave-nvm') {
     timeout: [time: 4, unit: 'HOURS']
   )
 
-  /*pipeline.createStage(
+  pipeline.createStage(
     name          : "Promote",
     isSkippable   : true,
     shouldExecute : {
@@ -321,9 +321,9 @@ node('ibm-jenkins-slave-nvm') {
       }
     },
     timeout: [time: 10, unit: 'MINUTES']
-  )*/
+  )
 
-  /*pipeline.createStage(
+  pipeline.createStage(
     name          : "Message",
     isSkippable   : true,
     stage         : {
@@ -372,7 +372,7 @@ node('ibm-jenkins-slave-nvm') {
       }
     },
     timeout: [time: 2, unit: 'MINUTES']
-  )*/
+  )
 
   pipeline.end()
 }

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -16,7 +16,7 @@ node('ibm-jenkins-slave-nvm') {
   def SLACK_CHANNEL = '#zowe-build'
   def ZOWE_RELEASE_REPOSITORY = 'libs-release-local'
   def ZOWE_RELEASE_PATH = '/org/zowe/nightly'
-  def ZOWE_BUILD_NAME = 'zowe-install-packaging :: staging'
+  def ZOWE_BUILD_NAME = 'zowe-install-packaging :: rc'
   def ZOWE_BUILD_REPOSITORY = 'libs-snapshot-local'
   def ZOWE_CLI_RELEASE_PATH = '/org/zowe/nightly/cli'
   def ZOWE_CLI_BUILD_NAME = 'Zowe CLI Bundle :: master'

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -88,7 +88,7 @@ node('ibm-jenkins-slave-nvm') {
         long currentTimestampInt = currentTimestamp as Long
         def timeElapse = (currentTimestampInt * 1000 - buildTimestampInt) / (3600 * 1000)
         echo "Build #${buildNumber} is ${timeElapse} hours ago"
-        if (timeElapse < 22) { // how many hours we consider it's too old?
+        if (timeElapse < 1) { // how many hours we consider it's too old?
           echo "Will skip re-build."
           sourceSmpeBuildInfo = latestBuild
         } else {

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -214,7 +214,7 @@ node('ibm-jenkins-slave-nvm') {
         //   testParameters.add(string(name: 'ZOWE_CLI_ARTIFACTORY_BUILD', value: ''))
         // }
         def test_result = build(
-            job: '/zowe-install-test/users/roavill2/add-fail-nightly',
+            job: '/zowe-install-test/users%2Froavill2%2Fadd-fail-nightly',
             parameters: testParameters,
             propagate: false
           )
@@ -272,7 +272,7 @@ node('ibm-jenkins-slave-nvm') {
         //   testParameters.add(string(name: 'ZOWE_CLI_ARTIFACTORY_BUILD', value: ''))
         // }
         def test_result = build(
-            job: '/zowe-install-test/users/roavill2/add-fail-nightly',
+            job: '/zowe-install-test/users%2Froavill2%2Fadd-fail-nightly',
             parameters: testParameters,
             propagate: false
           )

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -222,7 +222,7 @@ node('ibm-jenkins-slave-nvm') {
         if (test_result.result != 'SUCCESS') {
           testRegBuildErrorUrl = test_result.absoluteUrl
           echo "Test failed on regular build ${sourceRegBuildInfo.path}, check failure details at ${test_result.absoluteUrl}"
-          currentBuild.result == 'UNSTABLE'
+          currentBuild.result = 'UNSTABLE'
         }
       }
     },
@@ -280,7 +280,7 @@ node('ibm-jenkins-slave-nvm') {
         if (test_result.result != 'SUCCESS') {
           testSmpeBuildErrorUrl = test_result.absoluteUrl
           echo "Test failed on SMP/e build ${sourceSmpeBuildInfo.path}, check failure details at ${test_result.absoluteUrl}"
-          currentBuild.result == 'UNSTABLE'
+          currentBuild.result = 'UNSTABLE'
         }
       }
     },

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -288,7 +288,7 @@ node('ibm-jenkins-slave-nvm') {
     timeout: [time: 4, unit: 'HOURS']
   )
 
-  pipeline.createStage(
+  /*pipeline.createStage(
     name          : "Promote",
     isSkippable   : true,
     shouldExecute : {
@@ -321,9 +321,9 @@ node('ibm-jenkins-slave-nvm') {
       }
     },
     timeout: [time: 10, unit: 'MINUTES']
-  )
+  )*/
 
-  pipeline.createStage(
+  /*pipeline.createStage(
     name          : "Message",
     isSkippable   : true,
     stage         : {
@@ -372,7 +372,7 @@ node('ibm-jenkins-slave-nvm') {
       }
     },
     timeout: [time: 2, unit: 'MINUTES']
-  )
+  )*/
 
   pipeline.end()
 }


### PR DESCRIPTION
Adding code so that if the install-tests called by nightly build fail, the build finishes as unstable rather than successful.