### PR TITLE
Assign zowe docker user to same group as mounted volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
+## `1.20.0`
+
+### New features and enhancements
+- server-bundle docker image has been optimized to greatly reduce the size without impacting the content and usability
+- server-bundle docker image now runs zowe under the user "zowe", and the default mount locations of instance, keystore, and plugins directories is now within /home/zowe as a result
+
 ## `1.17.0`
 
 ### New features and enhancements

--- a/containers/server-bundle/Dockerfile
+++ b/containers/server-bundle/Dockerfile
@@ -41,7 +41,7 @@ RUN cd /home/zowe/utils/autoconv && \
     ln -s ./autoconv/bin/autoconv ../autoconv.sh
 
 # copy run.sh and optional zowe.pax
-COPY run.sh /home/zowe
+COPY run.sh run_inner.sh /home/zowe/
 COPY zowe.pax* /tmp
 
 # download zowe build if specified
@@ -50,7 +50,8 @@ RUN /home/zowe/utils/download-zowe-build.sh "${ZOWE_BUILD}"
 # 1. Convert content of pax files from ebcdic to ASCII
 # 2. replace or remove some zos specific parameters
 # 3. Install zowe, then remove installer files
-RUN mkdir -p /tmp/zowe-install && cd /tmp/zowe-install && \
+RUN mv /home/zowe/run_inner.sh /home/zowe/.run_inner.sh && \
+    mkdir -p /tmp/zowe-install && cd /tmp/zowe-install && \
     tar -xvf ../zowe.pax --strip 1 && \
     find . -type f -iregex '.*\.\(rexx\|js\|sh\|json\|jcl\|yaml\|clist\|env\)$' -exec sh -c "conv '{}' | sponge '{}'" \; && \
     find . -type f -name '*.sh' -exec sh -c "sed -i 's/-Xquickstart//' {}" \; && \
@@ -123,7 +124,5 @@ ENV ZWED_agent_http_port='8542'
 ENV LAUNCH_COMPONENT_GROUPS=DESKTOP,GATEWAY
 
 COPY --chown=zowe:zowe --from=builder /home/zowe /home/zowe
-
-USER zowe
 
 ENTRYPOINT ["/home/zowe/run.sh"]

--- a/containers/server-bundle/run.sh
+++ b/containers/server-bundle/run.sh
@@ -2,6 +2,7 @@
 
 if [[ "$ZOWE_START" == "0" ]]
 then
+    su zowe
     sleep infinity
 else
 
@@ -39,73 +40,31 @@ else
 	export INSTANCE_DIR=$EXTERNAL_INSTANCE
 fi
 
-if [ -d "${apps_dir}" ]; then
-  export ZLUX_ROOT=/home/zowe/install/components/app-server/share
-  cd ${apps_dir}
-  for D in */;
-   do
-    if test -f "$D/autoinstall.sh"; then
-      app=$(cd $D && pwd)
-      ZLUX_ROOT=$ZLUX_ROOT APP_PLUGIN_DIR=app ./$D/autoinstall.sh
-    elif test -f "$D/pluginDefinition.json"; then
-        $INSTANCE_DIR/bin/install-app.sh ${apps_dir}/$D
-    elif test -f "$D/manifest.yaml"; then
-        $ROOT_DIR/bin/zowe-install-component.sh -o ${apps_dir}/$D -i $INSTANCE_DIR
-    elif test -f "D/manifest.yml"; then
-        $ROOT_DIR/bin/zowe-install-component.sh -o ${apps_dir}/$D -i $INSTANCE_DIR
-    elif test -f "D/manifest.json"; then
-        $ROOT_DIR/bin/zowe-install-component.sh -o ${apps_dir}/$D -i $INSTANCE_DIR
-    fi
-  done
-fi
-
-if [ ! -d "${certs_dir}" ]; then
-    input1="/home/zowe/install/bin/zowe-setup-certificates.env.bkp"
-    while read -r line
-    do
-        test -z "${line%%#*}" && continue      # skip line if first char is #
-        key=${line%%=*}
-        if [ -n "${!key}" ]
-        then
-            echo "Replacing key=${key} with val=${!key}"
-            sed -i 's@'${key}'=.*@'${key}'='"${!key}"'@g' /home/zowe/install/bin/zowe-setup-certificates.env
+#Sync user 'zowe' to be in the same groups as the first file seen in each mounted config dir
+for D in "$certs_dir" "$apps_dir" "$EXTERNAL_INSTANCE"
+do
+    # echo "Acting on $D if exists"
+    if [ -d "$D" ]; then
+        ls -ltr $D
+        group=$(ls -g $D | cut -d " " -f 3 | sed '2!d')
+        # echo "Group in $D is $group"
+        if [ "$group" != "root" ]; then
+            exists=$(grep $group /etc/group | cut -f 1 -d ':')
+            # echo "Matching group? Found: $exists"
+            if [ "$group" != "$exists" ]; then
+                echo "Adding missing container group"
+                groupadd -g $group zowe_${group}
+            fi
+            ingid=$(id zowe | grep "gid=${group}(")
+            ingroup=$(id zowe | grep "(${group})")
+            if [ -z "$ingid" -a -z "$ingroup" ]; then 
+                echo "Added zowe to container group, zowe now in groups:"
+                usermod --groups zowe_${group} zowe
+                id zowe
+            fi
         fi
-    done < "$input1"
-
-#correct the replacements for the few env vars we dont want the user to override simply by env var alone
-    sed -i 's/ZOWE_USER_ID=ZWESVUSR/ZOWE_USER_ID=zowe/g' /home/zowe/install/bin/zowe-setup-certificates.env
-    sed -i 's/ZOWE_GROUP_ID=ZWEADMIN/ZOWE_GROUP_ID=zowe/g' /home/zowe/install/bin/zowe-setup-certificates.env
-
-    if [ -z "$VERIFY_CERTIFICATES" ]; then
-        sed -i 's/VERIFY_CERTIFICATES=true/VERIFY_CERTIFICATES=false/g' /home/zowe/install/bin/zowe-setup-certificates.env
     fi
-    sed -i 's/HOSTNAME=.*/HOSTNAME='"${ZOWE_EXPLORER_HOST}"'/g' /home/zowe/install/bin/zowe-setup-certificates.env
-    sed -i 's/IPADDRESS=.*/IPADDRESS='"${ZOWE_IP_ADDRESS}"'/g' /home/zowe/install/bin/zowe-setup-certificates.env
+done
 
-#cat /home/zowe/install/bin/zowe-setup-certificates.env
-
-    /home/zowe/install/bin/zowe-setup-certificates.sh
-    sed -i 's/-ebcdic//' /global/zowe/keystore/zowe-certificates.env
-fi
-
-
-if [ ! -d "/home/zowe/external_instance" ]; then
-    cp /home/zowe/instance/instance.env.bkp /home/zowe/instance/instance.env
-
-    input2="/home/zowe/instance/instance.env.bkp"
-    while read -r line
-    do
-        test -z "${line%%#*}" && continue      # skip line if first char is #
-        key=${line%%=*}
-        if [ -n "${!key}" ]
-        then
-            echo "Replacing key=${key} with val=${!key}"
-            sed -i 's@'${key}'=.*@'${key}'='"${!key}"'@g' /home/zowe/instance/instance.env
-        fi
-    done < "$input2"
-fi
-
-bash /home/zowe/instance/bin/internal/run-zowe.sh
-sleep infinity
-
+su -c "/home/zowe/.run_inner.sh" zowe
 fi

--- a/containers/server-bundle/run_inner.sh
+++ b/containers/server-bundle/run_inner.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+if [ -d "${apps_dir}" ]; then
+  export ZLUX_ROOT=/home/zowe/install/components/app-server/share
+  cd ${apps_dir}
+  for D in */;
+   do
+    if test -f "$D/autoinstall.sh"; then
+      app=$(cd $D && pwd)
+      ZLUX_ROOT=$ZLUX_ROOT APP_PLUGIN_DIR=app ./$D/autoinstall.sh
+    elif test -f "$D/pluginDefinition.json"; then
+        $INSTANCE_DIR/bin/install-app.sh ${apps_dir}/$D
+    elif test -f "$D/manifest.yaml"; then
+        $ROOT_DIR/bin/zowe-install-component.sh -o ${apps_dir}/$D -i $INSTANCE_DIR
+    elif test -f "D/manifest.yml"; then
+        $ROOT_DIR/bin/zowe-install-component.sh -o ${apps_dir}/$D -i $INSTANCE_DIR
+    elif test -f "D/manifest.json"; then
+        $ROOT_DIR/bin/zowe-install-component.sh -o ${apps_dir}/$D -i $INSTANCE_DIR
+    fi
+  done
+fi
+
+if [ ! -d "${certs_dir}" ]; then
+    input1="/home/zowe/install/bin/zowe-setup-certificates.env.bkp"
+    while read -r line
+    do
+        test -z "${line%%#*}" && continue      # skip line if first char is #
+        key=${line%%=*}
+        if [ -n "${!key}" ]
+        then
+            echo "Replacing key=${key} with val=${!key}"
+            sed -i 's@'${key}'=.*@'${key}'='"${!key}"'@g' /home/zowe/install/bin/zowe-setup-certificates.env
+        fi
+    done < "$input1"
+
+#correct the replacements for the few env vars we dont want the user to override simply by env var alone
+    sed -i 's/ZOWE_USER_ID=ZWESVUSR/ZOWE_USER_ID=zowe/g' /home/zowe/install/bin/zowe-setup-certificates.env
+    sed -i 's/ZOWE_GROUP_ID=ZWEADMIN/ZOWE_GROUP_ID=zowe/g' /home/zowe/install/bin/zowe-setup-certificates.env
+
+    if [ -z "$VERIFY_CERTIFICATES" ]; then
+        sed -i 's/VERIFY_CERTIFICATES=true/VERIFY_CERTIFICATES=false/g' /home/zowe/install/bin/zowe-setup-certificates.env
+    fi
+    sed -i 's/HOSTNAME=.*/HOSTNAME='"${ZOWE_EXPLORER_HOST}"'/g' /home/zowe/install/bin/zowe-setup-certificates.env
+    sed -i 's/IPADDRESS=.*/IPADDRESS='"${ZOWE_IP_ADDRESS}"'/g' /home/zowe/install/bin/zowe-setup-certificates.env
+
+#cat /home/zowe/install/bin/zowe-setup-certificates.env
+
+    /home/zowe/install/bin/zowe-setup-certificates.sh
+    sed -i 's/-ebcdic//' /global/zowe/keystore/zowe-certificates.env
+fi
+
+
+if [ ! -d "/home/zowe/external_instance" ]; then
+    cp /home/zowe/instance/instance.env.bkp /home/zowe/instance/instance.env
+
+    input2="/home/zowe/instance/instance.env.bkp"
+    while read -r line
+    do
+        test -z "${line%%#*}" && continue      # skip line if first char is #
+        key=${line%%=*}
+        if [ -n "${!key}" ]
+        then
+            echo "Replacing key=${key} with val=${!key}"
+            sed -i 's@'${key}'=.*@'${key}'='"${!key}"'@g' /home/zowe/instance/instance.env
+        fi
+    done < "$input2"
+fi
+
+bash /home/zowe/instance/bin/internal/run-zowe.sh
+sleep infinity


### PR DESCRIPTION
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [x] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
Recent changes to the docker image to run as user=zowe presented an issue where mounted volumes might have group permissions that did not match the docker image due to the docker image not having the same groups.
However, users can control whether docker mounts are read or read-write regardless of file permissions, so if the volume is writable, zowe should be able to make use of group-level permissions. Therefore, this change assigns zowe to the group seen within each mount folder before starting the servers. This has no impact on the host system, its just aligning the container to be more compatible with the mounts. The alternative would have been to tell users to set up group ids before running zowe in order to match what exists out of the box on the container, which is unecessary work if it can be automated such as in this PR.

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path below.-->
