### PR TITLE
Test to publish to both dockerhub and artifactory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,11 @@ node('ibm-jenkins-slave-nvm') {
       defaultValue: false
     ),
     booleanParam(
+      name: 'PUBLISH_DOCKER',
+      description: 'If we want to publish docker image to dockerhub.',
+      defaultValue: false
+    ),
+    booleanParam(
       name: 'KEEP_TEMP_FOLDER',
       description: 'If leave the temporary packaging folder on remote server.',
       defaultValue: false
@@ -202,12 +207,30 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
             )]){
               // build docker image
               sh "docker build -f Dockerfile.jenkins -t ${USERNAME}/zowe-v1-lts:amd64 ."
-              // publish
-              sh """
+            }
+            sh "docker save -o zowe-v1-lts.amd64.tar ompzowe/zowe-v1-lts"
+            // show files
+            sh 'echo ">>>>>>>>>>>>>>>>>> docker tar: " && pwd && ls -ltr zowe-v1-lts.amd64.tar'
+
+            
+            if (params.PUBLISH_DOCKER) {
+              withCredentials([usernamePassword(
+                credentialsId: 'ZoweDockerhub',
+                usernameVariable: 'USERNAME',
+                passwordVariable: 'PASSWORD'
+              )]){
+                // publish
+                sh """
                  docker login -u ${USERNAME} -p ${PASSWORD} \
                  && docker push ${USERNAME}/zowe-v1-lts:amd64
                  """
+              }
             }
+
+            //pipeline.artifactory.upload(
+            //  pattern: 'zowe-v1-lts.amd64.tar',
+            //  target: 
+            //)
           }
         }
       }


### PR DESCRIPTION
Testing out some docker commands.
Ultimately narrowing in on the best way to publish to artifactory into the same folder as the rest of the content, while in the docker build node, so that we can have docker nightlies without publishing to dockerhub.