### PR TITLE
Improve zwe documentation generation

### DIFF
--- a/.dependency/zwe_doc_generation/index.js
+++ b/.dependency/zwe_doc_generation/index.js
@@ -19,15 +19,9 @@ writeMdFiles(rootDocNode);
 
 function writeMdFiles(docNode, writtenParentNode = {}) {
     const { mdContent, assembledDocNode } = generateDocumentationForNode(docNode, writtenParentNode);
-    let directoryToWriteFile = generatedDocDirectory + '/' + assembledDocNode.command.replace(/\s/g, '/');
-    if (assembledDocNode.children && assembledDocNode.children.length) {
-        // create directory for command
-        if (!fs.existsSync(directoryToWriteFile)) {
-            fs.mkdirSync(directoryToWriteFile);
-        }
-    } else {
-        // remove last segment from file path so directory isn't created for child command
-        directoryToWriteFile = directoryToWriteFile.substring(0, directoryToWriteFile.lastIndexOf('/'));
+    const directoryToWriteFile = generatedDocDirectory + '/' + assembledDocNode.directory;
+    if (!fs.existsSync(directoryToWriteFile)) {
+        fs.mkdirSync(directoryToWriteFile, { recursive: true});
     }
     fs.writeFileSync(`${directoryToWriteFile}/${assembledDocNode.fileName}.md`, mdContent);
 

--- a/.dependency/zwe_doc_generation/index.js
+++ b/.dependency/zwe_doc_generation/index.js
@@ -20,11 +20,14 @@ writeMdFiles(rootDocNode);
 function writeMdFiles(docNode, writtenParentNode = {}) {
     const { mdContent, parts } = generateDocumentationForNode(docNode, writtenParentNode);
     let directoryToWriteFile = generatedDocDirectory + '/' + parts.command.replace(/\s/g, '/');
-    if (parts.children) {
+    if (parts.children && parts.children.length) {
         // create directory for command
         if (!fs.existsSync(directoryToWriteFile)) {
             fs.mkdirSync(directoryToWriteFile);
         }
+    } else {
+        // remove last segment from file path so directory isn't created for child command
+        directoryToWriteFile = directoryToWriteFile.substring(0, directoryToWriteFile.lastIndexOf('/'));
     }
     fs.writeFileSync(`${directoryToWriteFile}/${parts.fileName}.md`, mdContent);
 

--- a/.dependency/zwe_doc_generation/index.js
+++ b/.dependency/zwe_doc_generation/index.js
@@ -19,7 +19,14 @@ writeMdFiles(rootDocNode);
 
 function writeMdFiles(docNode, writtenParentNode = {}) {
     const { mdContent, parts } = generateDocumentationForNode(docNode, writtenParentNode);
-    fs.writeFileSync(`${generatedDocDirectory}/${parts.fileName}.md`, mdContent);
+    let directoryToWriteFile = generatedDocDirectory + '/' + parts.command.replace(/\s/g, '/');
+    if (parts.children) {
+        // create directory for command
+        if (!fs.existsSync(directoryToWriteFile)) {
+            fs.mkdirSync(directoryToWriteFile);
+        }
+    }
+    fs.writeFileSync(`${directoryToWriteFile}/${parts.fileName}.md`, mdContent);
 
     if (docNode.children && docNode.children.length) {
         for (const child of docNode.children) {

--- a/.dependency/zwe_doc_generation/index.js
+++ b/.dependency/zwe_doc_generation/index.js
@@ -18,9 +18,9 @@ const rootDocNode = getDocumentationTree({ dir: path.join(__dirname, '../../bin/
 writeMdFiles(rootDocNode);
 
 function writeMdFiles(docNode, writtenParentNode = {}) {
-    const { mdContent, parts } = generateDocumentationForNode(docNode, writtenParentNode);
-    let directoryToWriteFile = generatedDocDirectory + '/' + parts.command.replace(/\s/g, '/');
-    if (parts.children && parts.children.length) {
+    const { mdContent, assembledDocNode } = generateDocumentationForNode(docNode, writtenParentNode);
+    let directoryToWriteFile = generatedDocDirectory + '/' + assembledDocNode.command.replace(/\s/g, '/');
+    if (assembledDocNode.children && assembledDocNode.children.length) {
         // create directory for command
         if (!fs.existsSync(directoryToWriteFile)) {
             fs.mkdirSync(directoryToWriteFile);
@@ -29,11 +29,11 @@ function writeMdFiles(docNode, writtenParentNode = {}) {
         // remove last segment from file path so directory isn't created for child command
         directoryToWriteFile = directoryToWriteFile.substring(0, directoryToWriteFile.lastIndexOf('/'));
     }
-    fs.writeFileSync(`${directoryToWriteFile}/${parts.fileName}.md`, mdContent);
+    fs.writeFileSync(`${directoryToWriteFile}/${assembledDocNode.fileName}.md`, mdContent);
 
     if (docNode.children && docNode.children.length) {
         for (const child of docNode.children) {
-            writeMdFiles(child, parts);
+            writeMdFiles(child, assembledDocNode);
         }
     }
 }

--- a/.dependency/zwe_doc_generation/md-content.js
+++ b/.dependency/zwe_doc_generation/md-content.js
@@ -63,7 +63,7 @@ function generateDocumentationForNode(curNode, assembledParentNode) {
     }
 
     return {
-        parts: assembledDocNode,
+        assembledDocNode,
         mdContent: mdContent
     };
 }
@@ -72,12 +72,19 @@ function assembleDocumentationElementsForNode(curNode, assembledParentNode) {
     const fileName = getFileName(curNode.command, assembledParentNode.fileName);
     const command = assembledParentNode.command ? assembledParentNode.command + ' ' + curNode.command : curNode.command;
     const link = `[${curNode.command}](./${fileName})`;
-    const linkCommand = assembledParentNode.linkCommand ? `${assembledParentNode.linkCommand} > ${link}` : link;
+    const linkCommandElements = assembledParentNode.linkCommandElements ? [...assembledParentNode.linkCommandElements, link] : [link];
 
+    for (let elementIndex = 0; elementIndex < linkCommandElements.length - 1; elementIndex++) {
+        // add '../'to make link to parent commands proper given the directory structure
+        linkCommandElements[elementIndex] = linkCommandElements[elementIndex].replace(/\(/, '(../'); // path starts after '(', so add '../' after '('
+    }
+
+    const linkCommand = linkCommandElements.join(' > ');
     const docElements = {
         fileName,
         command,
         linkCommand,
+        linkCommandElements,
         children: curNode.children,
     };
 

--- a/.dependency/zwe_doc_generation/md-content.js
+++ b/.dependency/zwe_doc_generation/md-content.js
@@ -35,7 +35,7 @@ function generateDocumentationForNode(curNode, assembledParentNode) {
 
     if (children.length) {
         mdContent += ' [sub-command [sub-command]...] [parameter [parameter]...]' + SEPARATOR;
-        mdContent += SECTION_HEADER_PREFIX + 'Sub-commands' + SEPARATOR + children.map(c => `* [${c.command}](./${getFileName(c.command, fileName)})`).join('\n');
+        mdContent += SECTION_HEADER_PREFIX + 'Sub-commands' + SEPARATOR + children.map(c => `* [${c.command}](./${getRelativeFilePathForChild(c, fileName)})`).join('\n');
     } else {
         mdContent += ' [parameter [parameter]...]';
     }
@@ -69,7 +69,7 @@ function generateDocumentationForNode(curNode, assembledParentNode) {
 }
 
 function assembleDocumentationElementsForNode(curNode, assembledParentNode) {
-    const fileName = getFileName(curNode.command, assembledParentNode.fileName);
+    const fileName = assembledParentNode.fileName ? `${assembledParentNode.fileName}-${curNode.command}` : curNode.command;
     const command = assembledParentNode.command ? assembledParentNode.command + ' ' + curNode.command : curNode.command;
     const link = `[${curNode.command}](./${fileName})`;
     const linkCommandElements = assembledParentNode.linkCommandElements ? [...assembledParentNode.linkCommandElements, link] : [link];
@@ -170,8 +170,12 @@ function createMdTable(rawContent, docFileTableSyntax) {
     return docContent;
 }
 
-function getFileName(command, parentFileName) {
-    return parentFileName ? `${parentFileName}-${command}` : command;
+function getRelativeFilePathForChild(child, curCommandFileName) {
+    if (curCommandFileName) {
+        const childFileName = `${curCommandFileName}-${child.command}`;
+        return child.children.length ? child.command + '/' + childFileName : childFileName;
+    }
+    return child.command;
 }
 
 function hasDocType(docNode, type) {

--- a/.dependency/zwe_doc_generation/md-content.js
+++ b/.dependency/zwe_doc_generation/md-content.js
@@ -72,8 +72,13 @@ function assembleDocumentationElementsForNode(curNode, assembledParentNode) {
     const fileName = getFileName(curNode.command, assembledParentNode.fileName);
     const command = assembledParentNode.command ? assembledParentNode.command + ' ' + curNode.command : curNode.command;
     const link = `[${curNode.command}](./${fileName})`;
-    const linkCommandElements = assembledParentNode.linkCommandElements ? [...assembledParentNode.linkCommandElements, link] : [link];
 
+    let directory = assembledParentNode.directory ? assembledParentNode.directory : '.';
+    if (curNode.children.length) {
+        directory += '/' + curNode.command;
+    }
+
+    const linkCommandElements = assembledParentNode.linkCommandElements ? [...assembledParentNode.linkCommandElements, link] : [link];
     for (let elementIndex = 0; elementIndex < linkCommandElements.length - 1; elementIndex++) {
         // add '../'to make link to parent commands proper given the directory structure
         linkCommandElements[elementIndex] = linkCommandElements[elementIndex].replace(/\(/, '(../'); // path starts after '(', so add '../' after '('
@@ -85,6 +90,7 @@ function assembleDocumentationElementsForNode(curNode, assembledParentNode) {
         command,
         linkCommand,
         linkCommandElements,
+        directory,
         children: curNode.children,
     };
 

--- a/.dependency/zwe_doc_generation/md-content.js
+++ b/.dependency/zwe_doc_generation/md-content.js
@@ -15,12 +15,13 @@ const SECTION_HEADER_PREFIX = '## ';
 const SUB_SECTION_HEADER_PREFIX = '#' + SECTION_HEADER_PREFIX;
 const MD_TABLE_ROW_DELIMITER = '\n';
 const MD_TABLE_ENTRY_DELIMITER = '|';
+const CODE_SECTION = '```';
 
 // order content will appear, with prefix/postfix as needed
 const orderedDocumentationTypes = [
     { ...HELP, prefix: SECTION_HEADER_PREFIX + 'Description' + SEPARATOR },
     { ...EXPERIMENTAL },
-    { ...EXAMPLES, prefix: SECTION_HEADER_PREFIX + 'Examples' + SEPARATOR },
+    { ...EXAMPLES, prefix: SECTION_HEADER_PREFIX + 'Examples' + SEPARATOR + CODE_SECTION + '\n', postfix: '\n' + CODE_SECTION },
     { ...EXCLUSIVE_PARAMETERS, prefix: SECTION_HEADER_PREFIX + 'Parameters only for this command' + SEPARATOR },
     { ...PARAMETERS, prefix: SECTION_HEADER_PREFIX + 'Parameters' + SEPARATOR },
     { ...ERRORS, prefix: SECTION_HEADER_PREFIX + 'Errors' + SEPARATOR }

--- a/.dependency/zwe_doc_generation/md-content.js
+++ b/.dependency/zwe_doc_generation/md-content.js
@@ -72,16 +72,19 @@ function assembleDocumentationElementsForNode(curNode, assembledParentNode) {
     const fileName = getFileName(curNode.command, assembledParentNode.fileName);
     const command = assembledParentNode.command ? assembledParentNode.command + ' ' + curNode.command : curNode.command;
     const link = `[${curNode.command}](./${fileName})`;
+    const linkCommandElements = assembledParentNode.linkCommandElements ? [...assembledParentNode.linkCommandElements, link] : [link];
 
+    let relPathToParentLinks = './';
     let directory = assembledParentNode.directory ? assembledParentNode.directory : '.';
+
     if (curNode.children.length) {
         directory += '/' + curNode.command;
+        relPathToParentLinks = '../';
     }
 
-    const linkCommandElements = assembledParentNode.linkCommandElements ? [...assembledParentNode.linkCommandElements, link] : [link];
+    // add '../'to make link to parent commands proper given the directory structure
     for (let elementIndex = 0; elementIndex < linkCommandElements.length - 1; elementIndex++) {
-        // add '../'to make link to parent commands proper given the directory structure
-        linkCommandElements[elementIndex] = linkCommandElements[elementIndex].replace(/\(/, '(../'); // path starts after '(', so add '../' after '('
+        linkCommandElements[elementIndex] = linkCommandElements[elementIndex].replace(/\(/, '(' + relPathToParentLinks); // path starts after '(', so add '../' after '('
     }
 
     const linkCommand = linkCommandElements.join(' > ');

--- a/.github/workflows/zwe-doc-generation.yml
+++ b/.github/workflows/zwe-doc-generation.yml
@@ -45,7 +45,7 @@ jobs:
           # check out branch that will contain update and unsure there are no remote differences
           git checkout -b ${{ env.DOCS_SITE_COMMIT_BRANCH }}
           git pull origin ${{ env.DOCS_SITE_COMMIT_BRANCH }} || true # swallow error in case branch doesn't exist in remote
-          cp ../${{ env.ZWE_DOC_GENERATION_DIR }}/generated/* ${{ env.DOCS_SITE_ZWE_COMMAND_REFERENCE_DIR }}
+          cp -R ../${{ env.ZWE_DOC_GENERATION_DIR }}/generated/* ${{ env.DOCS_SITE_ZWE_COMMAND_REFERENCE_DIR }}
       
       - name: Commit changes to branch and push
         id: commitChanges

--- a/.github/workflows/zwe-doc-generation.yml
+++ b/.github/workflows/zwe-doc-generation.yml
@@ -10,7 +10,7 @@ on:
 env:
   DOCS_SITE_ZWE_COMMAND_REFERENCE_DIR: docs/appendix/zwe_server_command_reference
   # Will change this to a docs staging branch when v2 is out
-  DOCS_SITE_TARGET_BRANCH: v2-docs-branch
+  DOCS_SITE_TARGET_BRANCH: v2-doc-branch
   DOCS_SITE_COMMIT_BRANCH: auto-update-zwe-reference
   ZWE_DOC_GENERATION_DIR: .dependency/zwe_doc_generation
 


### PR DESCRIPTION
- Fixes a formatting bug with the examples not showing as code

- Improves `zwe` server command reference generation for the docs-site. The automation is fixed, [this action run](https://github.com/zowe/zowe-install-packaging/runs/5606036808?check_suite_focus=true) created [this PR to docs-site](https://github.com/zowe/docs-site/pull/2076) successfully.

- Adds a nav menu to the sidebar for the reference. Attached is a video created using a local version of the docs site to show the new nav menu.

https://user-images.githubusercontent.com/14897740/159085150-b2a4ff42-54ce-43b4-b3cd-badf46ece122.mov

PR with corresponding docs-site changes (sidebars.js update and the new documentation files): https://github.com/zowe/docs-site/pull/2077