### PR TITLE
Reduce global timeout

### DIFF
--- a/playbooks/roles/start/defaults/main.yml
+++ b/playbooks/roles/start/defaults/main.yml
@@ -2,8 +2,8 @@
 # ==============================================================================
 # Constants
 # ==============================================================================
-# 360 * 10 seconds = 1hour
-wait_for_zowe_service_retries: 360
+# 60 * 10 seconds = 10 mins
+wait_for_zowe_service_retries: 60
 # Every 10 seconds
 wait_for_zowe_service_delay: 10
 # If we clean up history job output befor starting new

--- a/tests/installation/Jenkinsfile
+++ b/tests/installation/Jenkinsfile
@@ -337,7 +337,7 @@ node('ibm-jenkins-slave-nvm') {
       withCredentials(serverCredentials) {
       withEnv(testEnvVars) {
         try {
-          nvmShell params.CLIENT_NODE_VERSION, "npm test -- --testPathPattern \"${TEST_SCOPES[params.TEST_SCOPE]['test_files']}\""
+          nvmShell params.CLIENT_NODE_VERSION, "npm test -- --testPathPattern --detectOpenHandles \"${TEST_SCOPES[params.TEST_SCOPE]['test_files']}\""
         } finally {
           nvmShell params.CLIENT_NODE_VERSION, "npm run merge-reports"
         }


### PR DESCRIPTION
#### Relevant issues
Implements #1809 

#### Changes proposed in this PR
- Reduce number of retries to 10mins based on slack conversation
- Add --detectOpenHandles to try and find unfinished jest tests