### PR TITLE
surpress deprecated warnings for core components

### DIFF
--- a/bin/internal/prepare-workspace.sh
+++ b/bin/internal/prepare-workspace.sh
@@ -99,7 +99,9 @@ validate_components() {
       validate_script=$(read_component_manifest "${component_dir}" ".commands.validate" 2>/dev/null)
       if [ -z "${validate_script}" -o "${validate_script}" = "null" ]; then
         # backward compatible purpose
-        print_formatted_warn "${LOGGING_SERVICE_ID}" "${LOGGING_SCRIPT_NAME}:${LINENO}" "- unable to determine validate script from component ${component_id} manifest, fall back to default bin/validate.sh"
+        if [ $(is_core_component "${component_dir}") != "true" ]; then
+          print_formatted_warn "${LOGGING_SERVICE_ID}" "${LOGGING_SCRIPT_NAME}:${LINENO}" "- unable to determine validate script from component ${component_id} manifest, fall back to default bin/validate.sh"
+        fi
         validate_script=bin/validate.sh
       fi
       if [ -x "${validate_script}" ]; then
@@ -195,7 +197,9 @@ configure_components() {
       configure_script=$(read_component_manifest "${component_dir}" ".commands.configure" 2>/dev/null)
       if [ -z "${configure_script}" -o "${configure_script}" = "null" ]; then
         # backward compatible purpose
-        print_formatted_warn "${LOGGING_SERVICE_ID}" "${LOGGING_SCRIPT_NAME}:${LINENO}" "* unable to determine configure script from component ${component_id} manifest, fall back to default bin/configure.sh"
+        if [ $(is_core_component "${component_dir}") != "true" ]; then
+          print_formatted_warn "${LOGGING_SERVICE_ID}" "${LOGGING_SCRIPT_NAME}:${LINENO}" "* unable to determine configure script from component ${component_id} manifest, fall back to default bin/configure.sh"
+        fi
         configure_script=bin/configure.sh
       fi
       if [ -x "${configure_script}" ]; then

--- a/bin/internal/start-component.sh
+++ b/bin/internal/start-component.sh
@@ -65,7 +65,9 @@ export LAUNCH_COMPONENT="${component_dir}/bin"
 start_script=$(read_component_manifest "${component_dir}" ".commands.start" 2>/dev/null)
 if [ -z "${start_script}" -o "${start_script}" = "null" ]; then
   # backward compatible purpose
-  print_formatted_warn "${LOGGING_SERVICE_ID}" "${LOGGING_SCRIPT_NAME}:${LINENO}" "unable to determine start script from component ${component_id} manifest, fall back to default bin/start.sh"
+  if [ $(is_core_component "${component_dir}") != "true" ]; then
+    print_formatted_warn "${LOGGING_SERVICE_ID}" "${LOGGING_SCRIPT_NAME}:${LINENO}" "unable to determine start script from component ${component_id} manifest, fall back to default bin/start.sh"
+  fi
   start_script=${component_dir}/bin/start.sh
 fi
 if [ -n "${component_dir}" ]; then

--- a/bin/utils/component-utils.sh
+++ b/bin/utils/component-utils.sh
@@ -58,6 +58,21 @@ find_component_directory() {
 }
 
 ###############################
+# Check if component is core component
+#
+# Required environment variables:
+# - ROOT_DIR
+#
+# @param string     component directory
+# Output            true|false
+is_core_component() {
+  component_dir=$1
+
+  core_component_dir=${ROOT_DIR}/components
+  [[ $component_dir == "${core_component_dir}"* ]] && echo true || echo false
+}
+
+###############################
 # Detect and verify file encoding
 #
 # This function will try to verify file encoding by reading sample string.

--- a/tests/sanity/test/utils-scripts/test-component-utils.js
+++ b/tests/sanity/test/utils-scripts/test-component-utils.js
@@ -17,6 +17,7 @@ describe('verify utils/component-utils', function() {
   const TMP_EXT_DIR = 'sanity_test_extensions';
   const dummy_component_name = 'sanity_test_dummy';
   let component_runtime_dir;
+  let component_instance_dir;
 
   before('prepare SSH connection', async function() {
     await sshHelper.prepareConnection();
@@ -31,6 +32,7 @@ describe('verify utils/component-utils', function() {
     TMP_DIR = tmpOnServer || '/tmp';
     debug(`TMP_DIR=${TMP_DIR}`);
     component_runtime_dir = `${TMP_DIR}/${TMP_EXT_DIR}/${dummy_component_name}`;
+    component_instance_dir = `${process.env.ZOWE_INSTANCE_DIR}/workspace/${dummy_component_name}`;
   });
 
   const find_component_directory = 'find_component_directory';
@@ -82,6 +84,39 @@ describe('verify utils/component-utils', function() {
           false
         );
       });
+    });
+
+  });
+
+  const is_core_component = 'is_core_component';
+  describe(`verify ${is_core_component}`, function() {
+    before('create test component', async function() {
+      await sshHelper.executeCommandWithNoError(`rm -rf ${component_runtime_dir} && mkdir -p ${component_runtime_dir} && rm -fr ${component_instance_dir} && echo 'name: ${dummy_component_name}' > ${component_runtime_dir}/manifest.yaml`);
+    });
+
+    after('dispose test component', async function() {
+      await sshHelper.executeCommandWithNoError(`rm -rf ${component_runtime_dir} && rm -fr ${component_instance_dir}`);
+    });
+
+    it('test with core component', async function() {
+      const component = 'jobs-api';
+      await test_component_function_has_expected_rc_stdout_stderr(
+        'echo $' + `(${is_core_component} "` + '$' + `(find_component_directory ${component})")`,
+        {},
+        {
+          stdout: 'true',
+        }
+      );
+    });
+
+    it('test with non-core component', async function() {
+      await test_component_function_has_expected_rc_stdout_stderr(
+        'echo $' + `(${is_core_component} "` + '$' + `(find_component_directory ${dummy_component_name})")`,
+        {},
+        {
+          stdout: 'false',
+        }
+      );
     });
 
   });
@@ -201,8 +236,6 @@ describe('verify utils/component-utils', function() {
 
   const convert_component_manifest = 'convert_component_manifest';
   describe(`verify ${convert_component_manifest}`, function() {
-    const component_instance_dir = `${process.env.ZOWE_INSTANCE_DIR}/workspace/${dummy_component_name}`;
-
     before('create test component', async function() {
       await sshHelper.executeCommandWithNoError(`rm -rf ${component_runtime_dir} && mkdir -p ${component_runtime_dir} && rm -fr ${component_instance_dir} && echo 'name: ${dummy_component_name}' > ${component_runtime_dir}/manifest.yaml`);
     });


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Relevant issues
<!-- Link to a relevant GitHub issue if any. If this PR applies to multiple issues, preface each issue reference with the "Fixes" keyword. For example, Fixes #123, Fixes #456. -->

Currently zowe runtime log will show deprecated messages like these:
- unable to determine validate script from component zss manifest, fall back to default bin/validate.sh
- unable to determine configure script from component zss manifest, fall back to default bin/configure.sh
- unable to determine start script from component app-server manifest, fall back to default bin/start.sh

They are redundant since we know what we should do on core components.

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
- Remove those warnings for core components.

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [x] No
