### PR TITLE
Fix regression in default zss auth behavior

### DIFF
--- a/example-zowe.yaml
+++ b/example-zowe.yaml
@@ -508,6 +508,9 @@ components:
     port: 7557
     crossMemoryServerName: ZWESIS_STD
     tls: true
+    agent:
+      jwt:
+        fallback: true
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   jobs-api:


### PR DESCRIPTION
This fixes the default config to match how ZSS worked in v1. This value, fallback, was true but became false when we were refactoring to remove server.json