### PR TITLE
Only run js test files

### DIFF
--- a/playbooks/host_vars/marist-1.yml
+++ b/playbooks/host_vars/marist-1.yml
@@ -1,5 +1,5 @@
 ---
-zowe_sanity_test_testcases: "./test/**/!(api-doc-gen.js)"
+zowe_sanity_test_testcases: "./test/**/!(api-doc-gen).js"
 zowe_token_name: ZWETOKEN
 zowe_token_label: jwtsecret
 zowe_apiml_security_x509_enabled: true

--- a/playbooks/roles/verify/defaults/main.yml
+++ b/playbooks/roles/verify/defaults/main.yml
@@ -11,7 +11,7 @@ work_dir_local: .tmp
 # if run test in debug mode. for example, set to "test:*"
 zowe_sanity_test_debug_mode: ""
 # only run subset of test cases
-zowe_sanity_test_testcases: "\"./test/**/!(api-doc-gen.js)\" --exclude ./**/test-zss-via-gateway.js"
+zowe_sanity_test_testcases: "\"./test/**/!(api-doc-gen).js\" --exclude ./**/test-zss-via-gateway.js"
 # default folder of sanity test
 zowe_sanity_test_root_dir: ../tests/sanity
 


### PR DESCRIPTION
Signed-off-by: stevenhorsman <steven@uk.ibm.com>

#### PR type
- [X] Bugfix

#### Relevant issues
Fixes #1844 

#### Changes proposed in this PR
- Update test matcher to only include .js files