### PR TITLE
App server container support

### DIFF
--- a/containers/kubernetes/workloads/app-server-deployment.yaml
+++ b/containers/kubernetes/workloads/app-server-deployment.yaml
@@ -116,6 +116,7 @@ spec:
               mountPath: "/home/zowe/runtime"
             - name: zowe-instance
               mountPath: "/home/zowe/instance"
+---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/containers/kubernetes/workloads/app-server-deployment.yaml
+++ b/containers/kubernetes/workloads/app-server-deployment.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-server
+  namespace: zowe
+  labels:
+    app.kubernetes.io/name: zowe
+    app.kubernetes.io/instance: zowe
+    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/component: app-server
+    app.kubernetes.io/part-of: app-server
+    app.kubernetes.io/managed-by: manual
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zowe
+      app.kubernetes.io/instance: zowe
+      app.kubernetes.io/component: app-server
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zowe
+        app.kubernetes.io/instance: zowe
+        app.kubernetes.io/component: app-server
+    spec:
+      securityContext:
+        runAsUser: 20000
+        runAsGroup: 20000
+        fsGroup: 20000
+      serviceAccountName: zowe-sa
+      volumes:
+        - name: zowe-runtime
+          emptyDir: {}
+        - name: zowe-instance
+          emptyDir: {}
+        - name: zowe-config
+          configMap:
+            name: zowe-config
+        - name: zowe-keystore
+          projected:
+            sources:
+            - configMap:
+                name: zowe-certificates-cm
+            - secret:
+                name: zowe-certificates-secret
+        - name: zowe-workspace
+          persistentVolumeClaim:
+            claimName: zowe-workspace-pvc
+      containers:
+        - name: app-server
+          image: zowe-docker-release.jfrog.io/ompzowe/app-server:1.24.0-ubuntu-amd64
+          imagePullPolicy: Always
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
+          ports:
+            - containerPort: 8547
+              protocol: TCP
+          command: ["/bin/bash", "-c"]
+          args:
+            - "/home/zowe/instance/bin/internal/run-zowe.sh"
+          env:
+            - name: ZWE_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","/home/zowe/runtime/bin/internal/container-prestop.sh"]
+          securityContext:
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: zowe-runtime
+              mountPath: "/home/zowe/runtime"
+            - name: zowe-instance
+              mountPath: "/home/zowe/instance"
+            - name: zowe-config
+              mountPath: "/home/zowe/instance/instance.env"
+              subPath: instance.env
+              readOnly: true
+            - name: zowe-keystore
+              mountPath: "/home/zowe/keystore/"
+              readOnly: true
+            - name: zowe-workspace
+              mountPath: "/home/zowe/instance/workspace"
+      initContainers:
+        - name: init-zowe
+          # image: zowe-docker-release.jfrog.io/ompzowe/zowe-launch-scripts:latest
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:1.24.0-ubuntu.staging
+          imagePullPolicy: Always
+          securityContext:
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: zowe-runtime
+              mountPath: "/home/zowe/runtime"
+            - name: zowe-instance
+              mountPath: "/home/zowe/instance"

--- a/files/zlux/config/plugins/org.zowe.configjs.json
+++ b/files/zlux/config/plugins/org.zowe.configjs.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.configjs",
-  "pluginLocation": "components/app-server/share/zlux-server-framework/plugins/config",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "zlux-server-framework/plugins/config",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.editor.json
+++ b/files/zlux/config/plugins/org.zowe.editor.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.editor",
-  "pluginLocation": "components/app-server/share/zlux-editor",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "zlux-editor",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.explorer-ip.json
+++ b/files/zlux/config/plugins/org.zowe.explorer-ip.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.explorer-ip",
-  "pluginLocation": "components/app-server/share/explorer-ip",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "explorer-ip",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.terminal.proxy.json
+++ b/files/zlux/config/plugins/org.zowe.terminal.proxy.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.terminal.proxy",
-  "pluginLocation": "components/app-server/share/zlux-server-framework/plugins/terminal-proxy",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "zlux-server-framework/plugins/terminal-proxy",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.terminal.tn3270.json
+++ b/files/zlux/config/plugins/org.zowe.terminal.tn3270.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.terminal.tn3270",
-  "pluginLocation": "components/app-server/share/tn3270-ng2",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "tn3270-ng2",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.terminal.vt.json
+++ b/files/zlux/config/plugins/org.zowe.terminal.vt.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.terminal.vt",
-  "pluginLocation": "components/app-server/share/vt-ng2",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "vt-ng2",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.agent.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.agent.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.zlux.agent",
-  "pluginLocation": "components/app-server/share/zlux-server-framework/plugins/zlux-agent",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "zlux-server-framework/plugins/zlux-agent",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.appmanager.app.propview.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.appmanager.app.propview.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.zlux.appmanager.app.propview",
-  "pluginLocation": "components/app-server/share/zlux-app-manager/system-apps/app-prop-viewer",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "zlux-app-manager/system-apps/app-prop-viewer",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.auth.safsso.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.auth.safsso.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.zlux.auth.safsso",
-  "pluginLocation": "components/app-server/share/zlux-server-framework/plugins/sso-auth",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "zlux-server-framework/plugins/sso-auth",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.bootstrap.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.bootstrap.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.zlux.bootstrap",
-  "pluginLocation": "components/app-server/share/zlux-app-manager/bootstrap",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "zlux-app-manager/bootstrap",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.zlux",
-  "pluginLocation": "components/app-server/share/zlux-server-framework/plugins/zlux-server",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "zlux-server-framework/plugins/zlux-server",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.logger.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.logger.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.zlux.logger",
-  "pluginLocation": "components/app-server/share/zlux-shared/src/logging",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "zlux-shared/src/logging",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.ng2desktop.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.ng2desktop.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.zlux.ng2desktop",
-  "pluginLocation": "components/app-server/share/zlux-app-manager/virtual-desktop",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "zlux-app-manager/virtual-desktop",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.ng2desktop.settings.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.ng2desktop.settings.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.zlux.ng2desktop.settings",
-  "pluginLocation": "components/app-server/share/zlux-app-manager/system-apps/system-settings-preferences",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "zlux-app-manager/system-apps/system-settings-preferences",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.sample.angular.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.sample.angular.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.zlux.sample.angular",
-  "pluginLocation": "components/app-server/share/sample-angular-app",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "sample-angular-app",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.sample.iframe.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.sample.iframe.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.zlux.sample.iframe",
-  "pluginLocation": "components/app-server/share/sample-iframe-app",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "sample-iframe-app",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zlux.sample.react.json
+++ b/files/zlux/config/plugins/org.zowe.zlux.sample.react.json
@@ -1,5 +1,5 @@
 {
   "identifier": "org.zowe.zlux.sample.react",
-  "pluginLocation": "components/app-server/share/sample-react-app",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "sample-react-app",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }

--- a/files/zlux/config/plugins/org.zowe.zosmf.workflows.json
+++ b/files/zlux/config/plugins/org.zowe.zosmf.workflows.json
@@ -1,6 +1,6 @@
 {
   "identifier": "org.zowe.zosmf.workflows",
-  "pluginLocation": "components/app-server/share/zlux-workflow",
-  "relativeTo": "$ROOT_DIR"
+  "pluginLocation": "zlux-workflow",
+  "relativeTo": "$ZLUX_ROOT_DIR"
 }
 


### PR DESCRIPTION
This PR enables the app-server container to work by having the plugins relative paths reference the the zlux location, rather than the ROOT_DIR which is not the same in a container as it is on z/os.