### PR TITLE
Update vscode-extension tag

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -367,7 +367,7 @@
       "componentGroup": "Zowe Visual Studio Code Extension",
       "entries": [{
         "repository": "vscode-extension-for-zowe",
-        "tag": "1.9.0",
+        "tag": "v1.9.0",
         "destinations": ["Visual Studio Code Marketplace"]
       }]
     }


### PR DESCRIPTION
**Related to**
Issue #1721 

**Changes being made**
Updating the source tag for vscode-extenions-for-zowe as it was missing the 'v' marker.