### PR TITLE
Switch list separation to commas for consistency

### DIFF
--- a/bin/utils/file-utils.sh
+++ b/bin/utils/file-utils.sh
@@ -91,7 +91,7 @@ validate_directory_is_accessible() {
 
 validate_directories_are_accessible() {
   invalid=0
-  for dir in $1
+  for dir in $(echo $1 | sed "s/,/ /g")
   do
     validate_directory_is_accessible "${dir}"
     valid_rc=$?

--- a/bin/utils/zowe-variable-utils.sh
+++ b/bin/utils/zowe-variable-utils.sh
@@ -46,7 +46,7 @@ validate_variable_is_set() {
 # Takes in a list of space separated names of the variables
 validate_variables_are_set() {
   invalid=0
-  for var in $1
+  for var in $(echo $1 | sed "s/,/ /g")
   do
     validate_variable_is_set "${var}"
     valid_rc=$?

--- a/tests/sanity/test/install/test-file-utils.js
+++ b/tests/sanity/test/install/test-file-utils.js
@@ -182,7 +182,7 @@ describe('verify file-utils', function() {
       });
   
       async function test_validate_directories_are_accessible(directories_list, invalid_directories) {
-        const command = `${validate_directories_are_accessible} "${directories_list.join(' ')}"`;
+        const command = `${validate_directories_are_accessible} "${directories_list.join()}"`;
         const expected_rc = invalid_directories.length;
         const error_list = invalid_directories.map((directory, index) => {
           return `Error ${index}: ${get_inaccessible_message(directory)}`;

--- a/tests/sanity/test/install/test-zowe-variable-utils.js
+++ b/tests/sanity/test/install/test-zowe-variable-utils.js
@@ -61,7 +61,7 @@ describe('verify zowe-variable-utils', function() {
     });
 
     async function test_validate_variables_set(variables_list, invalid_variables) {
-      const command = `${validate_variables_are_set} "${variables_list.join(' ')}"`;
+      const command = `${validate_variables_are_set} "${variables_list.join()}"`;
       const expected_rc = invalid_variables.length;
       const error_list = invalid_variables.map((variable, index) => {
         return `Error ${index}: ${variable} is empty`;


### PR DESCRIPTION
Signed-off-by: stevenhorsman <steven@uk.ibm.com>

#### Relevant issues
Part of #1803

#### Changes proposed in this PR
- Update utils list separation to be comma delimited for consistency with the rest of the code