### PR TITLE
PTF HTML cleanup, & build tweak to halt on unexpected PTF count

### DIFF
--- a/smpe/bld/ptf-split.rex
+++ b/smpe/bld/ptf-split.rex
@@ -275,7 +275,7 @@ return PTFs    /* _minCount */
 
 /*---------------------------------------------------------------------
  * --- determine how to distribute parts among PTFs
- * Returns nothing
+ * Returns return code
  * Args: /
  */
 _distribute: PROCEDURE EXPOSE ExecName Debug !Vars.

--- a/smpe/bld/ptf-split.rex
+++ b/smpe/bld/ptf-split.rex
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Copyright Contributors to the Zowe Project. 2019, 2019
+ * Copyright Contributors to the Zowe Project. 2019, 2021
  */
 /*
  *% Determine how to distribute parts among PTFs (sent to stdout).
@@ -47,7 +47,7 @@ if Debug then do; say ''; say '>' ExecName Args; end
 
 /* split startup arguments in multiple vars */
 parse var Args File !Vars.!Hdr1 !Vars.!Hdr2 !Vars.!Reserved Trash
-parse value !Vars.!Reserved 1 with !Vars.!Reserved .   /* default: 1 */
+parse value !Vars.!Reserved 0 with !Vars.!Reserved .   /* default: 0 */
 
 /* validate startup arguments */
 if File == ''
@@ -100,7 +100,7 @@ then do               /* unable to establish the SYSCALL environment */
 end    /* */
 
 if _readFile(File)                          /* get size of each part */
-  then call _distribute               /* determine part distribution */
+  then cRC=_distribute()              /* determine part distribution */
   else cRC=8
 
 if ExecEnv <> 'OMVS' then call syscalls 'OFF'           /* ignore RC */
@@ -205,6 +205,7 @@ return @Success    /* _syscall */
  * Updates:
  *  !Vars.!Lines.*: list of line counts
  *  !Vars.!Parts.*: list of part names
+ *  !Vars.!Total: total line count
  * Args:
  *  File: path of file to interpret
  */
@@ -269,9 +270,6 @@ do while !Vars.!Parts.0 > (PTFs * 900)      /* max 900 parts per PTF */
   PTFs=PTFs+1
 end    /* while parts */
 
-/* caller expects to use !Vars.!Reserved PTFs, so do as expected */
-if PTFs < !Vars.!Reserved then PTFs=!Vars.!Reserved
-
 if Debug then say '< _minCount' PTFs
 return PTFs    /* _minCount */
 
@@ -283,6 +281,7 @@ return PTFs    /* _minCount */
 _distribute: PROCEDURE EXPOSE ExecName Debug !Vars.
 if Debug then say '> _distribute'
 OK=0  /* FALSE */          /* assume we need more than minCount PTFs */
+cRC=0                                   /* assume everything is good */
 
 PTFs=_minCount()                 /* determine minimum number of PTFs */
 
@@ -323,6 +322,15 @@ do until OK                   /* repeat until we can place all parts */
   end    /* */
 end    /* until OK */
 
+/* does caller expect to use !Vars.!Reserved PTFs ? */
+if !Vars.!Reserved <> 0
+then if PTFs <> !Vars.!Reserved 
+  then do
+  say '** ERROR' ExecName 'actual PTF count ('PTFs') does not match' ,
+    'reserved PTF count ('!Vars.!Reserved')'
+  cRC=8  
+  end    /* */
+
 /* write result to stdout, line 1 has parts for PTF 1, line 2 ... */
 do T=1 to PTFs
   if Debug then
@@ -331,5 +339,5 @@ do T=1 to PTFs
 end    /* loop T */
 
 if Debug then say '< _distribute'
-return    /* _distribute */
+return cRC    /* _distribute */
 

--- a/smpe/bld/smpe-service.sh
+++ b/smpe/bld/smpe-service.sh
@@ -7,7 +7,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-# Copyright Contributors to the Zowe Project. 2019, 2019
+# Copyright Contributors to the Zowe Project. 2019, 2021
 #######################################################################
 
 #% package prepared product as service (++USERMOD, ++APAR, ++PTF)
@@ -904,6 +904,7 @@ do
   coreq="$coreq $sysmod"
 done < $ptf/$tracksCoreq    # while read         # all but first sysmod
 coreq=$(echo $coreq)                              # strip leading blank
+test -z "$coreq" && coreq="none"   # dummy value if there are no coreqs
 test $debug && echo "coreq=$coreq"
 
 # customize common variables


### PR DESCRIPTION
<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [x] Other... Please describe:
1. the HTML with PTF install instructions needs a small cosmetic tweak when we ship only 1 PTF
2. the build process is updated to halt the build when it is creating a different number of PTFs than listed in ptf-bucket.txt

#### Relevant issues
<!-- Link to a relevant GitHub issue if any. If this PR applies to multiple issues, preface each issue reference with the "Fixes" keyword. For example, Fixes #123, Fixes #456. -->

Fixes <!-- Issue number -->

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
- The HTML with PTF install instructions needs a small cosmetic tweak when we ship only 1 PTF.
- The build process is updated to halt the build when it is creating a different number of PTFs than listed in ptf-bucket.txt. When this happens, zowe-install-packaging\smpe\bld\service\ptf-bucket.txt must be updated to list the correct number of PTFs for this build. This way we ensure the community build will stay in sync with IBM's Shopz processing.

`** ERROR ptf-split.rex actual PTF count (1) does not match reserved PTF count (2)`

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path below.-->

#### Does this PR do something the person installing Zowe should know about?

<!-- Is this a fix or a feature that changes customizable files (e.g. configuration files, sample JCL, etc),
product requirements, or other installation or configuration related area? If so, please fill out the template below. 
There is no need to report the need to restart the servers to activate the change. Note that the provided text will be formatted in 64-character lines, and that round brackets, ( and ), must always be used in matching pairs. -->

---
* Affected function: _general area of interest_ *

---
* Description: _1 line description_ *

---
* Part: _name of customizable file involved_  *

---
_multi-line description_

#### Is there a related doc issue or Pull Request? 
<!-- Link to a relevant documentation issue or Pull Request if any. -->

Doc issue/PR number: 

#### Other information

