### PR TITLE
Fix certificate init by checking keytool location

### DIFF
--- a/bin/libs/certificate.sh
+++ b/bin/libs/certificate.sh
@@ -28,11 +28,23 @@ ZWE_PRIVATE_DEFAULT_CERTIFICATE_VALIDITY="3650"
 ZWE_PRIVATE_DEFAULT_CERTIFICATE_KEY_USAGE="keyEncipherment,digitalSignature,nonRepudiation,dataEncipherment"
 ZWE_PRIVATE_DEFAULT_CERTIFICATE_EXTENDED_KEY_USAGE="clientAuth,serverAuth"
 
+
+keytool_on_path=`type keytool &> /dev/null && echo true`
+if [ "${keytool_on_path}" != "true" ]; then
+  if [ -n "${JAVA_HOME}" ]; then
+    keytool_bin="${JAVA_HOME}/bin/keytool"
+  else
+    print_message "WARNING: keytool cannot be found, please put on PATH or define JAVA_HOME"
+  fi
+else
+  keytool_bin=keytool
+fi
+
 pkeytool() {
   args=$@
 
-  print_debug "- Calling keytool ${args}"
-  result=$(keytool "$@" 2>&1)
+  print_debug "- Calling ${keytool_bin} ${args}"
+  result=$("${keytool_bin}" "$@" 2>&1)
   code=$?
 
   if [ ${code} -eq 0 ]; then


### PR DESCRIPTION
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [x] Bugfix <!-- non-breaking change which fixes an issue -->

#### Relevant issues
Fixes https://github.com/zowe/zowe-install-packaging/issues/2608

#### Changes proposed in this PR
Small check for if we can really use `keytool` or need to reference `JAVA_HOME` to find it instead

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->


- [x] No