### PR TITLE
Fix for publishing source

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -19,9 +19,9 @@ node('zowe-jenkins-agent-dind-wdc') {
   def ZOWE_RELEASE_SMPE_PAX_FILEPATTERN = "zowe-smpe-*.zip"
   def ZOWE_RELEASE_SMPE_PTF_PROMOTE_FILEPATTERN = "smpe-promote-*.tar"
   def ZOWE_RELEASE_DOCKER_AMD64_FILEPATTERN = "server-bundle.amd64-*.tar"
-  def ZOWE_RELEASE_DOCKER_AMD64_SOURCE_FILEPATTERN = "server-bundle.source.amd64-*.tar"
+  def ZOWE_RELEASE_DOCKER_AMD64_SOURCE_FILEPATTERN = "server-bundle.sources.amd64-*.tar"
   def ZOWE_RELEASE_DOCKER_S390X_FILEPATTERN = "server-bundle.s390x-*.tar"
-  def ZOWE_RELEASE_DOCKER_S390X_SOURCE_FILEPATTERN = "server-bundle.source.s390x-*.tar"
+  def ZOWE_RELEASE_DOCKER_S390X_SOURCE_FILEPATTERN = "server-bundle.sources.s390x-*.tar"
   def ZOWE_RELEASE_CLI_CORE_FILEPATTERN = "zowe-cli-package-*.zip"
   def ZOWE_RELEASE_CLI_PLUGINS_FILEPATTERN = "zowe-cli-plugins-*.zip"
   def ZOWE_INSTALL_PACKAGING_REPO = 'zowe/zowe-install-packaging'
@@ -645,13 +645,17 @@ node('zowe-jenkins-agent-dind-wdc') {
           "export DOCKER_CLI_EXPERIMENTAL=enabled\n" +
           "docker manifest create ompzowe/server-bundle:latest ${manifestAmends}\n" +
           "docker manifest push ompzowe/server-bundle:latest\n" +
+          "docker manifest create ompzowe/server-bundle:v${params.ZOWE_RELEASE_VERSION} ${manifestAmends}\n" +
+          "docker manifest push ompzowe/server-bundle:v${params.ZOWE_RELEASE_VERSION}"
+        // publish source images
+        if (manifestSourceAmends) {
+          sh publishCommands +
+          "export DOCKER_CLI_EXPERIMENTAL=enabled\n" +
           "docker manifest create ompzowe/server-bundle:latest-sources ${manifestSourceAmends}\n" +
           "docker manifest push ompzowe/server-bundle:latest-sources\n" +
-          "docker manifest create ompzowe/server-bundle:v${params.ZOWE_RELEASE_VERSION} ${manifestAmends}\n" +
-          "docker manifest push ompzowe/server-bundle:v${params.ZOWE_RELEASE_VERSION}" +
           "docker manifest create ompzowe/server-bundle:v${params.ZOWE_RELEASE_VERSION}-sources ${manifestSourceAmends}\n" +
           "docker manifest push ompzowe/server-bundle:v${params.ZOWE_RELEASE_VERSION}-sources"
-
+        }
       }
     }
   )


### PR DESCRIPTION
Mistakenly closed https://github.com/zowe/zowe-install-packaging/pull/2125
Reopening this to solve the same issue:

This PR is to resolve errors seen in the release output https://wash.zowe.org:8443/view/Zowe/job/zowe-promote-publish/job/staging/92
In it, the source images are not found due to seemingly a typo, as https://zowe.jfrog.io/artifactory/libs-snapshot-local/org/zowe/1.21.0-SNAPSHOT/serv[…]er-bundle.sources.amd64-1.21.0-snapshot-826-20210427215530.tar exists, "sources" vs source.
Secondarily, the code did not check if there were any sources to publish before issuing the docker commands, leading to failure later on too.