### PR TITLE
Rename docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -210,16 +210,16 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
              mkdir -p zowe-build/${env.BRANCH_NAME}_${env.BUILD_NUMBER} &&
              cd zowe-build/${env.BRANCH_NAME}_${env.BUILD_NUMBER} &&
              git clone --branch master https://github.com/zowe/zowe-dockerfiles.git
-             cd zowe-dockerfiles/dockerfiles/zowe-release/s390x/zowe-v1-lts &&
+             cd zowe-dockerfiles/dockerfiles/zowe-release/s390x/server-bundle &&
              wget "https://zowe.jfrog.io/zowe/${zowePaxUploaded}" -O zowe.pax &&
              mkdir -p utils && cp -r ../../../../utils/* ./utils &&
-             sudo docker build -t ${USERNAME}/zowe-v1-lts:s390x . &&
-             sudo docker save -o zowe-v1-lts.s390x.tar ${USERNAME}/zowe-v1-lts:s390x &&
+             sudo docker build -t ${USERNAME}/server-bundle:s390x . &&
+             sudo docker save -o server-bundle.s390x.tar ${USERNAME}/server-bundle:s390x &&
              sudo chmod 777 * &&
-             echo ">>>>>>>>>>>>>>>>>> docker tar: " && pwd && ls -ltr zowe-v1-lts.s390x.tar
+             echo ">>>>>>>>>>>>>>>>>> docker tar: " && pwd && ls -ltr server-bundle.s390x.tar
           """
-          sshGet remote: Z_SERVER, from: "zowe-build/${env.BRANCH_NAME}_${env.BUILD_NUMBER}/zowe-dockerfiles/dockerfiles/zowe-release/s390x/zowe-v1-lts/zowe-v1-lts.s390x.tar", into: "zowe-v1-lts.s390x.tar"
-          pipeline.uploadArtifacts([ 'zowe-v1-lts.s390x.tar' ])
+          sshGet remote: Z_SERVER, from: "zowe-build/${env.BRANCH_NAME}_${env.BUILD_NUMBER}/zowe-dockerfiles/dockerfiles/zowe-release/s390x/server-bundle/server-bundle.s390x.tar", into: "server-bundle.s390x.tar"
+          pipeline.uploadArtifacts([ 'server-bundle.s390x.tar' ])
           sshCommand remote: Z_SERVER, command: \
           """
              rm -rf zowe-build/${env.BRANCH_NAME}_${env.BUILD_NUMBER}
@@ -254,7 +254,7 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
           // FIXME: this dockerfile should be merged into current repo to avoid
           //        version synchronizing issues
           sh 'git clone --branch master https://github.com/zowe/zowe-dockerfiles.git'
-          dir ('zowe-dockerfiles/dockerfiles/zowe-release/amd64/zowe-v1-lts') {
+          dir ('zowe-dockerfiles/dockerfiles/zowe-release/amd64/server-bundle') {
             // copy utils to docker build folder
             sh 'mkdir -p utils && cp -r ../../../../utils/* ./utils'
             // download zowe pax to docker build agent
@@ -271,12 +271,12 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
               passwordVariable: 'PASSWORD'
             )]){
               // build docker image
-              sh "docker build -t ${USERNAME}/zowe-v1-lts:amd64 ."
-              sh "docker save -o zowe-v1-lts.amd64.tar ${USERNAME}/zowe-v1-lts:amd64"
+              sh "docker build -t ${USERNAME}/server-bundle:amd64 ."
+              sh "docker save -o server-bundle.amd64.tar ${USERNAME}/server-bundle:amd64"
             }
             // show files
-            sh 'echo ">>>>>>>>>>>>>>>>>> docker tar: " && pwd && ls -ltr zowe-v1-lts.amd64.tar'
-            pipeline.uploadArtifacts([ 'zowe-v1-lts.amd64.tar' ])
+            sh 'echo ">>>>>>>>>>>>>>>>>> docker tar: " && pwd && ls -ltr server-bundle.amd64.tar'
+            pipeline.uploadArtifacts([ 'server-bundle.amd64.tar' ])
           }
         }
       }

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -18,8 +18,8 @@ node('ibm-jenkins-slave-dind') {
   def ZOWE_RELEASE_FILEPATTERN = "zowe-*.pax"
   def ZOWE_RELEASE_SMPE_PAX_FILEPATTERN = "zowe-smpe-*.zip"
   def ZOWE_RELEASE_SMPE_PTF_PROMOTE_FILEPATTERN = "smpe-promote-*.tar"
-  def ZOWE_RELEASE_DOCKER_AMD64_FILEPATTERN = "zowe-v1-lts.amd64-*.tar"
-  def ZOWE_RELEASE_DOCKER_S390X_FILEPATTERN = "zowe-v1-lts.s390x-*.tar"
+  def ZOWE_RELEASE_DOCKER_AMD64_FILEPATTERN = "server-bundle.amd64-*.tar"
+  def ZOWE_RELEASE_DOCKER_S390X_FILEPATTERN = "server-bundle.s390x-*.tar"
   def ZOWE_RELEASE_CLI_CORE_FILEPATTERN = "zowe-cli-package-*.zip"
   def ZOWE_RELEASE_CLI_PLUGINS_FILEPATTERN = "zowe-cli-plugins-*.zip"
   def ZOWE_INSTALL_PACKAGING_REPO = 'zowe/zowe-install-packaging'
@@ -250,7 +250,7 @@ node('ibm-jenkins-slave-dind') {
           def FMID = dockerImageAmd64['path'].split('/').last().split('-').first()
           releaseArtifacts['docker-amd64'] = [:]
           releaseArtifacts['docker-amd64']['source'] = dockerImageAmd64
-          releaseArtifacts['docker-amd64']['target'] = "zowe-v1-lts.amd64-${params.ZOWE_RELEASE_VERSION}.tar".toString()
+          releaseArtifacts['docker-amd64']['target'] = "server-bundle.amd64-${params.ZOWE_RELEASE_VERSION}.tar".toString()
         }
       } catch (e1) {
         echo ">>> no Docker image amd64 version found in the build."
@@ -268,7 +268,7 @@ node('ibm-jenkins-slave-dind') {
           def FMID = dockerImageS390x['path'].split('/').last().split('-').first()
           releaseArtifacts['docker-s390x'] = [:]
           releaseArtifacts['docker-s390x']['source'] = dockerImageS390x
-          releaseArtifacts['docker-s390x']['target'] = "zowe-v1-lts.s390x-${params.ZOWE_RELEASE_VERSION}.tar".toString()
+          releaseArtifacts['docker-s390x']['target'] = "server-bundle.s390x-${params.ZOWE_RELEASE_VERSION}.tar".toString()
         }
       } catch (e1) {
         echo ">>> no Docker image s390x version found in the build."
@@ -573,31 +573,31 @@ node('ibm-jenkins-slave-dind') {
         def manifestAmends = ""
         // load images
         if (releaseArtifacts['docker-amd64']) {
-          sh "docker load --input .release/zowe-v1-lts.amd64-*.tar"
+          sh "docker load --input .release/server-bundle.amd64-*.tar"
           if ("${USERNAME}" != "ompzowe") {
-            // the image in tar should always be ompzowe/zowe-v1-lts:amd64
-            sh "docker tag ompzowe/zowe-v1-lts:amd64 ${USERNAME}/zowe-v1-lts:amd64"
+            // the image in tar should always be ompzowe/server-bundle:amd64
+            sh "docker tag ompzowe/server-bundle:amd64 ${USERNAME}/server-bundle:amd64"
           }
-          publishCommands += "docker push ${USERNAME}/zowe-v1-lts:amd64\n"
-          manifestAmends += " --amend ${USERNAME}/zowe-v1-lts:amd64"
+          publishCommands += "docker push ${USERNAME}/server-bundle:amd64\n"
+          manifestAmends += " --amend ${USERNAME}/server-bundle:amd64"
         }
         if (releaseArtifacts['docker-s390x']) {
-          sh "docker load --input .release/zowe-v1-lts.s390x-*.tar"
+          sh "docker load --input .release/server-bundle.s390x-*.tar"
           if ("${USERNAME}" != "ompzowe") {
-            // the image in tar should always be ompzowe/zowe-v1-lts:s390x
-            sh "docker tag ompzowe/zowe-v1-lts:s390x ${USERNAME}/zowe-v1-lts:s390x"
+            // the image in tar should always be ompzowe/server-bundle:s390x
+            sh "docker tag ompzowe/server-bundle:s390x ${USERNAME}/server-bundle:s390x"
           }
-          publishCommands += "docker push ${USERNAME}/zowe-v1-lts:s390x\n"
-          manifestAmends += " --amend ${USERNAME}/zowe-v1-lts:s390x"
+          publishCommands += "docker push ${USERNAME}/server-bundle:s390x\n"
+          manifestAmends += " --amend ${USERNAME}/server-bundle:s390x"
         }
 
         // publish images
         sh publishCommands +
           "export DOCKER_CLI_EXPERIMENTAL=enabled\n" +
-          "docker manifest create ${USERNAME}/zowe-v1-lts:latest ${manifestAmends}\n" +
-          "docker manifest push ${USERNAME}/zowe-v1-lts:latest" +
-          "docker manifest create ${USERNAME}/zowe-v1-lts:v${params.ZOWE_RELEASE_VERSION} ${manifestAmends}\n" +
-          "docker manifest push ${USERNAME}/zowe-v1-lts:v${params.ZOWE_RELEASE_VERSION}"
+          "docker manifest create ${USERNAME}/server-bundle:latest ${manifestAmends}\n" +
+          "docker manifest push ${USERNAME}/server-bundle:latest" +
+          "docker manifest create ${USERNAME}/server-bundle:v${params.ZOWE_RELEASE_VERSION} ${manifestAmends}\n" +
+          "docker manifest push ${USERNAME}/server-bundle:v${params.ZOWE_RELEASE_VERSION}"
       }
     }
   )

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -159,20 +159,20 @@ $ ansible-playbook -l <server> install-docker.yml -v
 Please Note:
 
 - Similar to `install.yml` playbook, this playbook will install Zowe convenience build onto the target z/OS system, but only ZSS will be started on z/OS side. To customize which convenience build to start, `zowe_build_local` and `zowe_build_url` are also supported.
-- The playbook will also start Zowe on your computer in Docker container where this playbook is running. By default, the docker image been used is `ompzowe/zowe-v1-lts:amd64`. You can customize it with `zowe_docker_image` and `zowe_docker_tag` variables.
+- The playbook will also start Zowe on your computer in Docker container where this playbook is running. By default, the docker image been used is `ompzowe/server-bundle:amd64`. You can customize it with `zowe_docker_image` and `zowe_docker_tag` variables.
 - The install playbook will uninstall Zowe by default.
 - The `-v` option allows you to see stdout from server side, which includes installation log, etc.
 
 If you want to start container with a Zowe Docker image downloaded to your local computer, you can run the playbook with variable `zowe_docker_image_local`:
 
 ```
-$ ansible-playbook -l <server> install-docker.yml -v --extra-vars "zowe_docker_image_local=/path/to/your/local/zowe-v1-lts.tar"
+$ ansible-playbook -l <server> install-docker.yml -v --extra-vars "zowe_docker_image_local=/path/to/your/local/server-bundle.tar"
 ```
 
 If you want to start container with a Zowe Docker image from a URL, you can run the playbook with variable `zowe_docker_image_url`:
 
 ```
-$ ansible-playbook -l <server> install-docker.yml -v --extra-vars "zowe_docker_image_url=https://zowe.jfrog.io/zowe/libs-snapshot-local/org/zowe/1.18.0-STAGING/zowe-v1-lts-1.18.0.tar"
+$ ansible-playbook -l <server> install-docker.yml -v --extra-vars "zowe_docker_image_url=https://zowe.jfrog.io/zowe/libs-snapshot-local/org/zowe/1.18.0-STAGING/server-bundle-1.18.0.tar"
 ```
 
 For example, you can pick a downloadable Zowe build from https://zowe.jfrog.io/zowe/webapp/#/artifacts/browse/tree/General/libs-snapshot-local/org/zowe.

--- a/playbooks/roles/docker/defaults/main.yml
+++ b/playbooks/roles/docker/defaults/main.yml
@@ -7,7 +7,7 @@ wait_for_zowe_service_retries: 60
 # Every 10 seconds
 wait_for_zowe_service_delay: 5
 # zowe docker image
-zowe_docker_image: ompzowe/zowe-v1-lts
+zowe_docker_image: ompzowe/server-bundle
 zowe_docker_tag: amd64
 
 # ==============================================================================


### PR DESCRIPTION
Depends upon: https://github.com/zowe/zowe-dockerfiles/pull/24
This is a change just to the docker image name, for the purpose of identifying its purpose and allowing the version number to be independent of the name.
This should not impact behavior.