### PR TITLE
update launcher version to 0.0.8

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -117,7 +117,7 @@
       "artifact": "common-java-lib-*.zip"
     },
     "org.zowe.launcher": {
-      "version": "0.0.7"
+      "version": "0.0.8"
     },
     "org.zowe.keyring-utilities": {
       "version": "1.0.4",
@@ -405,7 +405,7 @@
         "destinations": ["Zowe PAX"]
       }, {
         "repository": "launcher",
-        "tag": "v0.0.7",
+        "tag": "v0.0.8",
         "destinations": ["Zowe PAX"]
       }]
     },


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

To include fix of https://github.com/zowe/launcher/pull/31