### PR TITLE
Add connection limit env properties

### DIFF
--- a/scripts/instance.template.env
+++ b/scripts/instance.template.env
@@ -42,6 +42,8 @@ APIML_SECURITY_AUTH_PROVIDER=zosmf
 ZWE_DISCOVERY_SERVICES_LIST=https://${ZOWE_EXPLORER_HOST}:${DISCOVERY_PORT}/eureka/
 # Enable debug logging for Api Mediation Layer services
 APIML_DEBUG_MODE_ENABLED=false
+APIML_MAX_CONNECTIONS_PER_ROUTE=100
+APIML_MAX_TOTAL_CONNECTIONS=1000
 ####################
 # caching service
 # TCP port of caching service


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

Add two environment properties to make API Gateway connection limit configurable by Zowe users. Required by https://github.com/zowe/api-layer/pull/985
