### PR TITLE
Automate ZIS plugin check & install at configuration step

### DIFF
--- a/bin/zowe-configure-component.sh
+++ b/bin/zowe-configure-component.sh
@@ -196,7 +196,7 @@ while [ $# -gt 0 ]; do #Checks for parameters
             COMPONENT_NAME=$1
             shift
         ;;
-        -i|--instance_dir) #Represents the path to zowe's instance directory (optional)
+        -i|--instance-dir) #Represents the path to zowe's instance directory (optional)
             shift
             path=$(get_full_path "$1")
             validate_directory_is_accessible "${path}"
@@ -204,10 +204,10 @@ while [ $# -gt 0 ]; do #Checks for parameters
                 if [ -e "$path/instance.env" -o -e "$path/zowe.yaml" ]; then
                     INSTANCE_DIR=${path}
                 else
-                    error_handler "-i|--instance_dir: Given path is not a zowe instance directory"
+                    error_handler "-i|--instance-dir: Given path is not a zowe instance directory"
                 fi
             else
-                error_handler "-i|--instance_dir: Given path is not a zowe instance directory or does not exist"
+                error_handler "-i|--instance-dir: Given path is not a zowe instance directory or does not exist"
             fi
             shift
         ;;
@@ -215,7 +215,7 @@ while [ $# -gt 0 ]; do #Checks for parameters
             IS_ZOWE_CORE=true
             shift
         ;;
-        -d|--target_dir) # Represents the path to the desired target directory to place the extensions (optional)
+        -d|--target-dir) # Represents the path to the desired target directory to place the extensions (optional)
             shift
             TARGET_DIR=$(get_full_path "$1")
             shift
@@ -257,6 +257,9 @@ if [ -z "${TARGET_DIR}" ]; then
                 zwe_extension_dir=$(read_zowe_instance_variable "ZWE_EXTENSION_DIR")
             elif [ -e "${INSTANCE_DIR}/zowe.yaml" ]; then
                 zwe_extension_dir=$(read_zowe_yaml_variable ".zowe.extensionDirectory")
+                if [ "${zwe_extension_dir}" = "null" ]; then
+                    zwe_extension_dir=
+                fi
             fi
         fi
         if [ -z "${zwe_extension_dir}" ]; then
@@ -281,6 +284,9 @@ if [ "${IS_ZOWE_CORE}" = "false" ]; then
         zwe_extension_dir=$(read_zowe_instance_variable "ZWE_EXTENSION_DIR")
     elif [ -e "${INSTANCE_DIR}/zowe.yaml" ]; then
         zwe_extension_dir=$(read_zowe_yaml_variable ".zowe.extensionDirectory")
+        if [ "${zwe_extension_dir}" = "null" ]; then
+            zwe_extension_dir=
+        fi
     fi
     if [ -n "${zwe_extension_dir}" -a "${TARGET_DIR}" != "${zwe_extension_dir}" ]; then
         error_handler "It's recommended to install all Zowe extensions into same directory. The recommended target directory is ZWE_EXTENSION_DIR (${ZWE_EXTENSION_DIR}) defined in Zowe instance.env."

--- a/bin/zowe-configure-component.sh
+++ b/bin/zowe-configure-component.sh
@@ -128,7 +128,7 @@ install_zis_plugin() {
                       # Need to cd because zis-plugin-install script relies on other relative scripts
                       set -e # Honor any errors from zis-plugin-install
                       cd "${ZIS_INSTALL_DIR}"
-                      sh zis-plugin-install.sh extended-install "${ZIS_PATH_DIR}${LOADLIB}" "${ZIS_PATH_DIR}${SAMPLIB}"
+                      sh zis-plugin-install.sh extended-install "${ZIS_PATH_DIR}/${LOADLIB}" "${ZIS_PATH_DIR}/${SAMPLIB}"
                       # ZIS Plugin install script has its own logging, no need to send success message
                       set +e
                   else 

--- a/bin/zowe-configure-component.sh
+++ b/bin/zowe-configure-component.sh
@@ -99,11 +99,9 @@ install_zis_plugin() {
       if [ -e "${INSTANCE_DIR}/instance.env" ]; then
           if [ -n "$(read_zowe_instance_variable "ZWES_ZIS_PARMLIB")" ]; then
               export ZIS_PARMLIB=$(read_zowe_instance_variable "ZWES_ZIS_PARMLIB")
-              log_message "ZIS PARM ${ZIS_PARMLIB}"
           fi
           if [ -n "$(read_zowe_instance_variable "ZWES_ZIS_PLUGINLIB")" ]; then
               export ZIS_PLUGINLIB=$(read_zowe_instance_variable "ZWES_ZIS_PLUGINLIB")
-              log_message "ZIS PLUGIN ${ZIS_PARMLIB}"
           fi
       fi
 
@@ -121,6 +119,8 @@ install_zis_plugin() {
           if [[ -z "${ZIS_PLUGINLIB}" ]]; then
               log_message "ZIS_PLUGINLIB N/A from env or instance. Skipping ZIS plugin check."
           else
+              log_message "Received ZIS_PARMLIB: ${ZIS_PARMLIB}"
+              log_message "Received ZIS_PLUGINLIB: ${ZIS_PLUGINLIB}"
               if test -f "$ZIS_INSTALL_FILE"; then
                   if [ -n "${ZIS_PATH_DIR}" ]; then 
                       LOADLIB=$(read_component_manifest "${TARGET_DIR}/${component_name}" ".zisPlugins[${iterator_index}].loadlib" 2>/dev/null)

--- a/bin/zowe-configure-component.sh
+++ b/bin/zowe-configure-component.sh
@@ -126,8 +126,11 @@ install_zis_plugin() {
                       LOADLIB="loadlib" # default
                       SAMPLIB="samplib" # default
                       # Need to cd because zis-plugin-install script relies on other relative scripts
-                      cd "${ZIS_INSTALL_DIR}" && ./zis-plugin-install.sh extended-install "${ZIS_PATH_DIR}${LOADLIB}" "${ZIS_PATH_DIR}${SAMPLIB}"
+                      set -e # Honor any errors from zis-plugin-install
+                      cd "${ZIS_INSTALL_DIR}"
+                      sh zis-plugin-install.sh extended-install "${ZIS_PATH_DIR}${LOADLIB}" "${ZIS_PATH_DIR}${SAMPLIB}"
                       # ZIS Plugin install script has its own logging, no need to send success message
+                      set +e
                   else 
                       log_message "No ZIS plugins detected in manifest."
                   fi
@@ -136,7 +139,6 @@ install_zis_plugin() {
       fi
       iterator_index=`expr $iterator_index + 1`
       ZIS_PATH_DIR=$(read_component_manifest "${TARGET_DIR}/${component_name}" ".zisPlugins[${iterator_index}].path" 2>/dev/null)
-      
     done
 }
 

--- a/bin/zowe-configure-component.sh
+++ b/bin/zowe-configure-component.sh
@@ -123,16 +123,10 @@ install_zis_plugin() {
               log_message "Received ZIS_PLUGINLIB: ${ZIS_PLUGINLIB}"
               if test -f "$ZIS_INSTALL_FILE"; then
                   if [ -n "${ZIS_PATH_DIR}" ]; then 
-                      LOADLIB=$(read_component_manifest "${TARGET_DIR}/${component_name}" ".zisPlugins[${iterator_index}].loadlib" 2>/dev/null)
-                      if [ "${LOADLIB}" = "null" ] || [ -z "${LOADLIB}" ]; then # Check custom defined lib directories in manifest.yaml
-                          LOADLIB="loadlib" # default
-                      fi
-                      SAMPLIB=$(read_component_manifest "${TARGET_DIR}/${component_name}" ".zisPlugins[${iterator_index}].samplib" 2>/dev/null)
-                      if [ "${SAMPLIB}" = "null" ] || [ -z "${SAMPLIB}" ]; then
-                          SAMPLIB="samplib" #default
-                      fi
+                      LOADLIB="loadlib" # default
+                      SAMPLIB="samplib" # default
                       # Need to cd because zis-plugin-install script relies on other relative scripts
-                      cd "${ZIS_INSTALL_DIR}" && ./zis-plugin-install.sh extended-install "${ZIS_PATH_DIR}/${LOADLIB}" "${ZIS_PATH_DIR}/${SAMPLIB}"
+                      cd "${ZIS_INSTALL_DIR}" && ./zis-plugin-install.sh extended-install "${ZIS_PATH_DIR}${LOADLIB}" "${ZIS_PATH_DIR}${SAMPLIB}"
                       # ZIS Plugin install script has its own logging, no need to send success message
                   else 
                       log_message "No ZIS plugins detected in manifest."

--- a/bin/zowe-configure-component.sh
+++ b/bin/zowe-configure-component.sh
@@ -93,8 +93,6 @@ install_zis_plugin() {
     ZIS_PATH_DIR=$(read_component_manifest "${TARGET_DIR}/${component_name}" ".zisPlugins[${iterator_index}].path" 2>/dev/null)
     ZIS_INSTALL_DIR="${TARGET_DIR}/zss/bin"
     ZIS_INSTALL_FILE="${ZIS_INSTALL_DIR}/zis-plugin-install.sh"
-    
-    INSTANCE_DIR="/u/ts6321/release3/zowe-instance"
 
     while [ "${ZIS_PATH_DIR}" != "null" ] && [ -n "${ZIS_PATH_DIR}" ]; do
 

--- a/bin/zowe-configure-component.sh
+++ b/bin/zowe-configure-component.sh
@@ -39,6 +39,7 @@ DEFAULT_TARGET_DIR=/global/zowe/extensions
 
 #######################################################################
 # Prepare shell environment
+
 if [ -z "${ZOWE_ROOT_DIR}" ]; then
   export ZOWE_ROOT_DIR=$(cd $(dirname $0)/../;pwd)
 fi
@@ -85,6 +86,66 @@ enable_component(){
             update_zowe_yaml_variable "components.${COMPONENT_NAME}.enabled" "true"
         fi
     fi
+}
+
+install_zis_plugin() {
+    iterator_index=0
+    ZIS_PATH_DIR=$(read_component_manifest "${TARGET_DIR}/${component_name}" ".zisPlugins[${iterator_index}].path" 2>/dev/null)
+    ZIS_INSTALL_DIR="${TARGET_DIR}/zss/bin"
+    ZIS_INSTALL_FILE="${ZIS_INSTALL_DIR}/zis-plugin-install.sh"
+    
+    INSTANCE_DIR="/u/ts6321/release3/zowe-instance"
+
+    while [ "${ZIS_PATH_DIR}" != "null" ] && [ -n "${ZIS_PATH_DIR}" ]; do
+
+      if [ -e "${INSTANCE_DIR}/instance.env" ]; then
+          if [ -n "$(read_zowe_instance_variable "ZWES_ZIS_PARMLIB")" ]; then
+              export ZIS_PARMLIB=$(read_zowe_instance_variable "ZWES_ZIS_PARMLIB")
+              log_message "ZIS PARM ${ZIS_PARMLIB}"
+          fi
+          if [ -n "$(read_zowe_instance_variable "ZWES_ZIS_PLUGINLIB")" ]; then
+              export ZIS_PLUGINLIB=$(read_zowe_instance_variable "ZWES_ZIS_PLUGINLIB")
+              log_message "ZIS PLUGIN ${ZIS_PARMLIB}"
+          fi
+      fi
+
+      if [ -n "${ZWES_ZIS_PARMLIB}" ]; then #Checks existing env variables
+          export ZIS_PARMLIB="${ZWES_ZIS_PARMLIB}"
+      fi
+          
+      if [ -n "${ZWES_ZIS_PLUGINLIB}" ]; then
+          export ZIS_PLUGINLIB="${ZWES_ZIS_PLUGINLIB}"
+      fi
+
+      if [[ -z "${ZIS_PARMLIB}" ]]; then
+          log_message "ZIS_PARMLIB N/A from env or instance. Skipping ZIS plugin check."
+      else
+          if [[ -z "${ZIS_PLUGINLIB}" ]]; then
+              log_message "ZIS_PLUGINLIB N/A from env or instance. Skipping ZIS plugin check."
+          else
+              if test -f "$ZIS_INSTALL_FILE"; then
+                  if [ -n "${ZIS_PATH_DIR}" ]; then 
+                      LOADLIB=$(read_component_manifest "${TARGET_DIR}/${component_name}" ".zisPlugins[${iterator_index}].loadlib" 2>/dev/null)
+                      if [ "${LOADLIB}" = "null" ] || [ -z "${LOADLIB}" ]; then # Check custom defined lib directories in manifest.yaml
+                          LOADLIB="loadlib" # default
+                      fi
+                      SAMPLIB=$(read_component_manifest "${TARGET_DIR}/${component_name}" ".zisPlugins[${iterator_index}].samplib" 2>/dev/null)
+                      if [ "${SAMPLIB}" = "null" ] || [ -z "${SAMPLIB}" ]; then
+                          SAMPLIB="samplib" #default
+                      fi
+                      # Need to cd because zis-plugin-install script relies on other relative scripts
+                      cd "${ZIS_INSTALL_DIR}" && ./zis-plugin-install.sh extended-install "${ZIS_PATH_DIR}/${LOADLIB}" "${ZIS_PATH_DIR}/${SAMPLIB}"
+                      # ZIS Plugin install script has its own logging, no need to send success message
+                  else 
+                      log_message "No ZIS plugins detected in manifest."
+                  fi
+              fi
+          fi
+      fi
+      iterator_index=`expr $iterator_index + 1`
+      ZIS_PATH_DIR=$(read_component_manifest "${TARGET_DIR}/${component_name}" ".zisPlugins[${iterator_index}].path" 2>/dev/null)
+      
+    done
 }
 
 install_app_framework_plugin(){
@@ -135,7 +196,7 @@ while [ $# -gt 0 ]; do #Checks for parameters
             COMPONENT_NAME=$1
             shift
         ;;
-        -i|--instance-dir) #Represents the path to zowe's instance directory (optional)
+        -i|--instance_dir) #Represents the path to zowe's instance directory (optional)
             shift
             path=$(get_full_path "$1")
             validate_directory_is_accessible "${path}"
@@ -143,10 +204,10 @@ while [ $# -gt 0 ]; do #Checks for parameters
                 if [ -e "$path/instance.env" -o -e "$path/zowe.yaml" ]; then
                     INSTANCE_DIR=${path}
                 else
-                    error_handler "-i|--instance-dir: Given path is not a zowe instance directory"
+                    error_handler "-i|--instance_dir: Given path is not a zowe instance directory"
                 fi
             else
-                error_handler "-i|--instance-dir: Given path is not a zowe instance directory or does not exist"
+                error_handler "-i|--instance_dir: Given path is not a zowe instance directory or does not exist"
             fi
             shift
         ;;
@@ -154,7 +215,7 @@ while [ $# -gt 0 ]; do #Checks for parameters
             IS_ZOWE_CORE=true
             shift
         ;;
-        -d|--target-dir) # Represents the path to the desired target directory to place the extensions (optional)
+        -d|--target_dir) # Represents the path to the desired target directory to place the extensions (optional)
             shift
             TARGET_DIR=$(get_full_path "$1")
             shift
@@ -196,9 +257,6 @@ if [ -z "${TARGET_DIR}" ]; then
                 zwe_extension_dir=$(read_zowe_instance_variable "ZWE_EXTENSION_DIR")
             elif [ -e "${INSTANCE_DIR}/zowe.yaml" ]; then
                 zwe_extension_dir=$(read_zowe_yaml_variable ".zowe.extensionDirectory")
-                if [ "${zwe_extension_dir}" = "null" ]; then
-                    zwe_extension_dir=
-                fi
             fi
         fi
         if [ -z "${zwe_extension_dir}" ]; then
@@ -223,9 +281,6 @@ if [ "${IS_ZOWE_CORE}" = "false" ]; then
         zwe_extension_dir=$(read_zowe_instance_variable "ZWE_EXTENSION_DIR")
     elif [ -e "${INSTANCE_DIR}/zowe.yaml" ]; then
         zwe_extension_dir=$(read_zowe_yaml_variable ".zowe.extensionDirectory")
-        if [ "${zwe_extension_dir}" = "null" ]; then
-            zwe_extension_dir=
-        fi
     fi
     if [ -n "${zwe_extension_dir}" -a "${TARGET_DIR}" != "${zwe_extension_dir}" ]; then
         error_handler "It's recommended to install all Zowe extensions into same directory. The recommended target directory is ZWE_EXTENSION_DIR (${ZWE_EXTENSION_DIR}) defined in Zowe instance.env."
@@ -250,6 +305,7 @@ if [ "${IS_ZOWE_CORE}" = "false" ]; then
     install_app_framework_plugin
 fi
 enable_component
+install_zis_plugin
 
 #######################################################################
 # Conclude


### PR DESCRIPTION
<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [x] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Relevant issues
<!-- Link to a relevant GitHub issue if any. If this PR applies to multiple issues, preface each issue reference with the "Fixes" keyword. For example, Fixes #123, Fixes #456. -->

Fixes https://app.zenhub.com/workspaces/web-ui-squad-60549e46bd10bf00115d1f69/issues/zowe/zlux/670

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
- Automates ZIS plugin discovery & install ZIS libs to the right ZWES datasets using the ZIS plugin install script. The ZIS libs, and how to customize where they are pointed to, is described in the doc change here:
https://github.com/zowe/docs-site/pull/1729/files?short_path=388b865#diff-388b86598a43590a411488b297bc9583b1fcf194eb552bca1934351c23852dd7

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path below.-->

#### Does this PR do something the person installing Zowe should know about?

<!-- Is this a fix or a feature that changes customizable files (e.g. configuration files, sample JCL, etc),
product requirements, or other installation or configuration related area? If so, please fill out the template below. 
There is no need to report the need to restart the servers to activate the change. Note that the provided text will be formatted in 64-character lines, and that round brackets, ( and ), must always be used in matching pairs. -->

---
* Affected function: ZIS Plugin installation *

---
* Description: ZIS Plugins should now be installed during the zowe-configure-instance.sh step  *

---
* Part: *

---
How to Test? 

First, set up manifest.yaml to include ZIS plugins. Docs that describe the structure are in the link above. Here is a modified, sample manifest.yaml for the Jobs API component

```
---
# ===== Zowe Component Manifest Definition =====
# Component name

//...

apimlServices:
  static:
  - file: apiml-static-registration.yaml.template
zisPlugins:
  -
    id: yourplugin1
    path: /proj/yourplugin1/zisServer/
  -
    id: yourplugin2
    path: /proj/yourplugin2/zisServer/
```

#### Is there a related doc issue or Pull Request? 
<!-- Link to a relevant documentation issue or Pull Request if any. -->

Doc issue/PR number: 

#### Other information

