### PR TITLE
Add keyring uninstall steps for ACF2

### DIFF
--- a/playbooks/roles/zowe/tasks/uninstall_keyring.yml
+++ b/playbooks/roles/zowe/tasks/uninstall_keyring.yml
@@ -24,5 +24,10 @@
 
 - import_role:
     name: zowe
+    tasks_from: uninstall_keyring_acf2
+  when: zos_security_system == 'ACF2'
+
+- import_role:
+    name: zowe
     tasks_from: uninstall_keyring_tss
   when: zos_security_system == 'TSS'

--- a/playbooks/roles/zowe/tasks/uninstall_keyring_acf2.yml
+++ b/playbooks/roles/zowe/tasks/uninstall_keyring_acf2.yml
@@ -9,15 +9,7 @@
     rm -f "{{ work_dir_remote }}/ACFNOKYR.jcl"
 
 - name: create initial ACFNOKYR.jcl
-  raw: cat <<EOF > "{{ work_dir_remote }}/ACFNOKYR.jcl"
-//ACFNOKYR JOB
-//RUN      EXEC PGM=IKJEFT01,REGION=0M
-//SYSTSPRT DD SYSOUT=*
-//SYSTSIN  DD DDNAME=ACF2
-//ACF2     DD DATA,DLM=$$,SYMBOLS=JCLONLY
-ACF
-  SET PROFILE(USER) DIVISION(CERTDATA)
-EOF
+  raw: echo "//ACFNOKYR JOB\n//RUN      EXEC PGM=IKJEFT01,REGION=0M\n//SYSTSPRT DD SYSOUT=*\n//SYSTSIN  DD DDNAME=ACF2\n//ACF2     DD DATA,DLM=$$,SYMBOLS=JCLONLY\nACF\n  SET PROFILE(USER) DIVISION(CERTDATA)" > "{{ work_dir_remote }}/ACFNOKYR.jcl"
 
 - name: Add remove Zowe ACF2 personal certficates statement(s) to JCL
   raw: echo "  DELETE &ZOWEUSER..{{ item}}" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
@@ -36,16 +28,7 @@ EOF
   ignore_errors: True
 
 - name: finalise ACFNOKYR.jcl
-  raw: cat <<EOF >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
-F ACF2,REBUILD(FAC)
-
-* List the keyring ................................................
-  SET PROFILE(USER) DIVISION(KEYRING)
-  LIST &ZOWEUSER..ZOWERING
-
-END
-$$
-EOF
+  raw: echo "F ACF2,REBUILD(FAC)\n\n* List the keyring ................................................\n  SET PROFILE(USER) DIVISION(KEYRING)\n  LIST &ZOWEUSER..ZOWERING\n\nEND\n$$" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
 
 - name: Print ACFNOKYR.jcl
   raw: cat "{{ work_dir_remote }}/ACFNOKYR.jcl"

--- a/playbooks/roles/zowe/tasks/uninstall_keyring_acf2.yml
+++ b/playbooks/roles/zowe/tasks/uninstall_keyring_acf2.yml
@@ -8,7 +8,6 @@
   raw: >-
     rm -f "{{ work_dir_remote }}/ACFNOKYR.jcl"
 
-
 - name: create initial ACFNOKYR.jcl
   raw: cat <<EOF > "{{ work_dir_remote }}/ACFNOKYR.jcl"
 //ACFNOKYR JOB

--- a/playbooks/roles/zowe/tasks/uninstall_keyring_acf2.yml
+++ b/playbooks/roles/zowe/tasks/uninstall_keyring_acf2.yml
@@ -5,8 +5,7 @@
 # build up jcl as we go then run at the end
 
 - name: Remove ACFNOKYR.jcl if exists
-  raw: >-
-    rm -f "{{ work_dir_remote }}/ACFNOKYR.jcl"
+  raw: rm -f "{{ work_dir_remote }}/ACFNOKYR.jcl"
 
 - name: create initial ACFNOKYR.jcl
   raw: echo "//ACFNOKYR JOB\n//RUN      EXEC PGM=IKJEFT01,REGION=0M\n//SYSTSPRT DD SYSOUT=*\n//SYSTSIN  DD DDNAME=ACF2\n//ACF2     DD DATA,DLM=$$,SYMBOLS=JCLONLY\nACF\n  SET PROFILE(USER) DIVISION(CERTDATA)" > "{{ work_dir_remote }}/ACFNOKYR.jcl"
@@ -33,7 +32,7 @@
 - name: Print ACFNOKYR.jcl
   raw: cat "{{ work_dir_remote }}/ACFNOKYR.jcl"
 
-  - name: Run ACFNOKYR.jcl
+- name: Run ACFNOKYR.jcl
   import_role:
     name: zos
     tasks_from: run_jcl

--- a/playbooks/roles/zowe/tasks/uninstall_keyring_acf2.yml
+++ b/playbooks/roles/zowe/tasks/uninstall_keyring_acf2.yml
@@ -8,10 +8,10 @@
   raw: rm -f "{{ work_dir_remote }}/ACFNOKYR.jcl"
 
 - name: create initial ACFNOKYR.jcl
-  raw: echo "//ACFNOKYR JOB\n//RUN      EXEC PGM=IKJEFT01,REGION=0M\n//SYSTSPRT DD SYSOUT=*\n//SYSTSIN  DD DDNAME=ACF2\n//ACF2     DD DATA,DLM=$$,SYMBOLS=JCLONLY\nACF\n  SET PROFILE(USER) DIVISION(CERTDATA)" > "{{ work_dir_remote }}/ACFNOKYR.jcl"
+  raw: echo "//ACFNOKYR JOB\n//RUN      EXEC PGM=IKJEFT01,REGION=0M\n//SYSTSPRT DD SYSOUT=*\n//SYSTSIN  DD DDNAME=ACF2\n//ACF2     DD DATA,DLM=\$\$,SYMBOLS=JCLONLY\nACF\n  SET PROFILE(USER) DIVISION(CERTDATA)" > "{{ work_dir_remote }}/ACFNOKYR.jcl"
 
 - name: Add remove Zowe ACF2 personal certficates statement(s) to JCL
-  raw: echo "  DELETE &ZOWEUSER..{{ item}}" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
+  raw: echo "  DELETE {{ zowe_runtime_user }}..{{ item}}" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
   loop: "{{ zowe_known_keyring_personal_digicerts }}"
 
 - name: Add remove Zowe ACF2 certauth certficates statement(s) to JCL
@@ -22,12 +22,12 @@
   raw: echo "  SET PROFILE(USER) DIVISION(KEYRING)" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
 
 - name: Add delete Zowe ACF2 keyrings statement(s) to JCL
-  raw: echo "  DELETE &ZOWEUSER..{{ item}}" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
+  raw: echo "  DELETE {{ zowe_runtime_user }}..{{ item}}" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
   loop: "{{ zowe_known_tss_keyring_names }}"
   ignore_errors: True
 
 - name: finalise ACFNOKYR.jcl
-  raw: echo "F ACF2,REBUILD(FAC)\n\n* List the keyring ................................................\n  SET PROFILE(USER) DIVISION(KEYRING)\n  LIST &ZOWEUSER..ZOWERING\n\nEND\n\$\$" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
+  raw: echo "\n  F ACF2,REBUILD(FAC)\n\n* List the keyring ................................................\n  SET PROFILE(USER) DIVISION(KEYRING)\n  LIST {{ zowe_runtime_user }}..ZOWERING\n\nEND\n\$\$" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
 
 - name: Print ACFNOKYR.jcl
   raw: cat "{{ work_dir_remote }}/ACFNOKYR.jcl"

--- a/playbooks/roles/zowe/tasks/uninstall_keyring_acf2.yml
+++ b/playbooks/roles/zowe/tasks/uninstall_keyring_acf2.yml
@@ -11,7 +11,7 @@
   raw: echo "//ACFNOKYR JOB\n//RUN      EXEC PGM=IKJEFT01,REGION=0M\n//SYSTSPRT DD SYSOUT=*\n//SYSTSIN  DD DDNAME=ACF2\n//ACF2     DD DATA,DLM=\$\$,SYMBOLS=JCLONLY\nACF\n  SET PROFILE(USER) DIVISION(CERTDATA)" > "{{ work_dir_remote }}/ACFNOKYR.jcl"
 
 - name: Add remove Zowe ACF2 personal certficates statement(s) to JCL
-  raw: echo "  DELETE {{ zowe_runtime_user }}..{{ item}}" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
+  raw: echo "  DELETE {{ zowe_runtime_user }}.{{ item}}" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
   loop: "{{ zowe_known_keyring_personal_digicerts }}"
 
 - name: Add remove Zowe ACF2 certauth certficates statement(s) to JCL
@@ -22,12 +22,12 @@
   raw: echo "  SET PROFILE(USER) DIVISION(KEYRING)" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
 
 - name: Add delete Zowe ACF2 keyrings statement(s) to JCL
-  raw: echo "  DELETE {{ zowe_runtime_user }}..{{ item}}" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
+  raw: echo "  DELETE {{ zowe_runtime_user }}.{{ item}}" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
   loop: "{{ zowe_known_tss_keyring_names }}"
   ignore_errors: True
 
 - name: finalise ACFNOKYR.jcl
-  raw: echo "\n  F ACF2,REBUILD(FAC)\n\n* List the keyring ................................................\n  SET PROFILE(USER) DIVISION(KEYRING)\n  LIST {{ zowe_runtime_user }}..ZOWERING\n\nEND\n\$\$" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
+  raw: echo "\n  F ACF2,REBUILD(FAC)\n\n* List the keyring ................................................\n  SET PROFILE(USER) DIVISION(KEYRING)\n  LIST {{ zowe_runtime_user }}.ZOWERING\n\nEND\n\$\$" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
 
 - name: Print ACFNOKYR.jcl
   raw: cat "{{ work_dir_remote }}/ACFNOKYR.jcl"

--- a/playbooks/roles/zowe/tasks/uninstall_keyring_acf2.yml
+++ b/playbooks/roles/zowe/tasks/uninstall_keyring_acf2.yml
@@ -27,7 +27,7 @@
   ignore_errors: True
 
 - name: finalise ACFNOKYR.jcl
-  raw: echo "F ACF2,REBUILD(FAC)\n\n* List the keyring ................................................\n  SET PROFILE(USER) DIVISION(KEYRING)\n  LIST &ZOWEUSER..ZOWERING\n\nEND\n$$" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
+  raw: echo "F ACF2,REBUILD(FAC)\n\n* List the keyring ................................................\n  SET PROFILE(USER) DIVISION(KEYRING)\n  LIST &ZOWEUSER..ZOWERING\n\nEND\n\$\$" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
 
 - name: Print ACFNOKYR.jcl
   raw: cat "{{ work_dir_remote }}/ACFNOKYR.jcl"

--- a/playbooks/roles/zowe/tasks/uninstall_keyring_acf2.yml
+++ b/playbooks/roles/zowe/tasks/uninstall_keyring_acf2.yml
@@ -1,0 +1,59 @@
+---
+# Delete acf Keyrings and certificates we've created
+# ============================================================================
+
+# build up jcl as we go then run at the end
+
+- name: Remove ACFNOKYR.jcl if exists
+  raw: >-
+    rm -f "{{ work_dir_remote }}/ACFNOKYR.jcl"
+
+
+- name: create initial ACFNOKYR.jcl
+  raw: cat <<EOF > "{{ work_dir_remote }}/ACFNOKYR.jcl"
+//ACFNOKYR JOB
+//RUN      EXEC PGM=IKJEFT01,REGION=0M
+//SYSTSPRT DD SYSOUT=*
+//SYSTSIN  DD DDNAME=ACF2
+//ACF2     DD DATA,DLM=$$,SYMBOLS=JCLONLY
+ACF
+  SET PROFILE(USER) DIVISION(CERTDATA)
+EOF
+
+- name: Add remove Zowe ACF2 personal certficates statement(s) to JCL
+  raw: echo "  DELETE &ZOWEUSER..{{ item}}" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
+  loop: "{{ zowe_known_keyring_personal_digicerts }}"
+
+- name: Add remove Zowe ACF2 certauth certficates statement(s) to JCL
+  raw: echo "  DELETE CERTAUTH.{{ item}}" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
+  loop: "{{ zowe_known_keyring_certauth_digicerts }}"
+
+- name: Add set keying division ACF2 statement to JCL
+  raw: echo "  SET PROFILE(USER) DIVISION(KEYRING)" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
+
+- name: Add delete Zowe ACF2 keyrings statement(s) to JCL
+  raw: echo "  DELETE &ZOWEUSER..{{ item}}" >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
+  loop: "{{ zowe_known_tss_keyring_names }}"
+  ignore_errors: True
+
+- name: finalise ACFNOKYR.jcl
+  raw: cat <<EOF >> "{{ work_dir_remote }}/ACFNOKYR.jcl"
+F ACF2,REBUILD(FAC)
+
+* List the keyring ................................................
+  SET PROFILE(USER) DIVISION(KEYRING)
+  LIST &ZOWEUSER..ZOWERING
+
+END
+$$
+EOF
+
+- name: Print ACFNOKYR.jcl
+  raw: cat "{{ work_dir_remote }}/ACFNOKYR.jcl"
+
+  - name: Run ACFNOKYR.jcl
+  import_role:
+    name: zos
+    tasks_from: run_jcl
+  vars:
+    jcl_filename: "{{ work_dir_remote }}/ACFNOKYR.jcl"

--- a/playbooks/roles/zowe/tasks/uninstall_keyring_tss.yml
+++ b/playbooks/roles/zowe/tasks/uninstall_keyring_tss.yml
@@ -2,7 +2,6 @@
 # Delete tss Keyrings and certificates we've created
 # ============================================================================
 
-# TODO - certificate names correct?
 - name: Remove Zowe TSS personal certficates
   raw: tsocmd "TSS REM({{ zowe_runtime_user }}) DIGICERT({{ item }})"
   loop: "{{ zowe_known_keyring_personal_digicerts }}"

--- a/tests/installation/Jenkinsfile
+++ b/tests/installation/Jenkinsfile
@@ -97,7 +97,7 @@ node('ibm-jenkins-slave-nvm') {
       jenkins_extra_locks: ['marist-2', 'marist-3'],
     ],
     'bundle: multiple keystore modes': [
-      test_files: 'dist/__tests__/extended/keystore-modes/acf*',
+      test_files: 'dist/__tests__/extended/keystore-modes/',
       jenkins_primary_lock: 'marist',
     ],
     'generate api documentation': [
@@ -105,7 +105,6 @@ node('ibm-jenkins-slave-nvm') {
       jenkins_primary_lock: 'marist',
     ]
   ]
-  // TODO - remove only acf2 before commit
 
   def lib = library("jenkins-library").org.zowe.jenkins_shared_library
 

--- a/tests/installation/Jenkinsfile
+++ b/tests/installation/Jenkinsfile
@@ -97,7 +97,7 @@ node('ibm-jenkins-slave-nvm') {
       jenkins_extra_locks: ['marist-2', 'marist-3'],
     ],
     'bundle: multiple keystore modes': [
-      test_files: 'dist/__tests__/extended/keystore-modes/',
+      test_files: 'dist/__tests__/extended/keystore-modes/acf*',
       jenkins_primary_lock: 'marist',
     ],
     'generate api documentation': [
@@ -105,6 +105,7 @@ node('ibm-jenkins-slave-nvm') {
       jenkins_primary_lock: 'marist',
     ]
   ]
+  // TODO - remove only acf2 before commit
 
   def lib = library("jenkins-library").org.zowe.jenkins_shared_library
 


### PR DESCRIPTION
#### Relevant issues
Implements #1637 

#### Changes proposed in this PR
- Add undo script for ACF2 keyring to ensure we start from a clean state each test run
