### PR TITLE
missing locks for keyring test

### DIFF
--- a/tests/installation/Jenkinsfile
+++ b/tests/installation/Jenkinsfile
@@ -110,6 +110,7 @@ node('zowe-jenkins-agent-dind-wdc') {
     'bundle: keyring on multiple security systems': [
       test_files: 'dist/__tests__/extended/keyring-modes/',
       jenkins_primary_lock: 'marist',
+      jenkins_extra_locks: ['marist-2', 'marist-3'],
     ],
     'generate api documentation': [
       test_files: 'dist/__tests__/basic/install-api-gen.js',


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

Bundle test for keyring should lock all 3 servers it's testing.