### PR TITLE
Update node versions

### DIFF
--- a/tests/installation/Jenkinsfile
+++ b/tests/installation/Jenkinsfile
@@ -171,7 +171,7 @@ node('zowe-jenkins-agent-dind') {
     // >>>>>>>> parametters for test cases
     choice(
       name: 'NODE_VERSION',
-      choices: ['v8.16.0', 'v6.17.0', 'v8.16.2', 'v8.17.0', 'v12.13.0', 'v12.14.1', 'v12.16.1'],
+      choices: ['v8.16.0', 'v8.17.0', 'v12.13.0', 'v12.16.1', 'v14.15.1'],
       description: 'This option is only valid for Marist server and specify node.js version on z/OS side. The installation will set NODE_HOME to /ZOWE/node/node-{{version}}-os390-s390x.',
       trim: true
     ),

--- a/tests/installation/src/__tests__/extended/node-versions/node-v14.ts
+++ b/tests/installation/src/__tests__/extended/node-versions/node-v14.ts
@@ -32,7 +32,7 @@ describe(testSuiteName, () => {
       testServer,
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
-        'zos_node_home': '/ZOWE/node/node-v6.17.0-os390-s390x',
+        'zos_node_home': '/ZOWE/node/node-v14.15.1-os390-s390x',
         'zowe_lock_keystore': 'false',
       }
     );


### PR DESCRIPTION
Signed-off-by: stevenhorsman <steven@uk.ibm.com>

#### Relevant issues
Part of #1830 

#### Changes proposed in this PR
- Remove v6 tests and add v14 test to bundle
- Add v14 option and remove obsolete options from test configuration