### PR TITLE
conditionally skip zss routing test for docker build

### DIFF
--- a/playbooks/roles/verify/tasks/main.yml
+++ b/playbooks/roles/verify/tasks/main.yml
@@ -42,6 +42,7 @@
     ZOWE_ROOT_DIR: "{{ zowe_root_dir }}"
     ZOWE_INSTANCE_DIR: "{{ zowe_instance_dir }}"
     ZOWE_EXTERNAL_HOST: "{{ zowe_external_domain_name }}"
+    ZOWE_ZOS_HOST: "{{ zowe_zos_host }}"
     SSH_HOST: "{{ ansible_ssh_host }}"
     SSH_PORT: "{{ ansible_port }}"
     SSH_USER: "{{ ansible_user }}"

--- a/tests/sanity/test/apiml/test-zss-routing.js
+++ b/tests/sanity/test/apiml/test-zss-routing.js
@@ -18,7 +18,12 @@ let assertNotEmptyValidResponse = (response) => {
   expect(response.data).to.not.be.empty;
 };
 
-describe('test zss can be routed via gateway', function() {
+const zosHost = process.env.ZOWE_ZOS_HOST || process.env.ZOWE_EXTERNAL_HOST;
+// FIXME: zss is static registered and registration information are not shared to Discovery running off Z.
+//        so disable this test if Gateway/Discovery host and z/OS host are not same.
+const skipTest = process.env.ZOWE_EXTERNAL_HOST !== zosHost;
+
+(skipTest ? describe.skip : describe)('test zss can be routed via gateway', function() {
   before('verify environment variables', function() {
     // allow self signed certs
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

Reason: zss is statically registered.