### PR TITLE
config get workspace perm fix

### DIFF
--- a/bin/libs/configmgr.ts
+++ b/bin/libs/configmgr.ts
@@ -84,7 +84,8 @@ function writeMergedConfig(config: any): number {
     zwePrivateWorkspaceEnvDir=`${workspace}/.env`;
     std.setenv('ZWE_PRIVATE_WORKSPACE_ENV_DIR', zwePrivateWorkspaceEnvDir);
   }
-  const mkdirrc = mkdirp(zwePrivateWorkspaceEnvDir);
+  mkdirp(workspace, 0o770);
+  const mkdirrc = mkdirp(zwePrivateWorkspaceEnvDir, 0o700);
   if (mkdirrc) { return mkdirrc; }
   const destination = `${zwePrivateWorkspaceEnvDir}/.zowe-merged.yaml`;
   const jsonDestination = `${zwePrivateWorkspaceEnvDir}/.zowe.json`;


### PR DESCRIPTION
In the event the configmgr.ts file was the one creating the workspace directory, it was defaulting on permissions, so here was just set 770 on workspace and 700 on .envs like we have done before.