### PR TITLE
Downgrade caching service

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -97,7 +97,7 @@
       "artifact": "gateway*.zip"
     },
     "org.zowe.apiml.sdk.caching-service-package": {
-      "version": "1.19.2",
+      "version": "1.19.1",
       "artifact": "caching-service*.zip"
     },
     "org.zowe.apiml.sdk.apiml-common-lib-package": {


### PR DESCRIPTION
Signed-off-by: stevenhorsman <steven@uk.ibm.com>

#### Relevant issues
Part of #1913 

#### Changes proposed in this PR
- Downgrade caching service as 1.19.2 was failing tests
