### PR TITLE
Update Zowe CLI components for 1.19.1 bundle

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -123,7 +123,7 @@
       "componentGroup": "Imperative CLI Framework for Zowe",
       "entries": [{
         "repository": "imperative",
-        "tag": "v4.10.2",
+        "tag": "v4.11.0",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
@@ -195,7 +195,7 @@
       "componentGroup": "Zowe CLI",
       "entries": [{
         "repository": "zowe-cli",
-        "tag": "v6.25.1",
+        "tag": "v6.26.0",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {


### PR DESCRIPTION
Changes in Imperative v4.11.0:
* Enhancement: Fixed plugin install commands which were broken in npm@7. [#457](https://github.com/zowe/imperative/issues/457)
* BugFix: Fixed incorrect formatting of code blocks in web help. [#535](https://github.com/zowe/imperative/issues/535)

Changes in Zowe CLI v6.26.0:
* Enhancement: Updated Imperative version to support npm@7. This fixes an error when installing plugins.