### PR TITLE
[WIP] Migrate scripting

### DIFF
--- a/bin/utils/migrate-tool/package-lock.json
+++ b/bin/utils/migrate-tool/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "dependencies": {
     "fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "requires": {
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "graceful-fs": {
@@ -20,18 +20,17 @@
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^2.0.0"
+        "graceful-fs": "^4.1.6"
       }
     },
     "universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/bin/utils/migrate-tool/package-lock.json
+++ b/bin/utils/migrate-tool/package-lock.json
@@ -1,0 +1,42 @@
+{
+  "name": "migrate-tool",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+    }
+  }
+}

--- a/bin/utils/migrate-tool/package.json
+++ b/bin/utils/migrate-tool/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "migrate-tool",
+  "version": "1.0.0",
+  "description": "A tool to migrate zowe instances and keystores between formats",
+  "main": "migrate-tool.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zowe/zowe-install-packaging-tools.git"
+  },
+  "author": "1000turquoisepogs",
+  "license": "EPL-2.0",
+  "bugs": {
+    "url": "https://github.com/zowe/zowe-install-packaging-tools/issues"
+  },
+  "homepage": "https://github.com/zowe/zowe-install-packaging-tools#readme",
+  "dependencies": {
+    "fs-extra": "^10.0.0",
+    "yaml": "^1.10.2"
+  }
+}

--- a/bin/utils/migrate-tool/package.json
+++ b/bin/utils/migrate-tool/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/zowe/zowe-install-packaging-tools#readme",
   "dependencies": {
-    "fs-extra": "^10.0.0",
+    "fs-extra": "^8.0.0",
     "yaml": "^1.10.2"
   }
 }

--- a/bin/utils/migrate-tools.js
+++ b/bin/utils/migrate-tools.js
@@ -1,0 +1,224 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const isZos = os.platform() == 'os390';
+
+
+const types = {
+  "zos": 1,
+  //aliases since there is uncertainty about zcx being independent or just "container"
+  "container": 2,
+  "docker": 2,
+  "kubernetes": 2,
+  "docker-bundle": 3
+};
+
+const TYPE_ZOS=1;
+const TYPE_CONTAINER=2;
+const TYPE_CONTAINER_BUNDLE=3;
+
+const commandArgs = process.argv.slice(2);
+if (commandArgs.length != 4) {
+  console.error(`Usage: Run this from zowe-migrate-instance.sh`);
+  process.exit(1);
+}
+
+const instanceDir = commandArgs[0];
+const outputDir = commandArgs[1];
+const toType = commandArgs[2];
+const fromType = commandArgs[3];
+
+if (!process.env['KEYSTORE_TYPE']) {
+  console.error(`Could not read KEYSTORE_TYPE env var. Env vars not set correctly for migration tool.`);
+  process.exit(1);
+}
+
+const WORKSPACE_DIR = path.join(instanceDir, 'workspace');
+const KEYSTORE_ENV_FILE = path.join(process.env['KEYSTORE_DIRECTORY'], 'zowe-certificates.env');
+
+
+if (toType == fromType) {
+  //this may be used to copy-paste duplicate instances in the future?
+  console.error(`Error: same type migration not yet implemented`);
+  process.exit(2);
+}
+
+if (toType == TYPE_ZOS && fromType == TYPE_CONTAINER) {
+  migrateZosContainer();
+} else if (toType == TYPE_ZOS && fromType == TYPE_CONTAINER_BUNDLE) {
+  migrateZosBundle();
+} else if (toType == TYPE_CONTAINER && fromType == TYPE_ZOS) {
+  migrateContainerZos();
+} else if (toType == TYPE_CONTAINER_BUNDLE && fromType == TYPE_ZOS) {
+  migrateBundleZos();
+} else if (toType == TYPE_CONTAINER_BUNDLE && fromType == TYPE_CONTAINER) {
+  migrateBundleContainer();
+} else if (toType == TYPE_CONTAINER && fromType == TYPE_CONTAINER_BUNDLE) {
+  migrateContainerBundle();
+} else {
+  console.error(`Error: unimplemented migration from ${fromType} to ${toType}`);
+  process.exit(3);
+}
+
+function migrateZosContainer() {
+  console.error('nyi migrateZosContainer');
+  process.exit(1);
+}
+function migrateContainerZos() {
+  console.error('nyi migrateContainerZos');
+  process.exit(1);
+}
+function migrateBundleContainer() {
+  console.error(`nyi migrateBundleContainer`);
+  process.exit(1);
+}
+function migrateContainerBundle() {
+  console.error(`nyi migrateContainerBundle`);
+  process.exit(1);
+}
+
+//ebcic -> ascii, keyring check (no support), path updating
+function migrateZosBundle() {
+  migrateKeystoreZosBundle();
+
+  if (isZos) {
+    //simple conversion: reading files and writing them will do ebcdic-ascii conversion automatically!
+    convertRecursively(path.join(instanceDir, 'workspace'), path.join(outputDir, 'instance', 'workspace', undefined));
+  } else {
+    //no tagging info, this is going to be guesswork.
+    console.error(`Error: Cannot migrate z/OS instance while not on z/OS. Rerun this script on z/OS.`);
+    process.exit(4);
+  }
+}
+
+//ascii -> ebcdic, path updating
+function migrateBundleZos() {
+  console.error(`nyi migrateBundleZos`);
+  process.exit(1);
+  /*
+  migrateKeystore();
+  migrateConfigZosBundle();
+
+  if (isZos) {
+    //everything is ascii, so try run tag-files.sh?
+    migrateWorkspace();
+  } else {
+    //TODO manual conversion based on extension and possible overrides
+  }
+  */
+}
+
+function canMigrateKeystore() {
+  return process.env['KEYSTORE_TYPE'] == "PKCS12";
+}
+
+function migrateKeystoreZosBundle() {
+  // ----- at beginning of file is a really good clue this is a text file
+  //zowe-certificates.env
+  if (!canMigrateKeystore()) {
+    console.error(`Keystore type ${process.env['KEYSTORE_TYPE']} is not supported for migration`);
+    process.exit(1);
+  }
+  fs.readFileSync(KEYSTORE_ENV_FILE,
+  convertRecursively(process.env['KEYSTORE_DIRECTORY'], path.join(outputDir, 'instance', ), undefined, WORKSPACE_DIR, certConvert);
+}
+
+function migrateConfigZosBundle() {
+  //migrate instance minus workspace
+  convertRecursively(instanceDir, path.join(outputDir, 'instance'), undefined, WORKSPACE_DIR, simpleConvert);
+  setDockerInstancePaths();
+}
+
+const INSTANCE_PATHS = {
+  'ROOT_DIR': "/home/zowe/install",
+  'JAVA_HOME': "/usr/local/openjdk-8",
+  'NODE_HOME':'/usr/local/node',
+  'KEYSTORE_DIRECTORY': "/home/zowe/certs"
+}
+
+function setDockerInstancePaths() {
+  let instance = fs.readFileSync(path.join(outputDir, 'instance', 'instance.env'), 'utf8');
+  let lines = instance.split('\n');
+  const paths = Object.keys(INSTANCE_PATHS);
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i].trim();
+    paths.forEach((path)=> {
+      if (line.startsWith(path+'=')) {
+        line = path+'='+INSTANCE_PATHS[path];
+      }
+    });
+  }
+  instance = lines.join('\n');
+  fs.writeFileSync(path.join(outputDir, 'instance', 'instance.env'));
+}
+
+
+function certConvert(fullPath, destinationPath, convertMap) {
+  const buff = fs.readFileSync(fullPath);
+  if (fullPath.endsWith('.p12')){ //p12 is binary, dont convert
+    //copy
+    fs.writeFileSync(destinationPath, buff);
+  } else {
+    const char = buff[0];
+    //look for -----
+    if (buff.length > 5 && (buff[0] == buff[1] == buff[2] == buff[3] == buff[4]) && (char == 0x60 || char == 0x2d)) {
+      //likely to be a text file cert or key
+      if (!convertMap) {
+        fs.writeFileSync(destinationPath, fs.readFileSync(fullPath, 'utf8'));
+      } else {
+        const content = fs.readFileSync(fullPath);
+        for (let i = 0; i < content.length; i++) {
+          content[i] = convertMap[i];
+        }
+        fs.writeFileSync(destinationPath, content);
+      }
+    } else { //i guess its binary
+      console.warn(`file '${fullPath}' not identified as text. first char=${char}`);
+      fs.writeFileSync(destinationPath, buff);
+    }
+    
+  }
+}
+
+function simpleConvert(fullPath, destinationPath, convertMap) {
+  if (!convertMap) {
+    //TODO make more efficient by streaming buffer
+    fs.writeFileSync(destinationPath, fs.readFileSync(fullPath, 'utf8'));
+  } else {
+    const content = fs.readFileSync(fullPath);
+    for (let i = 0; i < content.length; i++) {
+      content[i] = convertMap[i];
+    }
+    fs.writeFileSync(destinationPath, content);
+  }
+}
+
+//if convertMap is null, we use nodejs string conversion trick of zos to input ??? and output ascii
+//TODO make async
+function convertRecursively(inputPath, outputPath, convertMap, ignorePath, convertFunction) {
+  fs.mkdirSync(outputPath);
+  const names = fs.readdirSync(inputPath);
+  names.forEach(function(name) {
+    const fullPath = path.join(inputPath, name);
+    const destinationPath = path.join(outputPath, name);
+    if (fullPath != ignorePath) {
+      const stat = fs.statSync(fullPath);
+      if (stat.isDirectory()) {
+        fs.mkdirSync(destinationPath);
+        convertRecursively(fullPath, destinationPath, convertMap, ignorePath);
+      } else {
+        convertFunction(fullPath, destinationPath, convertMap);
+      }
+    }
+  });
+}

--- a/bin/utils/migrate-tools.js
+++ b/bin/utils/migrate-tools.js
@@ -2,12 +2,13 @@
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 */
-
+console.log('js type='+process.env['KEYSTORE_TYPE']);
+console.log('keystore='+process.env['KEYSTORE_DIRECTORY']);
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
@@ -35,8 +36,8 @@ if (commandArgs.length != 4) {
 
 const instanceDir = commandArgs[0];
 const outputDir = commandArgs[1];
-const toType = commandArgs[2];
-const fromType = commandArgs[3];
+const toType = types[commandArgs[2]];
+const fromType = types[commandArgs[3]];
 
 if (!process.env['KEYSTORE_TYPE']) {
   console.error(`Could not read KEYSTORE_TYPE env var. Env vars not set correctly for migration tool.`);
@@ -45,30 +46,39 @@ if (!process.env['KEYSTORE_TYPE']) {
 
 const WORKSPACE_DIR = path.join(instanceDir, 'workspace');
 const KEYSTORE_ENV_FILE = path.join(process.env['KEYSTORE_DIRECTORY'], 'zowe-certificates.env');
+const INSTANCE_PATHS = {
+  'ROOT_DIR': "/home/zowe/install",
+  'JAVA_HOME': "/usr/local/openjdk-8",
+  'NODE_HOME':'/usr/local/node',
+  'KEYSTORE_DIRECTORY': "/home/zowe/certs"
+}
 
+const KEYSTORE_KEYS = ['KEYSTORE', 'TRUSTSTORE', 'KEYSTORE_KEY', 'KEYSTORE_CERTIFICATE', 'KEYSTORE_CERTIFICATE_AUTHORITY'];
+
+const CONVERT_DIR_EXCEPTIONS = [ 'workspace/api-mediation/api-defs' ];
 
 if (toType == fromType) {
   //this may be used to copy-paste duplicate instances in the future?
   console.error(`Error: same type migration not yet implemented`);
   process.exit(2);
 }
-
-if (toType == TYPE_ZOS && fromType == TYPE_CONTAINER) {
+if (fromType == TYPE_ZOS && toType == TYPE_CONTAINER) {
   migrateZosContainer();
-} else if (toType == TYPE_ZOS && fromType == TYPE_CONTAINER_BUNDLE) {
+} else if (fromType == TYPE_ZOS && toType == TYPE_CONTAINER_BUNDLE) {
   migrateZosBundle();
-} else if (toType == TYPE_CONTAINER && fromType == TYPE_ZOS) {
+} else if (fromType == TYPE_CONTAINER && toType == TYPE_ZOS) {
   migrateContainerZos();
-} else if (toType == TYPE_CONTAINER_BUNDLE && fromType == TYPE_ZOS) {
+} else if (fromType == TYPE_CONTAINER_BUNDLE && toType == TYPE_ZOS) {
   migrateBundleZos();
-} else if (toType == TYPE_CONTAINER_BUNDLE && fromType == TYPE_CONTAINER) {
+} else if (fromType == TYPE_CONTAINER_BUNDLE && toType == TYPE_CONTAINER) {
   migrateBundleContainer();
-} else if (toType == TYPE_CONTAINER && fromType == TYPE_CONTAINER_BUNDLE) {
+} else if (fromType == TYPE_CONTAINER && toType == TYPE_CONTAINER_BUNDLE) {
   migrateContainerBundle();
 } else {
   console.error(`Error: unimplemented migration from ${fromType} to ${toType}`);
   process.exit(3);
 }
+console.warn("Path references for 3rd party components are not altered by this tool. Please review third party component documentation if further correction is needed");
 
 function migrateZosContainer() {
   console.error('nyi migrateZosContainer');
@@ -92,8 +102,9 @@ function migrateZosBundle() {
   migrateKeystoreZosBundle();
 
   if (isZos) {
+    migrateConfigZosBundle();
     //simple conversion: reading files and writing them will do ebcdic-ascii conversion automatically!
-    convertRecursively(path.join(instanceDir, 'workspace'), path.join(outputDir, 'instance', 'workspace', undefined));
+    convertRecursively(path.join(instanceDir, 'workspace'), path.join(outputDir, 'instance', 'workspace'), undefined, WORKSPACE_DIR, simpleConvert);
   } else {
     //no tagging info, this is going to be guesswork.
     console.error(`Error: Cannot migrate z/OS instance while not on z/OS. Rerun this script on z/OS.`);
@@ -129,8 +140,9 @@ function migrateKeystoreZosBundle() {
     console.error(`Keystore type ${process.env['KEYSTORE_TYPE']} is not supported for migration`);
     process.exit(1);
   }
-  fs.readFileSync(KEYSTORE_ENV_FILE,
-  convertRecursively(process.env['KEYSTORE_DIRECTORY'], path.join(outputDir, 'instance', ), undefined, WORKSPACE_DIR, certConvert);
+  fs.writeFileSync(path.join(outputDir, 'keystore', 'zowe-certificates.env'), fs.readFileSync(KEYSTORE_ENV_FILE,'utf8'));
+  convertRecursively(process.env['KEYSTORE_DIRECTORY'], path.join(outputDir, 'keystore'), undefined, WORKSPACE_DIR, certConvert);
+  setDockerKeystorePaths();
 }
 
 function migrateConfigZosBundle() {
@@ -139,27 +151,70 @@ function migrateConfigZosBundle() {
   setDockerInstancePaths();
 }
 
-const INSTANCE_PATHS = {
-  'ROOT_DIR': "/home/zowe/install",
-  'JAVA_HOME': "/usr/local/openjdk-8",
-  'NODE_HOME':'/usr/local/node',
-  'KEYSTORE_DIRECTORY': "/home/zowe/certs"
+function setDockerKeystorePaths() {
+  let keystore = fs.readFileSync(path.join(outputDir, 'keystore', 'zowe-certificates.env'), 'utf8');
+  let lines = keystore.split('\n');
+  let keystoreDir = process.env['KEYSTORE_DIRECTORY'];
+  const migrateDir = path.join(outputDir, 'keystore', 'migrated');
+
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i].trim();
+    for (let j = 0; j < KEYSTORE_KEYS.length; j++) {
+      let key = KEYSTORE_KEYS[j];
+      if (line.startsWith(key+'=')) {
+        value=line.substring(key.length+1);
+        if (value.startsWith(keystoreDir)) {
+          lines[i] = key + '=' + value.replace(keystoreDir, INSTANCE_PATHS.KEYSTORE_DIRECTORY);
+        } else {
+          //object does not originate in keystore. copy it out
+          let filename = path.basename(value);
+          let buf = fs.readFileSync(value);
+          try {
+            fs.mkdirSync(migrateDir);
+          } catch (e) {
+            if (e.code != 'EEXIST') {
+              throw e;
+            }
+          }
+
+          let destinationPath = path.join(migrateDir, filename);
+          if (isTextCert(buf)) {
+            fs.writeFileSync(destinationPath, fs.readFileSync(value, 'utf8'));
+          } else {
+            fs.writeFileSync(destinationPath, buf);
+          }
+          lines[i] = key + '=' + path.join(INSTANCE_PATHS.KEYSTORE_DIRECTORY, 'migrated', filename);
+        }
+        break;
+      }
+    };
+  }
+  keystore = lines.join('\n');
+  fs.writeFileSync(path.join(outputDir, 'keystore', 'zowe-certificates.env'), keystore);
 }
+
 
 function setDockerInstancePaths() {
   let instance = fs.readFileSync(path.join(outputDir, 'instance', 'instance.env'), 'utf8');
   let lines = instance.split('\n');
-  const paths = Object.keys(INSTANCE_PATHS);
+  const keys = Object.keys(INSTANCE_PATHS);
   for (let i = 0; i < lines.length; i++) {
     let line = lines[i].trim();
-    paths.forEach((path)=> {
-      if (line.startsWith(path+'=')) {
-        line = path+'='+INSTANCE_PATHS[path];
+    for (let j = 0; j < keys.length; j++) {
+      let key = keys[j];
+      if (line.startsWith(key+'=')) {
+        lines[i] = key+'='+INSTANCE_PATHS[key];
       }
-    });
+    };
   }
   instance = lines.join('\n');
-  fs.writeFileSync(path.join(outputDir, 'instance', 'instance.env'));
+  fs.writeFileSync(path.join(outputDir, 'instance', 'instance.env'), instance);
+}
+
+function isTextCert(buff) {
+  const char = buff[0];
+  //look for -----, 0x60, 0x2d, 0x05
+  return buff.length > 5 && (buff[0] == buff[1]) && (buff[0] == buff[2]) && (buff[0] == buff[3]) && (buff[0] == buff[4]) && (char == 0x05 || char == 0x2d);
 }
 
 
@@ -169,9 +224,7 @@ function certConvert(fullPath, destinationPath, convertMap) {
     //copy
     fs.writeFileSync(destinationPath, buff);
   } else {
-    const char = buff[0];
-    //look for -----
-    if (buff.length > 5 && (buff[0] == buff[1] == buff[2] == buff[3] == buff[4]) && (char == 0x60 || char == 0x2d)) {
+    if (isTextCert(buff)) {
       //likely to be a text file cert or key
       if (!convertMap) {
         fs.writeFileSync(destinationPath, fs.readFileSync(fullPath, 'utf8'));
@@ -183,10 +236,10 @@ function certConvert(fullPath, destinationPath, convertMap) {
         fs.writeFileSync(destinationPath, content);
       }
     } else { //i guess its binary
-      console.warn(`file '${fullPath}' not identified as text. first char=${char}`);
+      console.warn(`file '${fullPath}' not identified as text. first char=${buff[0]}`);
       fs.writeFileSync(destinationPath, buff);
     }
-    
+
   }
 }
 
@@ -194,19 +247,35 @@ function simpleConvert(fullPath, destinationPath, convertMap) {
   if (!convertMap) {
     //TODO make more efficient by streaming buffer
     fs.writeFileSync(destinationPath, fs.readFileSync(fullPath, 'utf8'));
-  } else {
+  } else if (convertMap != 'copy') {
     const content = fs.readFileSync(fullPath);
     for (let i = 0; i < content.length; i++) {
       content[i] = convertMap[i];
     }
     fs.writeFileSync(destinationPath, content);
+  } else {
+    fs.copyFileSync(fullPath, destinationPath);
   }
 }
+
 
 //if convertMap is null, we use nodejs string conversion trick of zos to input ??? and output ascii
 //TODO make async
 function convertRecursively(inputPath, outputPath, convertMap, ignorePath, convertFunction) {
-  fs.mkdirSync(outputPath);
+  try {
+    fs.mkdirSync(outputPath);
+  } catch (e) {
+    if (e.code != 'EEXIST') {
+      throw e;
+    }
+  }
+  let dontConvert = false;
+  for (let i = 0; i < CONVERT_DIR_EXCEPTIONS.length; i++) {
+    if (inputPath.endsWith(CONVERT_DIR_EXCEPTIONS[i])) {
+      dontConvert = true;
+    }
+  }
+
   const names = fs.readdirSync(inputPath);
   names.forEach(function(name) {
     const fullPath = path.join(inputPath, name);
@@ -214,10 +283,16 @@ function convertRecursively(inputPath, outputPath, convertMap, ignorePath, conve
     if (fullPath != ignorePath) {
       const stat = fs.statSync(fullPath);
       if (stat.isDirectory()) {
-        fs.mkdirSync(destinationPath);
-        convertRecursively(fullPath, destinationPath, convertMap, ignorePath);
+        try {
+          fs.mkdirSync(destinationPath);
+        } catch (e) {
+          if (e.code != 'EEXIST') {
+            throw e;
+          }
+        }
+        convertRecursively(fullPath, destinationPath, convertMap, ignorePath, convertFunction);
       } else {
-        convertFunction(fullPath, destinationPath, convertMap);
+        convertFunction(fullPath, destinationPath, dontConvert ? 'copy' : convertMap);
       }
     }
   });

--- a/bin/zowe-migrate-instance.sh
+++ b/bin/zowe-migrate-instance.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+
+if [ $# -lt 4 ]; then
+  echo "Usage: $0 -i instance_directory -o output_directory -t to_install_type -f from_install_type\n Types: zos, container, docker, kubernetes, docker-bundle"
+  exit 1
+fi
+
+# set defaults here
+
+
+while getopts "i:t:f" opt; do
+  case $opt in
+    i) INSTANCE_DIR=$OPTARG;;
+    k) KEYSTORE_DIR=$OPTARG;;
+    t) TO_TYPE=$OPTARG;;
+    f) FROM_TYPE=$OPTARG;;
+    o) OUTPUT_DIR=$OPTARG;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+shift $(($OPTIND-1))
+
+if [ -e "$INSTANCE_DIR/instance.env" ]; then
+  mkdir -p $OUTPUT_DIR
+
+  readInstance()
+  if [ -z "$KEYSTORE_DIR" ]; then
+    KEYSTORE_DIR="$KEYSTORE_DIRECTORY"
+  fi
+  readKeystore()
+  cd utils
+  node migrate-tools.js "$INSTANCE_DIR" "$OUTPUT_DIR" "$TO_TYPE" "$FROM_TYPE"
+  else
+    echo "Error: cannot read instance.env"
+  fi
+else
+  echo "Error: cannot read INSTANCE_DIR file read-essential-vars.sh"
+  exit 1
+fi
+
+readInstance() {
+  . "$INSTANCE_DIR/instance.env"
+  if [ $? -ne 0 ]; then
+    mkdir -p $OUTPUT_DIR/instance
+    iconv -f 819 -t 1047 "$INSTANCE_DIR/instance.env" > "$OUTPUT_DIR/instance/instance.env.iconv1047"
+    . "$OUTPUT_DIR/instance/instance.env.iconv1047"
+  fi
+}
+
+readKeystore() {
+  . "$KEYSTORE_DIR/zowe-certificates.env"
+  if [ $? -ne 0 ]; then
+    mkdir -p $OUTPUT_DIR/keystore
+    iconv -f 819 -t 1047 "$KEYSTORE_DIR/zowe-certificates.env" > "$OUTPUT_DIR/keystore/zowe-certificates.env.iconv1047"
+    . "$OUTPUT_DIR/keystore/zowe-certificates.env.iconv1047"
+  fi    
+}

--- a/bin/zowe-migrate-instance.sh
+++ b/bin/zowe-migrate-instance.sh
@@ -114,8 +114,8 @@ if [ -e "$INSTANCE_DIR/instance.env" ]; then
   fi
   readKeystore
 
-  cd utils
-  node migrate-tools.js "$INSTANCE_DIR" "$OUTPUT_DIR" "$TO_TYPE" "$FROM_TYPE"
+  cd utils/migrate-tool
+  node migrate-tool.js "$INSTANCE_DIR" "$OUTPUT_DIR" "$TO_TYPE" "$FROM_TYPE"
 else
   echo "Error: cannot read instance.env"
   exit 1

--- a/bin/zowe-migrate-instance.sh
+++ b/bin/zowe-migrate-instance.sh
@@ -7,61 +7,116 @@
 #
 # Copyright Contributors to the Zowe Project.
 
-if [ $# -lt 4 ]; then
-  echo "Usage: $0 -i instance_directory -o output_directory -t to_install_type -f from_install_type\n Types: zos, container, docker, kubernetes, docker-bundle"
+if [ $# -lt 8 ]; then
+  echo "Usage: $0 -i instance_directory -o output_directory -t to_install_type -f from_install_type [-k input_keystore_directory] [-d output_keystore_directory] [-r output_root_directory]\n Types: zos, container, docker, kubernetes, docker-bundle"
   exit 1
 fi
 
 # set defaults here
 
 
-while getopts "i:t:f" opt; do
-  case $opt in
-    i) INSTANCE_DIR=$OPTARG;;
-    k) KEYSTORE_DIR=$OPTARG;;
-    t) TO_TYPE=$OPTARG;;
-    f) FROM_TYPE=$OPTARG;;
-    o) OUTPUT_DIR=$OPTARG;;
-    \?)
-      echo "Invalid option: -$OPTARG" >&2
+while [ $# -gt 0 ]; do
+  arg="$1"
+  case $arg in
+    -i)
+        shift
+        INSTANCE_DIR=$1
+        shift
+    ;;
+    -k)
+        shift
+        KEYSTORE_DIR=$1
+        shift
+    ;;
+    -t)
+        shift
+        TO_TYPE=$1
+        shift
+    ;;
+    -f)
+        shift
+        FROM_TYPE=$1
+        shift
+    ;;
+    -o)
+        shift
+        OUTPUT_DIR=$1
+        shift
+    ;;
+    -r)
+        shift
+        export MIGRATE_ROOT_DIR=$1
+        shift
+    ;;
+    -d)
+        shift
+        export MIGRATE_KEYSTORE_DIRECTORY=$1
+        shift
+    ;;
+    *)
+      echo "Invalid option: $1" >&2
       exit 1
-      ;;
   esac
 done
-shift $(($OPTIND-1))
 
-if [ -e "$INSTANCE_DIR/instance.env" ]; then
-  mkdir -p $OUTPUT_DIR
-
-  readInstance()
-  if [ -z "$KEYSTORE_DIR" ]; then
-    KEYSTORE_DIR="$KEYSTORE_DIRECTORY"
-  fi
-  readKeystore()
-  cd utils
-  node migrate-tools.js "$INSTANCE_DIR" "$OUTPUT_DIR" "$TO_TYPE" "$FROM_TYPE"
-  else
-    echo "Error: cannot read instance.env"
-  fi
-else
-  echo "Error: cannot read INSTANCE_DIR file read-essential-vars.sh"
+if [ -z $INSTANCE_DIR -o -z $TO_TYPE -o -z $FROM_TYPE -o -z OUTPUT_DIR ]; then
+  echo "Usage: $0 -i instance_directory -o output_directory -t to_install_type -f from_install_type [-k keystore_directory]\n Types: zos, container, docker, kubernetes, docker-bundle"
   exit 1
 fi
 
 readInstance() {
+  mkdir -p $OUTPUT_DIR/instance
+
   . "$INSTANCE_DIR/instance.env"
   if [ $? -ne 0 ]; then
-    mkdir -p $OUTPUT_DIR/instance
+    echo "cant read instance"
     iconv -f 819 -t 1047 "$INSTANCE_DIR/instance.env" > "$OUTPUT_DIR/instance/instance.env.iconv1047"
-    . "$OUTPUT_DIR/instance/instance.env.iconv1047"
+    source_env "$OUTPUT_DIR/instance/instance.env.iconv1047"
+  else
+    source_env "$INSTANCE_DIR/instance.env"
   fi
 }
 
 readKeystore() {
+  mkdir -p $OUTPUT_DIR/keystore
+
   . "$KEYSTORE_DIR/zowe-certificates.env"
   if [ $? -ne 0 ]; then
-    mkdir -p $OUTPUT_DIR/keystore
+    echo "cant read keystore"
     iconv -f 819 -t 1047 "$KEYSTORE_DIR/zowe-certificates.env" > "$OUTPUT_DIR/keystore/zowe-certificates.env.iconv1047"
-    . "$OUTPUT_DIR/keystore/zowe-certificates.env.iconv1047"
-  fi    
+    source_env "$OUTPUT_DIR/keystore/zowe-certificates.env.iconv1047"
+  else
+    source_env "$KEYSTORE_DIR/zowe-certificates.env"
+  fi
 }
+
+source_env() {
+  env_file=$1
+
+  . "${env_file}"
+
+  while read -r line ; do
+    # skip line if first char is #
+    test -z "${line%%#*}" && continue
+    key=${line%%=*}
+    export $key
+  done < "${env_file}"
+}
+
+if [ -e "$INSTANCE_DIR/instance.env" ]; then
+  echo "mkdir -p $OUTPUT_DIR"
+  mkdir -p $OUTPUT_DIR
+
+  readInstance
+  echo "keystore dir=$KEYSTORE_DIRECTORY"
+  if [ -z "$KEYSTORE_DIR" ]; then
+    KEYSTORE_DIR="$KEYSTORE_DIRECTORY"
+  fi
+  readKeystore
+
+  cd utils
+  node migrate-tools.js "$INSTANCE_DIR" "$OUTPUT_DIR" "$TO_TYPE" "$FROM_TYPE"
+else
+  echo "Error: cannot read instance.env"
+  exit 1
+fi

--- a/bin/zowe-migrate-instance.sh
+++ b/bin/zowe-migrate-instance.sh
@@ -67,26 +67,26 @@ fi
 readInstance() {
   mkdir -p $OUTPUT_DIR/instance
 
-  . "$INSTANCE_DIR/instance.env"
-  if [ $? -ne 0 ]; then
-    echo "cant read instance"
+  
+  if [ $(. "$INSTANCE_DIR/instance.env" 2> /dev/null) ]; then
+    source_env "$INSTANCE_DIR/instance.env"
+  else
+    echo "Can't read instance file, attempting to read as EBCDIC."
     iconv -f 819 -t 1047 "$INSTANCE_DIR/instance.env" > "$OUTPUT_DIR/instance/instance.env.iconv1047"
     source_env "$OUTPUT_DIR/instance/instance.env.iconv1047"
-  else
-    source_env "$INSTANCE_DIR/instance.env"
   fi
 }
 
 readKeystore() {
   mkdir -p $OUTPUT_DIR/keystore
 
-  . "$KEYSTORE_DIR/zowe-certificates.env"
-  if [ $? -ne 0 ]; then
-    echo "cant read keystore"
+  
+  if [ $(. "$KEYSTORE_DIR/zowe-certificates.env" 2> /dev/null) ]; then
+    source_env "$KEYSTORE_DIR/zowe-certificates.env"
+  else
+    echo "Can't read keystore file, attempting to read as EBCDIC."
     iconv -f 819 -t 1047 "$KEYSTORE_DIR/zowe-certificates.env" > "$OUTPUT_DIR/keystore/zowe-certificates.env.iconv1047"
     source_env "$OUTPUT_DIR/keystore/zowe-certificates.env.iconv1047"
-  else
-    source_env "$KEYSTORE_DIR/zowe-certificates.env"
   fi
 }
 
@@ -104,11 +104,11 @@ source_env() {
 }
 
 if [ -e "$INSTANCE_DIR/instance.env" ]; then
-  echo "mkdir -p $OUTPUT_DIR"
   mkdir -p $OUTPUT_DIR
+  export ENV_NODE_HOME="$NODE_HOME"
+  export ENV_JAVA_HOME="$JAVA_HOME"
 
   readInstance
-  echo "keystore dir=$KEYSTORE_DIRECTORY"
   if [ ! -z "$KEYSTORE_DIR" ]; then
     export KEYSTORE_DIRECTORY="$KEYSTORE_DIR"
   fi

--- a/bin/zowe-migrate-instance.sh
+++ b/bin/zowe-migrate-instance.sh
@@ -109,8 +109,8 @@ if [ -e "$INSTANCE_DIR/instance.env" ]; then
 
   readInstance
   echo "keystore dir=$KEYSTORE_DIRECTORY"
-  if [ -z "$KEYSTORE_DIR" ]; then
-    KEYSTORE_DIR="$KEYSTORE_DIRECTORY"
+  if [ ! -z "$KEYSTORE_DIR" ]; then
+    export KEYSTORE_DIRECTORY="$KEYSTORE_DIR"
   fi
   readKeystore
 

--- a/scripts/tag-files.sh
+++ b/scripts/tag-files.sh
@@ -202,6 +202,8 @@ find . \( \
 -name ".gitmodules" -o \
 -name "*.jcl" -o \
 -name "*.JCL" -o \
+-name "*.env" -o \
+-name "*.ENV" -o \
 -name "*.sh" -o \
 -name "*.SH" \
 \) -exec sh -c 'iconv -f iso8859-1 -t 1047 "$0" > "$0".1047' {} \; -exec sh -c 'mv "$0".1047 "$0"' {} \;


### PR DESCRIPTION
There's a lot of stuff in here that might be removed and a lot of important things still to do.
Basic concept is to allow one or more types of zowe installs to be to/from converted in terms of instance and keystore so you can port your instance and keystore to another install.