### PR TITLE
Test build for ZSS TLS

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -12,7 +12,7 @@
   },
   "binaryDependencies": {
     "org.zowe.zlux.zlux-core": {
-      "version": "~1.20.0-STAGING",
+      "version": "~1.20.0-271-S-151-S-S-S",
       "artifact": "*.pax"
     },
     "org.zowe.zlux.zss-auth": {
@@ -52,7 +52,7 @@
       "artifact": "*.pax"
     },
     "org.zowe.zss": {
-      "version": "~1.20.0-STAGING",
+      "version": "~1.20.0-PR-260",
       "artifact": "*.pax"
     },
     "org.zowe.explorer.jobs": {

--- a/scripts/instance.template.env
+++ b/scripts/instance.template.env
@@ -66,10 +66,11 @@ MVS_EXPLORER_UI_PORT=8548 # the port the mvs-explorer UI service will use
 USS_EXPLORER_UI_PORT=8550 # the port the uss-explorer UI service will use
 ZOWE_EXPLORER_FRAME_ANCESTORS="${ZOWE_EXPLORER_HOST}:*,${ZOWE_IP_ADDRESS}:*" # comma seperated list of hosts allowed to embed explorers
 
-# Zowe Desktop/app framework variables
-ZOWE_ZLUX_SERVER_HTTPS_PORT=8544
+# Zowe Desktop, ZSS, app framework variables
+ZOWE_ZSS_SERVER_TLS=true # set to false for backward compatibility if dependent component has network issue to ZSS
 ZOWE_ZSS_SERVER_PORT=8542
 ZOWE_ZSS_XMEM_SERVER_NAME=ZWESIS_STD
+ZOWE_ZLUX_SERVER_HTTPS_PORT=8544
 ZOWE_ZLUX_SSH_PORT=22
 ZOWE_ZLUX_TELNET_PORT=23
 ZOWE_ZLUX_SECURITY_TYPE= # The security type of the tn3270 connection - valid values are blank('') for telnet, or 'tls'


### PR DESCRIPTION
Lacking a good description while I test this out, but what we're about to do is have ZSS use TLS 1.2 by default (away from only http) and we need to test both that this is going to work out of the box correctly and automatically, and second that we need to fix any tests that will break due to the tests not using https.