### PR TITLE
Remove pluginlib occurrences temporarily

### DIFF
--- a/bin/zowe-configure-instance.sh
+++ b/bin/zowe-configure-instance.sh
@@ -11,7 +11,7 @@
 ################################################################################
 
 if [ $# -lt 2 ]; then
-  echo "Usage: $0 -c zowe_install_directory [-g zowe_group] [--skip_temp | -d dsn_prefix | (-l loadlib -p parmlib -z zis_pluginlib)]"
+  echo "Usage: $0 -c zowe_install_directory [-g zowe_group] [--skip_temp | -d dsn_prefix | (-l loadlib -p parmlib)]"
   exit 1
 fi
 
@@ -49,11 +49,6 @@ while [ $# -gt 0 ]; do
     -p|--parmlib)
       shift
       ZIS_PARMLIB=$1
-      shift
-      ;;
-    -z|--zis_pluginlib)
-      shift
-      ZIS_PLUGINLIB=$1
       shift
       ;;
     -d|--dsn_prefix)
@@ -111,14 +106,15 @@ get_zis_params() {
   if [ ! -z "${DSN_PREFIX}" ]; then
     ZIS_PARMLIB=${DSN_PREFIX}.SZWESAMP
     ZIS_LOADLIB=${DSN_PREFIX}.SZWEAUTH
+    # currently unused
     ZIS_PLUGINLIB=${DSN_PREFIX}.SZWEPLUG
   else
     if [ -z "${ZIS_LOADLIB}" -o -z "${ZIS_PARMLIB}" ]; then
       if [ -n "${NO_TEMP}" ]; then
         echo_and_log "ZIS parameters wont be recorded due to missing arguments. You may record them in the instance configuration later."
-      elif [ -d "/tmp/zowe/${ZOWE_VERSION}" ]; then
+      elif [ -d "/tmp/zowe-${ZOWE_VERSION}" ]; then
         get_zowe_version
-        for file in /tmp/zowe/$ZOWE_VERSION/install-*.env; do
+        for file in /tmp/zowe-$ZOWE_VERSION/install-*.env; do
           if [[ -f "${file}" ]]; then
             ROOT_DIR_VAL=$(cat "${file}" | grep "^ZOWE_ROOT_DIR=" | cut -d'=' -f2)
             if [ "${ROOT_DIR_VAL}" = "${ZOWE_ROOT_DIR}" ]; then
@@ -133,6 +129,7 @@ get_zis_params() {
         else
           ZIS_PARMLIB=${ZOWE_DSN_PREFIX}.SZWESAMP
           ZIS_LOADLIB=${ZOWE_DSN_PREFIX}.SZWEAUTH
+          # currently unused
           ZIS_PLUGINLIB=${ZOWE_DSN_PREFIX}.SZWEPLUG
         fi
       else
@@ -143,7 +140,8 @@ get_zis_params() {
   echo "ZOWE_DSN_PREFIX=$ZOWE_DSN_PREFIX" >> ${LOG_FILE}
   echo "ZIS_PARMLIB=$ZIS_PARMLIB" >> ${LOG_FILE}
   echo "ZIS_LOADLIB=$ZIS_LOADLIB" >> ${LOG_FILE}
-  echo "ZIS_PLUGINLIB=$ZIS_PLUGINLIB" >> ${LOG_FILE}
+#  pluginlib code temporarily disabled but will be used again soon.
+#  echo "ZIS_PLUGINLIB=$ZIS_PLUGINLIB" >> ${LOG_FILE}
 }
 
 create_new_instance() {
@@ -162,7 +160,6 @@ create_new_instance() {
     -e "s#{{zowe_ip_address}}#${ZOWE_IP_ADDRESS}#" \
     -e "s#{{zwes_zis_loadlib}}#${ZIS_LOADLIB}#" \
     -e "s#{{zwes_zis_parmlib}}#${ZIS_PARMLIB}#" \
-    -e "s#{{zwes_zis_pluginlib}}#${ZIS_PLUGINLIB}#" \
     "${TEMPLATE}" \
     > "${INSTANCE}"
 

--- a/install/zowe-install.sh
+++ b/install/zowe-install.sh
@@ -215,9 +215,9 @@ record_zis_info() {
   # Later retrieve this info by looking in a known folder location with info that helps to disambiguate which install it originated from
   # This is not foolproof, but will use the info from the latest install of a given ROOT_DIR
   if [ "${RUN_ON_ZOS}" = "true" ]; then
-    mkdir -p /tmp/zowe/$ZOWE_VERSION
+    mkdir -p /tmp/zowe-${ZOWE_VERSION}
     CURRENT_TIME=`date +%Y%j%H%M%S`
-    INSTALL_VAR_FILE=/tmp/zowe/${ZOWE_VERSION}/install-${CURRENT_TIME}.env
+    INSTALL_VAR_FILE=/tmp/zowe-${ZOWE_VERSION}/install-${CURRENT_TIME}.env
     echo "ZOWE_DSN_PREFIX=$ZOWE_DSN_PREFIX\nZOWE_ROOT_DIR=$ZOWE_ROOT_DIR\nZOWE_VERSION=$ZOWE_VERSION" >> $INSTALL_VAR_FILE
   fi
 }

--- a/scripts/instance.template.env
+++ b/scripts/instance.template.env
@@ -76,7 +76,6 @@ ZOWE_ZSS_SERVER_PORT=8542
 ZOWE_ZSS_SERVER_TLS=true # Set this to false if you need to use ZSS without TLS (Backward-compat). May be needed if encountering desktop login failure due to app-server to ZSS communication failure
 ZOWE_ZSS_XMEM_SERVER_NAME=ZWESIS_STD
 ZWES_ZIS_LOADLIB={{zwes_zis_loadlib}}
-ZWES_ZIS_PLUGINLIB={{zwes_zis_pluginlib}}
 ZWES_ZIS_PARMLIB={{zwes_zis_parmlib}}
 ZWES_ZIS_PARMLIB_MEMBER=ZWESIP00
 


### PR DESCRIPTION
This is a partial reversion to accompany https://github.com/zowe/zowe-install-packaging/pull/2216 by removing references to pluginlib. the rest of the code for better or worse can record locations of loadlib, parmlib in non-smpe settings and allow manual entry for smpe which will help zis plugin automation down the line.