### PR TITLE
dummy ompzowe/zowe-launch-scripts workflow

### DIFF
--- a/.github/workflows/zowe-launch-scripts-images.yml
+++ b/.github/workflows/zowe-launch-scripts-images.yml
@@ -1,0 +1,16 @@
+name: Build ompzowe/zowe-launch-scripts
+on:
+  # push:
+  # pull_request:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'Set to "true" if we want to release the base images'
+        required: false
+        default: ''
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

Another dummy workflow to enable manual build.