### PR TITLE
fix test failures with node v12.16.1 and add v12.18.4 into test

### DIFF
--- a/tests/installation/Jenkinsfile
+++ b/tests/installation/Jenkinsfile
@@ -161,7 +161,7 @@ node('zowe-jenkins-agent-dind-wdc') {
     // >>>>>>>> parametters for test cases
     choice(
       name: 'NODE_VERSION',
-      choices: ['v8.16.0', 'v8.17.0', 'v12.13.0', 'v12.16.1', 'v14.15.1'],
+      choices: ['v8.16.0', 'v8.17.0', 'v12.13.0', 'v12.16.1', 'v12.18.4', 'v14.15.1'],
       description: 'This option is only valid for Marist server and specify node.js version on z/OS side. The installation will set NODE_HOME to /ZOWE/node/node-{{version}}-os390-s390x.',
       trim: true
     ),

--- a/tests/installation/src/__tests__/extended/node-versions/node-v12.ts
+++ b/tests/installation/src/__tests__/extended/node-versions/node-v12.ts
@@ -32,7 +32,7 @@ describe(testSuiteName, () => {
       testServer,
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
-        'zos_node_home': '/ZOWE/node/node-v12.16.1-os390-s390x',
+        'zos_node_home': '/ZOWE/node/node-v12.18.4-os390-s390x',
         'zowe_lock_keystore': 'false',
       }
     );

--- a/tests/sanity/test/utils-scripts/test-component-utils.js
+++ b/tests/sanity/test/utils-scripts/test-component-utils.js
@@ -92,7 +92,7 @@ describe('verify utils/component-utils', function() {
     it('test reading component name', async function() {
       const component = 'jobs-api';
       await test_component_function_has_expected_rc_stdout_stderr(
-        `echo \$(${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".name")`,
+        'echo $' + `(${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".name")`,
         {},
         {
           stdout: component,
@@ -103,7 +103,7 @@ describe('verify utils/component-utils', function() {
     it('test reading component commands.start', async function() {
       const component = 'jobs-api';
       await test_component_function_has_expected_rc_stdout_stderr(
-        `echo \$(${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".commands.start")`,
+        'echo $' + `(${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".commands.start")`,
         {},
         {
           stdout: 'bin/start.sh',
@@ -114,7 +114,7 @@ describe('verify utils/component-utils', function() {
     it('test reading non-existing component manifest entry', async function() {
       const component = 'jobs-api';
       await test_component_function_has_expected_rc_stdout_stderr(
-        `echo \$(${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".commands.somethingDoesNotExist")`,
+        'echo $' + `(${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".commands.somethingDoesNotExist")`,
         {},
         {
           stdout: 'null',
@@ -125,7 +125,7 @@ describe('verify utils/component-utils', function() {
     it('test reading component manifest entry with wrong definition', async function() {
       const component = 'jobs-api';
       await test_component_function_has_expected_rc_stdout_stderr(
-        `echo \$(${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".commands[].start")`,
+        'echo $' + `(${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".commands[].start")`,
         {},
         {
           rc: 0,

--- a/tests/sanity/test/utils-scripts/test-component-utils.js
+++ b/tests/sanity/test/utils-scripts/test-component-utils.js
@@ -125,11 +125,11 @@ describe('verify utils/component-utils', function() {
     it('test reading component manifest entry with wrong definition', async function() {
       const component = 'jobs-api';
       await test_component_function_has_expected_rc_stdout_stderr(
-        'echo $' + `(${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".commands[].start")`,
+        'echo $' + `(${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".commands[].start" 2>&1)`,
         {},
         {
           rc: 0,
-          stderr: 'Error: Cannot iterate over object',
+          stdout: 'Error: Cannot iterate over object',
         }
       );
     });

--- a/tests/sanity/test/utils-scripts/test-component-utils.js
+++ b/tests/sanity/test/utils-scripts/test-component-utils.js
@@ -92,7 +92,7 @@ describe('verify utils/component-utils', function() {
     it('test reading component name', async function() {
       const component = 'jobs-api';
       await test_component_function_has_expected_rc_stdout_stderr(
-        `${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".name"`,
+        `echo \$(${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".name")`,
         {},
         {
           stdout: component,
@@ -103,7 +103,7 @@ describe('verify utils/component-utils', function() {
     it('test reading component commands.start', async function() {
       const component = 'jobs-api';
       await test_component_function_has_expected_rc_stdout_stderr(
-        `${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".commands.start"`,
+        `echo \$(${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".commands.start")`,
         {},
         {
           stdout: 'bin/start.sh',
@@ -114,7 +114,7 @@ describe('verify utils/component-utils', function() {
     it('test reading non-existing component manifest entry', async function() {
       const component = 'jobs-api';
       await test_component_function_has_expected_rc_stdout_stderr(
-        `${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".commands.somethingDoesNotExist"`,
+        `echo \$(${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".commands.somethingDoesNotExist")`,
         {},
         {
           stdout: 'null',
@@ -125,10 +125,10 @@ describe('verify utils/component-utils', function() {
     it('test reading component manifest entry with wrong definition', async function() {
       const component = 'jobs-api';
       await test_component_function_has_expected_rc_stdout_stderr(
-        `${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".commands[].start"`,
+        `echo \$(${read_component_manifest} "${process.env.ZOWE_ROOT_DIR}/components/${component}" ".commands[].start")`,
         {},
         {
-          rc: 1,
+          rc: 0,
           stderr: 'Error: Cannot iterate over object',
         }
       );


### PR DESCRIPTION
<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [x] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Relevant issues
<!-- Link to a relevant GitHub issue if any. If this PR applies to multiple issues, preface each issue reference with the "Fixes" keyword. For example, Fixes #123, Fixes #456. -->

Fixes test failures of `read_component_manifest` with node v12.16.1. This failure doesn't block Zowe from starting up properly. The output of `read_component_manifest` will be passed to shell script and encoding will be handled properly. But if return the node output directly to SSH command, like what test is doing, it's not readable.

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
- The direct output from node.js is in ISO8859-1 encoding and need a shell echo wrapper to convert it to IBM-1047 and then it can be displayed properly.
- Add v12.18.4 to test scenarios.

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [x] No
