### PR TITLE
Switching dockerhub account used for docker image publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,7 +196,7 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
             sh 'echo ">>>>>>>>>>>>>>>>>> sub-node: " && pwd && ls -ltr .'
 
             withCredentials([usernamePassword(
-              credentialsId: 'DockerGizaUser',
+              credentialsId: 'ZoweDockerhub',
               usernameVariable: 'USERNAME',
               passwordVariable: 'PASSWORD'
             )]){


### PR DESCRIPTION
Switching the account used for dockerhub from rsqa to ompzowe, as a more official sounding name to use.