### PR TITLE
Update sourceDependencies for Zowe CLI v2

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -130,7 +130,7 @@
       "componentGroup": "Imperative CLI Framework for Zowe",
       "entries": [{
         "repository": "imperative",
-        "tag": "master",
+        "tag": "next",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
@@ -209,21 +209,21 @@
       "componentGroup": "Zowe CLI",
       "entries": [{
         "repository": "zowe-cli",
-        "tag": "master",
+        "tag": "next",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
       "componentGroup": "IBM&reg CICS&reg Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-cics-plugin",
-        "tag": "master",
+        "tag": "next",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
       "componentGroup": "IBM&reg Db2&reg Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-db2-plugin",
-        "tag": "master",
+        "tag": "next",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
@@ -237,14 +237,7 @@
       "componentGroup": "IBM&reg MQ Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-mq-plugin",
-        "tag": "master",
-        "destinations": ["Zowe CLI Package"]
-      }]
-    }, {
-      "componentGroup": "Secure Credential Store Plug-in for Zowe CLI",
-      "entries": [{
-        "repository": "zowe-cli-scs-plugin",
-        "tag": "master",
+        "tag": "next",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
@@ -258,7 +251,7 @@
       "componentGroup": "IBM&reg IMS&reg Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-ims-plugin",
-        "tag": "master",
+        "tag": "next",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {


### PR DESCRIPTION
* Updated Imperative, Zowe CLI, and CICS/DB2/IMS/MQ plug-ins to point to next branch
* Removed Secure Credential Store which is no longer supported in vNext
* No changes to perf-timing and FTP plug-in which don't have next branches