### PR TITLE
Add link to the common java library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,7 @@ sed -e 's#{BUILD_BRANCH}#${env.BRANCH_NAME}#g' \
       // download components
       pipeline.artifactory.download(
         spec        : 'artifactory-download-spec.json',
-        expected    : 27
+        expected    : 28
       )
 
       // we want build log pulled in for SMP/e build

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -145,6 +145,13 @@
         "destinations": ["Zowe PAX"]
       }]
     }, {
+       "componentGroup": "Zowe common java libraries",
+       "entries": [{
+         "repository": "common-java",
+         "tag": "master",
+         "destinations": ["Zowe PAX"]
+       }]
+     }, {
       "componentGroup": "Zowe Application Framework",
       "entries": [{
           "repository": "zlux-app-manager",

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -107,6 +107,10 @@
     "org.zowe.apiml.sdk.apiml-common-lib-package": {
       "version": "1.24.4",
       "artifact": "apiml-common-lib-*.zip"
+    },            
+    "org.zowe.apiml.sdk.common-java-lib-package": {
+      "version": "1.21.3",
+      "artifact": "common-java-lib-*.zip"
     },
     "org.zowe.launcher": {
       "version": "0.0.5"


### PR DESCRIPTION
The library necessary for building the PAX file going forward from 1.24 release is added. AT-TLS functionality depends on this library.