### PR TITLE
disable cleanup-ipc-mq.sh by default

### DIFF
--- a/bin/internal/prepare-instance.sh
+++ b/bin/internal/prepare-instance.sh
@@ -424,7 +424,7 @@ print_formatted_info "ZWELS" "prepare-instance.sh:${LINENO}" "starting Zowe inst
 print_formatted_debug "ZWELS" "prepare-instance.sh:${LINENO}" "use configuration defined in ${ZWELS_CONFIG_LOAD_METHOD}"
 
 # Fix node.js piles up in IPC message queue
-if [ "${ZWE_RUN_ON_ZOS}" = "true" ]; then
+if [ "${ZWE_RUN_ON_ZOS}" = "true" -a "${ZWE_PRIVATE_CLEANUP_IPC_MQ}" = "true" ]; then
   ${ROOT_DIR}/scripts/utils/cleanup-ipc-mq.sh
 fi
 


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

Based on node.js team suggestion, cleanup-ipc-mq.sh is not needed in newer node versions.

This PR will make cleanup-ipc-mq.sh optional and disabled by default.