### PR TITLE
bugfix for internal config get for ha when no ha property

### DIFF
--- a/bin/commands/internal/config/get/index.ts
+++ b/bin/commands/internal/config/get/index.ts
@@ -22,6 +22,9 @@ export function execute(configPath:string, haInstance?: string) {
   }
   if (haInstance && (!configPath.startsWith(`haInstances.${haInstance}.`))) {
     output=fakejq.jqget(ZOWE_CONFIG, `.haInstances[${haInstance}].${configPath}`); //TODO expand path
+    if (!output) { //if the instance doesnt specify this onfig, we'll fallback to the base config.
+      output=fakejq.jqget(ZOWE_CONFIG, `.${configPath}`); //TODO expand path
+    }
   } else {
     output=fakejq.jqget(ZOWE_CONFIG, `.${configPath}`); //TODO expand path
   }


### PR DESCRIPTION
This is a bugfix for the case when you call `zwe internal config get` with ha specified, but the ha section either doesnt exist or the ha section doesnt have the requested parameter. in that case, we fallback to the global one.

test:
`zwe internal config get --configmgr --config "FILE(/edits.yaml):FILE(/zowe.yaml)" --ha-instance myhost --path .zowe.workspaceDirectory`


`zwe internal config get --configmgr --config "FILE(/edits.yaml):FILE(/zowe.yaml)" --path .zowe.workspaceDirectory`

they should be the same if there's no ha section for `myhost`, but in the `--ha-instance` case, you'd get a blank return!