### PR TITLE
Default component validation mode when missing for backwards compatibility.

### DIFF
--- a/bin/commands/components/install/extract/index.ts
+++ b/bin/commands/components/install/extract/index.ts
@@ -128,7 +128,7 @@ export function execute(componentFile: string, autoEncoding?: string): string {
     if (autoEncoding != 'no' && autotag == 'yes') {
       // automatically tag files
       common.printDebug("- Automatically tag files");
-      result = shell.execOutSync('sh', '-c', `${ZOWE_CONFIG.zowe.runtimeDirectory}/bin/utils/tag-files.sh" "${tmpDir}" 2>&1`);
+      result = shell.execOutSync('sh', '-c', `"${ZOWE_CONFIG.zowe.runtimeDirectory}/bin/utils/tag-files.sh" "${tmpDir}" 2>&1`);
       if (result.out) {
         common.printTrace(result.out);
       }

--- a/bin/libs/component.ts
+++ b/bin/libs/component.ts
@@ -226,7 +226,8 @@ export function validateConfigForComponent(componentId: string, manifest: any, c
     configPath=`FILE(${configPath})`; 
   }
   const schemas = getSchemasForComponentConfig(manifest, componentDir);
-  if (!schemas && ZOWE_CONFIG.zowe.configmgr.validation != 'COMPONENT-COMPAT') { //can be undefined if not stated in manifest.yaml
+  const validationMode = ZOWE_CONFIG.zowe.configmgr?.validation ? ZOWE_CONFIG.zowe.configmgr.validation : 'COMPONENT-COMPAT';
+  if (!schemas && validationMode == 'COMPONENT-COMPAT') { //can be undefined if not stated in manifest.yaml
     common.printError(`Component ${componentId} is missing property manifest property schemas.configs, validation will fail`);
     return false;
   } else if (!schemas) {

--- a/bin/libs/config.ts
+++ b/bin/libs/config.ts
@@ -75,7 +75,7 @@ export function zosConvertEnvDirFileEncoding(file: string) {
   if (encoding && encoding != 0 && encoding != 1047) {
     const tmpfile=`${std.getenv('ZWE_PRIVATE_WORKSPACE_ENV_DIR')}/t`;
     os.remove(tmpfile);
-    shell.execSync(`iconv`, `-f`, ""+encoding, `-t`, `IBM-1047`, file, `>`, tmpfile);
+    shell.execSync('sh', '-c', `iconv -f "${encoding}" -t "IBM-1047" "${file}" > "${tmpfile}"`);
     os.rename(tmpfile, file);
     shell.execSync('chmod', `640`, file);
     common.printTrace(`>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>AFTER ${file}`);

--- a/bin/libs/zos-fs.ts
+++ b/bin/libs/zos-fs.ts
@@ -63,7 +63,7 @@ export function detectFileEncoding(fileName: string, expectedSample: string, exp
            autoEncoding) && !fileContents.includes(expectedSample)) {
         return 1047;
       } else if (expectedEncodingNumber) {
-        let execReturn = shell.execOutSync('sh', `iconv`, `-f`, `${expectedEncodingNumber}`, `-t`, `1047`, `${fileName}`, `|`, `grep`, `${expectedSample}`);
+        let execReturn = shell.execOutSync('sh', '-c', `iconv -f "${expectedEncodingNumber}" -t 1047 "${fileName}" | grep "${expectedSample}"`);
         if (execReturn.rc == 0 && execReturn.out) {
           return expectedEncodingNumber;
         }
@@ -72,7 +72,7 @@ export function detectFileEncoding(fileName: string, expectedSample: string, exp
         const commonEncodings = [819, 850];
         for (let i = 0; i < commonEncodings.length; i++) {
           const encoding = commonEncodings[i];
-          let execReturn = shell.execOutSync('sh', `iconv`, `-f`, `${encoding}`, `-t`, `1047`, `${fileName}`, `|`, `grep`, `${expectedSample}`);
+          let execReturn = shell.execOutSync('sh', '-c', `iconv -f "${encoding}" -t 1047 "${fileName}" | grep "${expectedSample}"`);
           if (execReturn.rc == 0 && execReturn.out) {
             return encoding;
           }
@@ -103,7 +103,7 @@ export function ensureFileEncoding(file: string, expectedSample: string, expecte
     // TODO  any cases we cannot find encoding?
     if (fileEncoding != expectedEncoding) {
       common.printTrace(`- Convert encoding of ${file} from ${fileEncoding} to ${expectedEncoding}.`);
-      let shellReturn = shell.execSync('sh', `iconv`, `-f`, `${fileEncoding}`, `-t`, `${expectedEncoding}`, `${file}`, `>`, `${file}.tmp`);
+      let shellReturn = shell.execSync('sh', '-c', `iconv -f "${fileEncoding}" -t "${expectedEncoding}" "${file}" > "${file}.tmp"`);
       if (!shellReturn.rc) {
         os.rename(`${file}.tmp`, file);
       }


### PR DESCRIPTION
Default component validation mode when missing for backwards compatibility.

This property is new in example-zowe.yaml so when we assume people keep their zowe.yaml between releases and since we haven't yet cut over to having a true "defaults.yaml", we need to have some defaulting in the code about this property missing.