### PR TITLE
marist 1 has storage class defined, remove ZOWE02 volume specifications

### DIFF
--- a/.pax/post-packaging.sh
+++ b/.pax/post-packaging.sh
@@ -53,7 +53,7 @@ FMID=AZWE${FMID_VERSION}
 # to package on another server, we may need different settings
 export TMPDIR=/ZOWE/tmp
 SMPE_BUILD_HLQ=ZOWEAD3
-SMPE_BUILD_VOLSER=ZOWE02
+SMPE_BUILD_VOLSER=
 
 # write data sets list we want to clean up
 echo "${SMPE_BUILD_HLQ}.${RANDOM_MLQ}" > ${CURR_PWD}/cleanup-smpe-packaging-datasets.txt

--- a/playbooks/group_vars/marist.yml
+++ b/playbooks/group_vars/marist.yml
@@ -21,10 +21,7 @@ zowe_smpe_hlq_tzone: ZOWEAD3.SMPE
 zowe_smpe_hlq_dzone: ZOWEAD3.SMPE
 zowe_smpe_dir_prefix: /ZOWE/staging
 zowe_smpe_rel_file_prefix: ZOWEAD3
-zowe_smpe_volser: ZOWE02
 # marist server tn3270 port
 zowe_zlux_terminal_telnet_port: 623
 # optional, this is the folder where we store Zowe FMIDs on the z/OS server
 zowe_fmids_dir_remote: /ZOWE/zowe-fmids
-# caching service volume
-zowe_caching_vsam_volume: ZOWE02

--- a/playbooks/host_vars/marist-1.yml
+++ b/playbooks/host_vars/marist-1.yml
@@ -3,3 +3,8 @@ zowe_sanity_test_testcases: "./test/**/!(api-doc-gen).js"
 zowe_token_name: ZWETOKEN
 zowe_token_label: jwtsecret
 zowe_apiml_security_x509_enabled: true
+
+# smpe deployment volume, default will use storage class defined
+zowe_smpe_volser:
+# caching service volume, default will use storage class defined
+zowe_caching_vsam_volume:

--- a/playbooks/host_vars/marist-2.yml
+++ b/playbooks/host_vars/marist-2.yml
@@ -1,3 +1,8 @@
 ---
 zos_security_system: ACF2
 zowe_token_label: JWTSECRET
+
+# smpe deployment volume
+zowe_smpe_volser: ZOWE02
+# caching service volume
+zowe_caching_vsam_volume: ZOWE02

--- a/playbooks/host_vars/marist-3.yml
+++ b/playbooks/host_vars/marist-3.yml
@@ -1,2 +1,7 @@
 ---
 zos_security_system: TSS
+
+# smpe deployment volume
+zowe_smpe_volser: ZOWE02
+# caching service volume
+zowe_caching_vsam_volume: ZOWE02

--- a/playbooks/roles/configure/tasks/create_vsam_dataset.yml
+++ b/playbooks/roles/configure/tasks/create_vsam_dataset.yml
@@ -28,11 +28,6 @@
     msg: zowe_caching_vsam_storage_class is required
   when: zos_vsam_rls and (zowe_caching_vsam_storage_class is not defined or zowe_caching_vsam_storage_class is none or zowe_caching_vsam_storage_class == '')
 
-- name: Check if zowe_caching_vsam_volume has a value
-  fail:
-    msg: zowe_caching_vsam_volume is required
-  when: not zos_vsam_rls and (zowe_caching_vsam_volume is not defined or zowe_caching_vsam_volume is none or zowe_caching_vsam_volume == '')
-
 - name: Set caching service vsam data set name
   set_fact:
     zowe_caching_service_vsam_dsname: "{{ zowe_dataset_prefix }}.{{ zowe_caching_service_vsam_dsprefix }}{{ zowe_instance_id }}"
@@ -50,7 +45,8 @@
     cat "{{ work_dir_remote }}/ZWECSVSM.raw.jcl" | \
     sed -e "48,999s/#dsname/{{ zowe_caching_service_vsam_dsname }}/g" | \
     sed -e "48,999s/#storclas/{{ zowe_caching_vsam_storage_class }}/g" | \
-    sed -e "48,999s/#volume/{{ zowe_caching_vsam_volume }}/" \
+    sed -e "48,999s/#volume/{{ zowe_caching_vsam_volume }}/" | \
+    sed -e '/VOLUME()/d' \
     > "{{ work_dir_remote }}/ZWECSVSM.jcl"
 
 - name: Set ZWEVSVSM job MODE configuration


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [x] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Relevant issues
<!-- Link to a relevant GitHub issue if any. If this PR applies to multiple issues, preface each issue reference with the "Fixes" keyword. For example, Fixes #123, Fixes #456. -->

Fixes build failure related to volume allocation on marist systems.

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
- remove ZOWE02 volume configuration for marist 1 system.
- make VOLUME optional when creating caching api VSAM dataset.

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [x] No
