### PR TITLE
Explicitly set execute to prevent s390x build error

### DIFF
--- a/containers/server-bundle/Dockerfile
+++ b/containers/server-bundle/Dockerfile
@@ -124,5 +124,6 @@ ENV ZWED_agent_http_port='8542'
 ENV LAUNCH_COMPONENT_GROUPS=DESKTOP,GATEWAY
 
 COPY --chown=zowe:zowe --from=builder /home/zowe /home/zowe
+RUN chmod a+x /home/zowe/*.sh
 
 ENTRYPOINT ["/home/zowe/run.sh"]

--- a/containers/server-bundle/Dockerfile
+++ b/containers/server-bundle/Dockerfile
@@ -124,6 +124,6 @@ ENV ZWED_agent_http_port='8542'
 ENV LAUNCH_COMPONENT_GROUPS=DESKTOP,GATEWAY
 
 COPY --chown=zowe:zowe --from=builder /home/zowe /home/zowe
-RUN chmod a+x /home/zowe/*.sh
+RUN chmod a+x /home/zowe/*.sh /home/zowe/.run_inner.sh
 
 ENTRYPOINT ["/home/zowe/run.sh"]


### PR DESCRIPTION
Very small PR to fix an issue seen in 1.20 RCs: the s390x build is adding our run scripts without execute bit, therefore the docker image of s390x isnt working. This should fix it.