### PR TITLE
Add zlinux build to build process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ node('ibm-jenkins-slave-nvm') {
 
   def pipeline = lib.pipelines.generic.GenericPipeline.new(this)
   def manifest
+  def zowePaxUploaded
 
   pipeline.admins.add("jackjia", "stevenh", "joewinchester", "markackert")
 
@@ -172,7 +173,7 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
       if (params.BUILD_DOCKER) {
         // this is a hack to find the zowe.pax upload
         // FIXME: ideally this should be reachable from pipeline property
-        def zowePaxUploaded = sh(
+        zowePaxUploaded = sh(
           script: "cat .tmp-pipeline-publish-spec.json | jq -r '.files[] | select(.pattern == \".pax/zowe.pax\") | .target'",
           returnStdout: true
         ).trim()
@@ -253,10 +254,6 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
       if (params.BUILD_DOCKER) {
         // this is a hack to find the zowe.pax upload
         // FIXME: ideally this should be reachable from pipeline property
-        def zowePaxUploaded = sh(
-          script: "cat .tmp-pipeline-publish-spec.json | jq -r '.files[] | select(.pattern == \".pax/zowe.pax\") | .target'",
-          returnStdout: true
-        ).trim()
         echo "zowePaxUploaded=${zowePaxUploaded}"
         if (zowePaxUploaded == "") {
           sh "echo 'content of .tmp-pipeline-publish-spec.json' && cat .tmp-pipeline-publish-spec.json"
@@ -288,8 +285,8 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
             )]){
               // build docker image
               sh "docker build -f Dockerfile.jenkins -t ${USERNAME}/zowe-v1-lts:amd64 ."
+              sh "docker save -o zowe-v1-lts.amd64.tar ${USERNAME}/zowe-v1-lts:amd64"
             }
-            sh "docker save -o zowe-v1-lts.amd64.tar ${USERNAME}/zowe-v1-lts:amd64"
             // show files
             sh 'echo ">>>>>>>>>>>>>>>>>> docker tar: " && pwd && ls -ltr zowe-v1-lts.amd64.tar'
             pipeline.uploadArtifacts([ 'zowe-v1-lts.amd64.tar' ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,8 +161,6 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
       '.pax/AZWE*'
     ]
   )
-
-  def dockerArtifacts = []
   
   pipeline.createStage(
     name: "Build zLinux Docker",
@@ -226,7 +224,7 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
              echo ">>>>>>>>>>>>>>>>>> docker tar: " && pwd && ls -ltr zowe-v1-lts.s390x.tar
           """
           sshGet remote: Z_SERVER, from: "zowe-build/${env.BRANCH_NAME}_${env.BUILD_NUMBER}/zowe-dockerfiles/dockerfiles/zowe-release/s390x/zowe-v1-lts/zowe-v1-lts.s390x.tar", into: "zowe-v1-lts.s390x.tar"
-          dockerArtifacts.add( 'zowe-v1-lts.s390x.tar' )
+          pipeline.uploadArtifacts([ 'zowe-v1-lts.s390x.tar' ])
           if (params.PUBLISH_DOCKER) {
             sshCommand remote: Z_SERVER, command: \
             """
@@ -290,7 +288,7 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
             }
             // show files
             sh 'echo ">>>>>>>>>>>>>>>>>> docker tar: " && pwd && ls -ltr zowe-v1-lts.amd64.tar'
-            dockerArtifacts.add( 'zowe-v1-lts.amd64.tar' )
+            pipeline.uploadArtifacts([ 'zowe-v1-lts.amd64.tar' ])
 
             if (params.PUBLISH_DOCKER) {
               withCredentials([usernamePassword(
@@ -311,19 +309,5 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
     }
   )
 
-  pipeline.createStage(
-    name: "Docker Artifactory Upload",
-    timeout: [ time: 30, unit: 'MINUTES' ],
-    isSkippable: true,
-    showExecute: {
-      return params.BUILD_DOCKER
-    },
-    stage: {
-      if (params.BUILD_DOCKER) {
-        pipeline.uploadArtifacts(dockerArtifacts);
-      }
-    }
-  )
-  
   pipeline.end()
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,6 +162,8 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
     ]
   )
 
+  def dockerArtifacts = []
+  
   pipeline.createStage(
     name: "Build zLinux Docker",
     timeout: [ time: 60, unit: 'MINUTES' ],
@@ -224,7 +226,7 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
              echo ">>>>>>>>>>>>>>>>>> docker tar: " && pwd && ls -ltr zowe-v1-lts.s390x.tar
           """
           sshGet remote: Z_SERVER, from: "zowe-build/${env.BRANCH_NAME}_${env.BUILD_NUMBER}/zowe-dockerfiles/dockerfiles/zowe-release/s390x/zowe-v1-lts/zowe-v1-lts.s390x.tar", into: "zowe-v1-lts.s390x.tar"
-          pipeline.uploadArtifacts([ 'zowe-v1-lts.s390x.tar' ])
+          dockerArtifacts.add( 'zowe-v1-lts.s390x.tar' )
           if (params.PUBLISH_DOCKER) {
             sshCommand remote: Z_SERVER, command: \
             """
@@ -235,9 +237,8 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
           sshCommand remote: Z_SERVER, command: \
           """
              rm -rf zowe-build/${env.BRANCH_NAME}_${env.BUILD_NUMBER}
+             sudo docker system prune -f
           """
-          //TODO need way to cleanup docker to save space, dont know how to auto-yes here
-          //              docker system prune -y
         }
       }
     }
@@ -289,7 +290,7 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
             }
             // show files
             sh 'echo ">>>>>>>>>>>>>>>>>> docker tar: " && pwd && ls -ltr zowe-v1-lts.amd64.tar'
-            pipeline.uploadArtifacts([ 'zowe-v1-lts.amd64.tar' ])
+            dockerArtifacts.add( 'zowe-v1-lts.amd64.tar' )
 
             if (params.PUBLISH_DOCKER) {
               withCredentials([usernamePassword(
@@ -310,5 +311,19 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
     }
   )
 
+  pipeline.createStage(
+    name: "Docker Artifactory Upload",
+    timeout: [ time: 30, unit: 'MINUTES' ],
+    isSkippable: true,
+    showExecute: {
+      return params.BUILD_DOCKER
+    },
+    stage: {
+      if (params.BUILD_DOCKER) {
+        pipeline.uploadArtifacts(dockerArtifacts);
+      }
+    }
+  )
+  
   pipeline.end()
 }


### PR DESCRIPTION
In this PR, a new stage is made to build docker for zlinux. I decided to make this a stage separate from docker for linux, so you can see progress better, but it's a very similar task with the exception that zlinux needs to do the actions over ssh, while the linux build happens within a docker node inside of our primary jenkins docker node.
The zlinux build completes more quickly than the linux build, since it's a separate system that is ssh into.
The result ends up on artifactory and optionally dockerhub. For artifactory, you can see the output here: https://zowe.jfrog.io/zowe/libs-snapshot-local/org/zowe/1.17.0-PR-1763/ where zlinux contains the string "s390x", while linux contains "amd64".