### PR TITLE
WIP: Add prereq_python playbook zos role

### DIFF
--- a/playbooks/roles/zos/tasks/prereq_python.yml
+++ b/playbooks/roles/zos/tasks/prereq_python.yml
@@ -1,0 +1,22 @@
+---
+# this role checks if Python is available on z/OS by using the zos_ping module
+# from the ibm.ibm_zos_core collection
+
+# input:
+# - z/OS host: obtained from the playbook that imports the role
+# requirements:
+# - ibm.ibm_zos_core collection installed on the control node
+# - ansible_connection: ibm.ibm_zos_core.zos_ssh on the playbook or host_vars
+# output:
+# - zos_ping verifies the presence of z/OS Web Client Enablement Toolkit, iconv, and Python.
+# - zos_ping returns pong when the target host is not missing any of the dependencies.
+
+# TODO add ibm.ibm_zos_core collection to ../meta/main.yaml so we can use only the module name
+- name: Ping the z/OS host and perform resource checks
+  ibm.ibm_zos_core.zos_ping:
+  register: prereq_python_result
+
+- name: Print result
+  debug:
+    msg: "A valid release of Python is available on the host."
+  when: prereq_python_result.ping == "pong"

--- a/playbooks/try-prereq_python.yml
+++ b/playbooks/try-prereq_python.yml
@@ -1,0 +1,17 @@
+---
+- name: Test prereq_python role
+  hosts: all
+  gather_facts: false
+  become: false
+  
+  # ibm.ibm_zos_core.zos_ssh connection is required here or on the host_vars.
+  # keeping it here for now to avoid this new requirement for all host connections.
+  vars:
+      ansible_connection: ibm.ibm_zos_core.zos_ssh
+
+  tasks:
+  # ============================================================================
+  # Check if Python is available on the z/OS host
+  - import_role:
+      name: zos
+      tasks_from: prereq_python


### PR DESCRIPTION
<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [x] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Relevant issues
<!-- Link to a relevant GitHub issue if any. If this PR applies to multiple issues, preface each issue reference with the "Fixes" keyword. For example, Fixes #123, Fixes #456. -->

Fixes #1206 

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
- Add a new playbook zos role called prereq_python.yml , to check if a valid version of Python is available on the z/OS host. It relies on the ibm.ibm_zos_core collection, using the zos_ping module to check for Python and other requirements, and requires the zos_ssh connection type.
- Add a try-prereq_python.yml playbook to test the new prereq_python role, while waiting to see where it's going to be used.

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path below.-->

#### Does this PR do something the person installing Zowe should know about?

<!-- Is this a fix or a feature that changes customizable files (e.g. configuration files, sample JCL, etc),
product requirements, or other installation or configuration related area? If so, please fill out the template below. 
There is no need to report the need to restart the servers to activate the change. Note that the provided text will be formatted in 64-character lines, and that round brackets, ( and ), must always be used in matching pairs. -->

---
* Affected function: _general area of interest_ *

---
* Description: _1 line description_ *

---
* Part: _name of customizable file involved_  *

---
_multi-line description_

#### Is there a related doc issue or Pull Request? 
<!-- Link to a relevant documentation issue or Pull Request if any. -->

Doc issue/PR number: 

#### Other information
I discussed this PR with Jack Jia, as part of my work on issue #1206 . Tried to keep the use of ibm_zos_core very clear for now, but later it could be added as one of the collections on the meta/main.yml file, so we can use the modules without having to prefix them with ibm.ibm_zos_core. 
To use the try-prereq_python.yml playbook for testing the new role, the control node must have the ibm_zos_core collection installed, using command:
`ansible-galaxy collection install ibm.ibm_zos_core`

Please let me know if you have any questions, thank you!