### PR TITLE
Fix potential value list for caching storage mode

### DIFF
--- a/example-zowe.yaml
+++ b/example-zowe.yaml
@@ -492,11 +492,11 @@ components:
 
     storage:
       evictionStrategy: reject
-      # can be inMemory, VSAM
+      # can be inMemory, VSAM or redis
       mode: VSAM
       size: 10000
       vsam:
-        # your VSAM data set created by ZWECSVSM job
+        # your VSAM data set created by "zwe init vsam" command or ZWECSVSM JCL
         # this is required if storage mode is VSAM
         name: ""
 

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -15,12 +15,12 @@
           "additionalProperties": false,
           "description": "Zowe setup configurations used by \"zwe install\" and \"zwe init\" commands.",
           "properties": {
-            "mvs": {
+            "dataset": {
               "type": "object",
               "additionalProperties": false,
               "description": "MVS data set related configurations",
               "properties": {
-                "hlq": {
+                "prefix": {
                   "type": "string",
                   "description": "Where Zowe MVS data sets will be installed"
                 },


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

In `example-zowe.yaml`, `redis` is missed from the list of possible supported values of caching service storage mode.