### PR TITLE
Revert caching service placeholder vars

### DIFF
--- a/scripts/instance.template.env
+++ b/scripts/instance.template.env
@@ -42,15 +42,6 @@ APIML_SECURITY_AUTH_PROVIDER=zosmf
 ZWE_DISCOVERY_SERVICES_LIST=https://${ZOWE_EXPLORER_HOST}:${DISCOVERY_PORT}/eureka/
 # Enable debug logging for Api Mediation Layer services
 APIML_DEBUG_MODE_ENABLED=false
-####################
-# caching service
-# TCP port of caching service
-ZWE_CACHING_SERVICE_PORT=7555
-# specify persistent method of caching service
-# currently VSAM is the only option
-ZWE_CACHING_SERVICE_PERSISTENT=VSAM
-# specify the data set name of the caching service VSAM
-ZWE_CACHING_SERVICE_VSAM_DATASET=
 
 # explorer variables
 JOBS_API_PORT=8545 # the port the jobs API service will use


### PR DESCRIPTION
Joe Winchester Yesterday at 7:02 PM
I’m doing some 1.17 rc testing and when running zowe-configure-instance.sh the instance.env  file is updated with the following properties
ZWE_CACHING_SERVICE_PORT=7555
ZWE_CACHING_SERVICE_PERSISTENT=VSAM
ZWE_CACHING_SERVICE_VSAM_DATASET=
Should these be included in 1.17 as values and if so are there any docs for what values should be used ?  I’m happy to doc them as “Under development” but wanted to check if there is accompanying doc and/or perhaps they’ve been released into staging too soon.   cc: @Jack T. Jia
6 replies
Jack T. Jia  14 hours ago
Hi Joe, you are right this could be confusing for the end user. There is no doc item for this right now. I was thinking to add it when caching service can be started. So far, we can comment or mark them as under development. Which way you think is better?
Joe Winchester  14 hours ago
I’ll mark them as under development in the doc.  For the port does this need to be an available port is going to be allocated or is it just a placeholder ?
Jack T. Jia  13 hours ago
it’s a place holder. for this release, my understanding is caching service won’t be started by default
:+1:
1

David Janda  12 hours ago
We can remove them if you agree that they should not be there to confuse users. I am of the same oppinion.
David Janda  12 hours ago
And add them later when they become relevant.
David Janda  12 hours ago
Let us know how you want to proceed