### PR TITLE
Target missing bugfix

### DIFF
--- a/bin/zowe-configure-instance.sh
+++ b/bin/zowe-configure-instance.sh
@@ -250,10 +250,11 @@ else
   create_new_instance
 fi
 
-#Make install-app.sh present per-instance for convenience
+#Make plugin install scripts present per-instance for convenience
+mkdir -p ${INSTANCE_DIR}/bin/utils
 # TODO V2: These shouldn't be in bin, these should be called by the component installer. Put them in bin/utils
 cp ${ZOWE_ROOT_DIR}/components/app-server/share/zlux-app-server/bin/install-app.sh ${INSTANCE_DIR}/bin/install-app.sh
-cp ${ZOWE_ROOT_DIR}/components/app-server/share/zlux-app-server/bin/uninstall-app.sh ${INSTANCE_DIR}/bin/uninstall-app.sh
+cp ${ZOWE_ROOT_DIR}/components/app-server/share/zlux-app-server/bin/uninstall-app.sh ${INSTANCE_DIR}/bin/uninstall-app.shmkdir -p ${INSTANCE_DIR}/bin/utils
 cp ${ZOWE_ROOT_DIR}/components/zss/bin/zis-plugin-install.sh ${INSTANCE_DIR}/bin/utils/zis-plugin-install.sh
 # copy other files we needed for <instance>/bin
 cp -R ${ZOWE_ROOT_DIR}/bin/instance/* ${INSTANCE_DIR}/bin


### PR DESCRIPTION
This is a very small fix.
I noticed that https://github.com/zowe/zowe-install-packaging/pull/2366/files#diff-c63db39e2b7ed310c913b756f87979d3794db9b6aae58afd55a87be7de7ec5d7R257 causes an error and results in the file not being copied, because the utils directory does not yet exist.
It apparently comes from doing a pattern copy from ROOT_DIR, so either making the directory first, or moving these cp actions to after the ROOT_DIR copy will fix the problem.