### PR TITLE
Add missing scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
+## `1.25.0`
+
+### New feautres and enhancements
+- app-server's uninstall-app.sh script is now available in the instance bin folder.
+- zss's zis-plugin-install.sh script is now available in the instance bin/utils folder.
+
 ## `1.24.0`
 
 ### New features and enhancements

--- a/bin/zowe-configure-instance.sh
+++ b/bin/zowe-configure-instance.sh
@@ -251,7 +251,10 @@ else
 fi
 
 #Make install-app.sh present per-instance for convenience
+# TODO V2: These shouldn't be in bin, these should be called by the component installer. Put them in bin/utils
 cp ${ZOWE_ROOT_DIR}/components/app-server/share/zlux-app-server/bin/install-app.sh ${INSTANCE_DIR}/bin/install-app.sh
+cp ${ZOWE_ROOT_DIR}/components/app-server/share/zlux-app-server/bin/uninstall-app.sh ${INSTANCE_DIR}/bin/uninstall-app.sh
+cp ${ZOWE_ROOT_DIR}/components/zss/bin/zis-plugin-install.sh ${INSTANCE_DIR}/bin/utils/zis-plugin-install.sh
 # copy other files we needed for <instance>/bin
 cp -R ${ZOWE_ROOT_DIR}/bin/instance/* ${INSTANCE_DIR}/bin
 


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [x] Bugfix <!-- non-breaking change which fixes an issue -->

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
Certain useful scripts for app-server and zss are not currently available in the instance directory. This could lead to users finding the scripts in component directories, using them, and then possibly later having a problem if we decide to move or rename files within component directories, since they are internal & undocumented.
This attempts to fix the problem by putting useful scripts into the instance, where we will not make name or location changes that will cause issues unless there is some kind of major version change. 

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path below.-->

#### Does this PR do something the person installing Zowe should know about?

I don't like the location of install-app.sh, as people should have components and use the component installer instead of install-app. But, I can't move it right now, it would be a breaking change for some.

Also, the component installers should be here too. But I don't know, the scripts may need adjustment to live in the instance location.