### PR TITLE
Do not require schema files for extensions in manifest.yaml in 2.3

### DIFF
--- a/schemas/manifest-schema.json
+++ b/schemas/manifest-schema.json
@@ -5,7 +5,7 @@
   "description": "Manifest file spec for declaring properties of a zowe server component",
   "type": "object",
   "additionalProperties": true,
-  "required": [ "name", "id", "schemas" ],
+  "required": [ "name", "id" ],
   "properties": {
     "name": {
       "type": "string",


### PR DESCRIPTION
2.3 code is not yet doing extension schema validation of zowe.yaml, just a sanity test on manifest.yaml
However this manifest says you need a schema for zowe.yaml, which is kind of silly because we then dont do anything with it.
Until https://github.com/zowe/zowe-install-packaging/pull/3006 gets merged, i think we should just remove schema from the "required" field, so that we dont cause extension friction in 2.3