### PR TITLE
remove IBM_JAVA_OPTIONS customization

### DIFF
--- a/bin/apiml_cm.sh
+++ b/bin/apiml_cm.sh
@@ -21,10 +21,6 @@
 # https://www.ibm.com/support/knowledgecenter/en/SSYKE2_8.0.0/com.ibm.java.security.component.80.doc/security-component/keytoolDocs/keytool_overview.html
 #
 
-if [ `uname` = "OS/390" ]; then
-    export IBM_JAVA_OPTIONS="-Dfile.encoding=IBM-1047"
-fi
-
 BASE_DIR=$(dirname "$0")
 PARAMS="$@"
 PWD=`pwd`


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

In older JDK, for example, 

```
java version "1.8.0_311"
Java(TM) SE Runtime Environment (build 8.0.7.0 - pmz6480sr7-20211025_01(SR7))
IBM J9 VM (build 2.9, JRE 1.8.0 z/OS s390x-64-Bit Compressed References 20211022_15212 (JIT enabled, AOT enabled)
OpenJ9   - 6abb372
OMR      - b898db9
IBM      - 2f2c48b)
JCL - 20210930_01 based on Oracle jdk8u311-b11
```

keytool -J argument will overwrite `IBM_JAVA_OPTIONS`.

But with newer JDK, for example,

```
java version "1.8.0_331"
Java(TM) SE Runtime Environment (build 8.0.7.10 - pmz6480sr7fp10-20220505_01(SR7 FP10))
IBM J9 VM (build 2.9, JRE 1.8.0 z/OS s390x-64-Bit Compressed References 20220427_27745 (JIT enabled, AOT enabled)
OpenJ9   - b15041a
OMR      - 3671a9f
IBM      - 1b0232b)
JCL - 20220504_01 based on Oracle jdk8u331-b09
```

`IBM_JAVA_OPTIONS` will overwrite keytool -J argument. This will result a failure when exporting z/OSMF certificates/CAs with command: `keytool -printcert -sslserver zosmf-host:port -J-Dfile.encoding=UTF8 -rfc`.
