### PR TITLE
Update zlux-core manifest

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -12,7 +12,7 @@
   },
   "binaryDependencies": {
     "org.zowe.zlux.zlux-core": {
-      "version": "~2.0.0-zlux-build-",
+      "version": "~2.0.0-v2.x-staging-zlux-core",
       "artifact": "*.pax"
     },
     "org.zowe.zlux.sample-angular-app": {


### PR DESCRIPTION
This aligns the manifest of v2 to match the current staging name scheme for zlux-core.