### PR TITLE
Update scripts for pluginlib existence

### DIFF
--- a/bin/zowe-configure-component.sh
+++ b/bin/zowe-configure-component.sh
@@ -112,7 +112,9 @@ install_zis_plugin() {
       if [ -n "${ZWES_ZIS_PLUGINLIB}" ]; then
           export ZIS_PLUGINLIB="${ZWES_ZIS_PLUGINLIB}"
       fi
-
+      if [ -n "${ZWES_ZIS_INSTALL_TO_PLUGINLIB}" ]; then
+          export ZIS_INSTALL_TOPLUGINLIB="${ZWES_ZIS_INSTALL_TO_PLUGINLIB}"
+      fi
       if [[ -z "${ZIS_PARMLIB}" ]]; then
           log_message "ZIS_PARMLIB N/A from env or instance. Skipping ZIS plugin check."
       else

--- a/bin/zowe-configure-component.sh
+++ b/bin/zowe-configure-component.sh
@@ -113,7 +113,7 @@ install_zis_plugin() {
           export ZIS_PLUGINLIB="${ZWES_ZIS_PLUGINLIB}"
       fi
       if [ -n "${ZWES_ZIS_INSTALL_TO_PLUGINLIB}" ]; then
-          export ZIS_INSTALL_TOPLUGINLIB="${ZWES_ZIS_INSTALL_TO_PLUGINLIB}"
+          export ZIS_INSTALL_TO_PLUGINLIB="${ZWES_ZIS_INSTALL_TO_PLUGINLIB}"
       fi
       if [[ -z "${ZIS_PARMLIB}" ]]; then
           log_message "ZIS_PARMLIB N/A from env or instance. Skipping ZIS plugin check."

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -52,7 +52,7 @@
       "artifact": "*.pax"
     },
     "org.zowe.zss": {
-      "version": "~1.25.0-STAGING",
+      "version": "~1.25.0-PR-338",
       "artifact": "*.pax"
     },
     "org.zowe.explorer.jobs": {

--- a/scripts/instance.template.env
+++ b/scripts/instance.template.env
@@ -79,6 +79,9 @@ ZWES_ZIS_LOADLIB={{zwes_zis_loadlib}}
 ZWES_ZIS_PLUGINLIB={{zwes_zis_pluginlib}}
 ZWES_ZIS_PARMLIB={{zwes_zis_parmlib}}
 ZWES_ZIS_PARMLIB_MEMBER=ZWESIP00
+# pluginlib needs to be APF authorized and enabled in the ZIS JCL before plugins within can be used.
+# when set to false, plugins will be installed within the ZIS loadlib but these will be lost upon zowe upgrade
+ZWES_ZIS_INSTALL_TO_PLUGINLIB=false
 
 # terminal app variables
 ZOWE_ZLUX_SSH_PORT=22

--- a/scripts/utils/zowe-copy-to-JES.sh
+++ b/scripts/utils/zowe-copy-to-JES.sh
@@ -10,7 +10,7 @@
 ################################################################################
 
 # Function: Copy SAMPLIB member into JES PROCLIB concatenation
-# Usage:  ./zowe-copy-to-JES.sh -s $samplib -i ${input_member} -r $proclib -o ${output_member} [-b $loadlib -a $parmlib]
+# Usage:  ./zowe-copy-to-JES.sh -s $samplib -i ${input_member} -r $proclib -o ${output_member} [-b $loadlib -a $parmlib -p $pluglib]
 
 # Needs ../internal/opercmd to check JES concatenation
 # Needs ./mcopyshr.clist to write to the target PDS
@@ -24,12 +24,13 @@
 # The changes made are equivalent to this:
 # sed -e "s/${XMEM_ELEMENT_ID}.SISLOAD/${XMEM_LOADLIB}/g" \
 #     -e "s/${XMEM_ELEMENT_ID}.SISSAMP/${XMEM_PARMLIB}/g" \
+#     -e "s/${XMEM_ELEMENT_ID}.SISPLUG/${XMEM_PLUBLIB}/g" \
 #     -e "s/NAME='ZWESIS_STD'/NAME='${XMEM_SERVER_NAME}'/g" \ (this default is not edited)
 #     ${ZSS}/SAMPLIB/ZWESIS01 > ${ZSS}/SAMPLIB/${XMEM_JCL}.tmp
 # sed -e "s/zis-loadlib/${XMEM_LOADLIB}/g" \
 #     ${ZSS}/SAMPLIB/ZWESAUX > ${ZSS}/SAMPLIB/${XMEM_AUX_JCL}.tmp
 
-while getopts "a:b:f:i:l:o:r:s:" opt; do
+while getopts "a:b:f:i:l:o:p:r:s:" opt; do
   case $opt in
     a) parmlib=$OPTARG;;
     b) loadlib=$OPTARG;;
@@ -37,6 +38,7 @@ while getopts "a:b:f:i:l:o:r:s:" opt; do
     i) input_member=$OPTARG;;
     l) LOG_DIRECTORY=$OPTARG;;
     o) output_member=$OPTARG;;
+    p) pluglib=$OPTARG;;
     r) proclib=$OPTARG;;
     s) samplib=$OPTARG;;
     \?)
@@ -167,11 +169,13 @@ else
   # Edit the JCL in flight using parms 5 and 6 ...
   # These strings are in ZWESISTC
       # ZWES.SISLOAD
-      # ZWES.SISSAMP 
+      # ZWES.SISSAMP
+      # ZWES.SISPLUG
   # These strings are in ZWESASTC
       # zis-loadlib
   #
   sed -e "s/ZWES.SISLOAD/${loadlib}/g" \
+      -e "s/ZWES.SISPLUG/${pluglib}/g" \
       -e "s/ZWES.SISSAMP/${parmlib}/g" \
       -e "s/zis-loadlib/${loadlib}/g" \
       "//'$samplib(${input_member})'" > $TEMP_DIR/$samplib.${input_member}.jcl

--- a/scripts/utils/zowe-install-xmem.sh
+++ b/scripts/utils/zowe-install-xmem.sh
@@ -201,6 +201,7 @@ script_exit 1
 fi
 
 authlib=`echo ${data_set_prefix}.SZWEAUTH | tr '[:lower:]' '[:upper:]'`
+pluglib=`echo ${data_set_prefix}.SZWEPLUG | tr '[:lower:]' '[:upper:]'`
 samplib=`echo ${data_set_prefix}.SZWESAMP | tr '[:lower:]' '[:upper:]'`
 
 if [[ -z ${parmlib} ]]
@@ -210,6 +211,7 @@ else
   parmlib=`echo ${parmlib} | tr '[:lower:]' '[:upper:]'`
 fi
 
+
 if [[ -z ${proclib} ]]
 then
   proclib=auto
@@ -218,11 +220,12 @@ else
 fi
 
 echo    "authlib =" $authlib >> $LOG_FILE
+echo    "pluglib =" $pluglib >> $LOG_FILE
 echo    "samplib =" $samplib >> $LOG_FILE
 echo    "parmlib =" $parmlib >> $LOG_FILE
 echo    "proclib =" $proclib >> $LOG_FILE
 
-for dsname in $authlib $samplib $parmlib $proclib
+for dsname in $authlib $samplib $parmlib $proclib $pluglib
 do
   if [[ $proclib = auto ]]
   then
@@ -239,7 +242,12 @@ do
   if [[ $? -ne 0 ]]
   then
     echo Dataset \"$dsname\" not found | tee -a ${LOG_FILE}
-    script_exit 4
+    if [[ $dsname = $pluglib ]]
+    then
+      echo If ZIS plugin library desired, create \"$pluglib\" before installing ZIS plugins
+    else
+      script_exit 4
+    fi
   fi
 done
 
@@ -297,7 +305,7 @@ ZWEXMP00=ZWESIP00  # for ZWESIS01
 ZWEXASTC=ZWESASTC  # for ZWESAUX
 ZWEXMSTC=ZWESISTC  # for ZWESIS01
 
-# the extra parms ${authlib} ${parmlib} are used to replace DSNs in PROCLIB members
+# the extra parms ${authlib} ${parmlib} ${pluglib} are used to replace DSNs in PROCLIB members
 ./zowe-copy-to-JES.sh \
   -s ${samplib} \
   -i ${ZWEXASTC} \
@@ -305,6 +313,7 @@ ZWEXMSTC=ZWESISTC  # for ZWESIS01
   -o ${ZWEXASTC} \
   -b ${authlib} \
   -a ${parmlib} \
+  -p ${pluglib} \
   -f ${LOG_FILE}
 aux_rc=$?
 echo "ZWEXASTC rc from zowe-copy-to-JES.sh is ${aux_rc}" >> ${LOG_FILE}
@@ -315,6 +324,7 @@ echo "ZWEXASTC rc from zowe-copy-to-JES.sh is ${aux_rc}" >> ${LOG_FILE}
   -o ${ZWEXMSTC} \
   -b ${authlib} \
   -a ${parmlib} \
+  -p ${pluglib} \
   -f ${LOG_FILE}
 xmem_rc=$?
 echo "ZWEXMSTC rc from zowe-copy-to-JES.sh is ${xmem_rc}" >> ${LOG_FILE}

--- a/scripts/zowe-install-MVS.sh
+++ b/scripts/zowe-install-MVS.sh
@@ -57,11 +57,13 @@ then
 # Statements below must not exceed col 80
 #----------------------------------------------------------------------------80|
 cat > ${TEMP_DIR}/${script%%.*}/SAMPLIB/ZWESIPRG <<EndOfZWESIPRG
-/* issue this console command to authorize the loadlib temporarily */
+/* issue this console command to authorize loadlib, pluginlib temporarily */
 SETPROG APF,ADD,DSNAME=${ZOWE_DSN_PREFIX}.SZWEAUTH,VOLUME=${volume}
+SETPROG APF,ADD,DSNAME=${ZOWE_DSN_PREFIX}.SZWEPLUG,VOLUME=${volume}
 /* Add this statement to SYS1.PARMLIB(PROGxx) or equivalent
-   to authorize the loadlib permanently */
+   to authorize loadlib, pluginlib permanently */
 APF ADD DSNAME(${ZOWE_DSN_PREFIX}.SZWEAUTH) VOLUME(${volume})
+APF ADD DSNAME(${ZOWE_DSN_PREFIX}.SZWEPLUG) VOLUME(${volume})
 EndOfZWESIPRG
 #----------------------------------------------------------------------------80|
 fi

--- a/workflows/templates/ZWESECUR.vtl
+++ b/workflows/templates/ZWESECUR.vtl
@@ -396,8 +396,8 @@
 
 /* DEFINE ZOWE DATA SET PROTECTION ................................. */
 
-/* - HLQ..SZWEAUTH is an APF authorized data set. It is strongly     */
-/*   advised to protect it against updates.                          */
+/* - HLQ..SZWEAUTH and SZWEPLUG are APF authorized data sets.        */
+/*   It is strongly advised to protect it against updates.           */
 /* - The sample commands assume that EGN (Enhanced Generic Naming)   */
 /*   is active, which allows the usage of ** to represent any number */
 /*   of qualifiers in the DATASET class. Substitute *.** with * if   */
@@ -613,8 +613,8 @@ F ACF2,REBUILD(FAC)
 *
 * DEFINE ZOWE DATA SET PROTECTION .................................
 *
-* - HLQ..SZWEAUTH is an APF authorized data set. It is strongly
-*   advised to protect it against updates.
+* - HLQ..SZWEAUTH and SZWEPLUG are APF authorized data sets.
+*   It is strongly advised to protect it against updates.
 *
 *  HLQ stub
 SET RULE
@@ -812,8 +812,8 @@ $$
 
 /* DEFINE ZOWE DATA SET PROTECTION ................................. */
 
-/* - HLQ..SZWEAUTH is an APF authorized data set. It is strongly    */
-/*   advised to protect it against updates.                          */
+/* - HLQ..SZWEAUTH and SZWEPLUG are APF authorized data sets.        */
+/*   It is strongly advised to protect it against updates.           */
 
 /* HLQ stub                                                          */
   TSS ADD(&ADMINDEP.) DATASET(&HLQ..)


### PR DESCRIPTION
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [x] Feature <!-- non-breaking change which adds functionality -->

#### Changes proposed in this PR
This PR attempts to handle ZIS pluginlib in the same ways loadlib is handled, as it is an APF dataset for ZIS content, same as loadlib, with the only difference being that it is initially empty and exists at configure-time onward, rather than at install time.
Therefore, install references to loadlib cant also have pluginlib references, as pluginlib would not exist.
I have gone through scripts to determine if pluginlib references can be added, depending upon whether or not actions are attempting to be done on it before it exists. I believe I've covered it all.

Also, I added a new instance var ZWES_ZIS_INSTALL_TO_PLUGINLIB which makes zis plugin installing backward compatible and tolerant for if users have not yet created/configured the pluginlib.

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [x] No

<!-- If yes, please describe the impact and migration path below.-->
#### Is there a related doc issue or Pull Request? 

Doc issue/PR number:  https://github.com/zowe/docs-site/pull/1825

#### Other information

ZSS PR for the JCL https://github.com/zowe/zss/pull/338

