### PR TITLE
Update versions for Zowe CLI v2 RC2

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -126,7 +126,7 @@
       "componentGroup": "Imperative CLI Framework for Zowe",
       "entries": [{
         "repository": "imperative",
-        "tag": "v5.0.0-next.202204142147",
+        "tag": "v5.0.2",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
@@ -205,21 +205,21 @@
       "componentGroup": "Zowe CLI",
       "entries": [{
         "repository": "zowe-cli",
-        "tag": "v7.0.0-next.202204142300",
+        "tag": "v7.0.2",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
       "componentGroup": "IBM&reg CICS&reg Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-cics-plugin",
-        "tag": "v5.0.0-next.202204141925",
+        "tag": "v5.0.0",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
       "componentGroup": "IBM&reg Db2&reg Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-db2-plugin",
-        "tag": "v5.0.0-next.202204121850",
+        "tag": "v5.0.0",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
@@ -233,21 +233,21 @@
       "componentGroup": "IBM&reg MQ Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-mq-plugin",
-        "tag": "v3.0.0-next.202204141925",
+        "tag": "v3.0.0",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
       "componentGroup": "z/OS&reg FTP Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-ftp-plugin",
-        "tag": "v2.0.0-next.202204131412",
+        "tag": "v2.0.0",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
       "componentGroup": "IBM&reg IMS&reg Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-ims-plugin",
-        "tag": "v3.0.0-next.202204142150",
+        "tag": "v3.0.0",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {


### PR DESCRIPTION
⚠️ Do not merge until Imperative 5.0.2 and Zowe CLI 7.0.2 are published.