### PR TITLE
Increase timeout length

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -228,7 +228,7 @@ node('ibm-jenkins-slave-nvm') {
       }
     },
     allowMissingJunit : true,
-    timeout: [time: 2, unit: 'HOURS']
+    timeout: [time: 3, unit: 'HOURS']
   )
 
   pipeline.test(
@@ -286,7 +286,7 @@ node('ibm-jenkins-slave-nvm') {
       }
     },
     allowMissingJunit : true,
-    timeout: [time: 4, unit: 'HOURS']
+    timeout: [time: 5, unit: 'HOURS']
   )
 
   pipeline.createStage(


### PR DESCRIPTION
#### Relevant issues
https://github.com/zowe/zowe-install-packaging/issues/1661

#### Changes proposed in this PR
Increases the timeout for the install-tests, since those timeouts were set we have added more tests so they should be increased.

The issue with the positives being stated after timeout still exists, I'm still trying to get that working.