### PR TITLE
Fix portability of swagger support plugins

### DIFF
--- a/files/zlux/config/plugins/org.zowe.zlux.agent.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.agent.json
@@ -1,0 +1,5 @@
+{
+  "identifier": "org.zowe.zlux.agent",
+  "pluginLocation": "components/app-server/share/zlux-server-framework/plugins/zlux-agent",
+  "relativeTo": "$ROOT_DIR"
+}

--- a/files/zlux/config/plugins/org.zowe.zlux.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.json
@@ -1,0 +1,5 @@
+{
+  "identifier": "org.zowe.zlux",
+  "pluginLocation": "components/app-server/share/zlux-server-framework/plugins/zlux-server",
+  "relativeTo": "$ROOT_DIR"
+}

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -12,7 +12,7 @@
   },
   "binaryDependencies": {
     "org.zowe.zlux.zlux-core": {
-      "version": "~1.22.0-171-zlux-app-server",
+      "version": "~1.22.0-STAGING",
       "artifact": "*.pax",
     },
     "org.zowe.zlux.zss-auth": {

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -12,7 +12,7 @@
   },
   "binaryDependencies": {
     "org.zowe.zlux.zlux-core": {
-      "version": "~1.22.0-STAGING",
+      "version": "~1.22.0-171-zlux-app-server",
       "artifact": "*.pax",
     },
     "org.zowe.zlux.zss-auth": {


### PR DESCRIPTION
Without relativeTo plugins for our two new meta-plugins that add proper swagger support, the plugins break if ROOT_DIR is changed.
With the addition of the relativeTo pointers here, the plugins become portable just as our other plugins are, so this is the behavior we want.