### PR TITLE
Only inject ZWEToken if x509 enabled

### DIFF
--- a/playbooks/roles/configure/tasks/configure_instance.yml
+++ b/playbooks/roles/configure/tasks/configure_instance.yml
@@ -53,7 +53,7 @@
 # This is TEMPORARY workaround because of missing security setup on some servers and problem with ZSS configuration,
 # remove once this is fixed
 - name: Add ZSS configuration to instance.env
-  when: zos_security_system == 'RACF'
+  when: zowe_apiml_security_x509_enabled
   raw: |-
     echo "ZWED_agent_jwt_token_name=ZWETOKEN" >> "{{ zowe_instance_dir }}/instance.env"
     echo "ZWED_agent_jwt_token_label=jwtsecret" >> "{{ zowe_instance_dir }}/instance.env"


### PR DESCRIPTION
Signed-off-by: stevenhorsman <steven@uk.ibm.com>
#### Relevant issues
Fixes #1800 

#### Changes proposed in this PR
- Only inject ZWE token if x509 enabled
