### PR TITLE
Move apimlServices.static.basePackage to apimlServices.basePackage in manifest schema

### DIFF
--- a/schemas/manifest-schema.json
+++ b/schemas/manifest-schema.json
@@ -135,6 +135,10 @@
       "description": "This section defines how the component will be registered to the API Mediation Layer Discovery Service.",
       "additionalProperties": false,
       "properties": {
+        "basePackage": {
+          "type": "string",
+          "description": "Defines the base package name of the extension. It is used to notify the extended service of the location for component scan."
+        },
         "dynamic": {
           "type": "array",
           "description": "This information will tell Zowe and users what services you will register under the Discovery service.",
@@ -160,10 +164,6 @@
               "file": {
                 "type": "string",
                 "description": "Defines the path to the static definition file. This file is supposed to be a template."
-              },
-              "basePackage": {
-                "type": "string",
-                "description": "Defines the base package name of the extension. It is used to notify the extended service of the location for component scan."
               }
             }
           }


### PR DESCRIPTION
- [ ] Necessary documentation (if appropriate) have been added / updated
... I need to update https://docs.zowe.org/stable/appendix/server-component-manifest/#:~:text=be%20a%20template.-,basePackage,-Defines%20the%20base when this gets merged.
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
- [x] Bugfix <!-- non-breaking change which fixes an issue -->

#### Changes proposed in this PR
Move apimlServices.static.basePackage to apimlServices.basePackage in manifest schema
Apparently this original value was never correct but never tested, now that 2.4 is doing more validation, we discovered this incorrect value.

#### Does this PR introduce a breaking change?
- [x] No - rather if not merged, we could cause an accidental break