### PR TITLE
Introduce size of the Cache in the environment vavriables.

### DIFF
--- a/scripts/instance.template.env
+++ b/scripts/instance.template.env
@@ -48,6 +48,10 @@ APIML_MAX_TOTAL_CONNECTIONS=1000
 # caching service
 # TCP port of caching service
 ZWE_CACHING_SERVICE_PORT=7555
+# specify amount of records before eviction strategies start evicting
+ZWE_CACHING_STORAGE_SIZE=10000
+# specify eviction strategy to be used when the storage size is achieved
+ZWE_CACHING_EVICTION_STRATEGY=reject
 # specify persistent method of caching service
 # currently VSAM is the only option
 ZWE_CACHING_SERVICE_PERSISTENT=VSAM


### PR DESCRIPTION
The caching service startup was failing because it needed to add two properties for a startup. The properties are added with the default values in this PR. 

