### PR TITLE
Fix iconv syntax that is used in file encoding

### DIFF
--- a/bin/commands/components/install/extract/index.ts
+++ b/bin/commands/components/install/extract/index.ts
@@ -128,7 +128,7 @@ export function execute(componentFile: string, autoEncoding?: string): string {
     if (autoEncoding != 'no' && autotag == 'yes') {
       // automatically tag files
       common.printDebug("- Automatically tag files");
-      result = shell.execOutSync('sh', '-c', `${ZOWE_CONFIG.zowe.runtimeDirectory}/bin/utils/tag-files.sh" "${tmpDir}" 2>&1`);
+      result = shell.execOutSync('sh', '-c', `"${ZOWE_CONFIG.zowe.runtimeDirectory}/bin/utils/tag-files.sh" "${tmpDir}" 2>&1`);
       if (result.out) {
         common.printTrace(result.out);
       }

--- a/bin/libs/config.ts
+++ b/bin/libs/config.ts
@@ -75,7 +75,7 @@ export function zosConvertEnvDirFileEncoding(file: string) {
   if (encoding && encoding != 0 && encoding != 1047) {
     const tmpfile=`${std.getenv('ZWE_PRIVATE_WORKSPACE_ENV_DIR')}/t`;
     os.remove(tmpfile);
-    shell.execSync(`iconv`, `-f`, ""+encoding, `-t`, `IBM-1047`, file, `>`, tmpfile);
+    shell.execSync('sh', '-c', `iconv -f "${encoding}" -t "IBM-1047" "${file}" > "${tmpfile}"`);
     os.rename(tmpfile, file);
     shell.execSync('chmod', `640`, file);
     common.printTrace(`>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>AFTER ${file}`);

--- a/bin/libs/zos-fs.ts
+++ b/bin/libs/zos-fs.ts
@@ -63,7 +63,7 @@ export function detectFileEncoding(fileName: string, expectedSample: string, exp
            autoEncoding) && !fileContents.includes(expectedSample)) {
         return 1047;
       } else if (expectedEncodingNumber) {
-        let execReturn = shell.execOutSync('sh', `iconv`, `-f`, `${expectedEncodingNumber}`, `-t`, `1047`, `${fileName}`, `|`, `grep`, `${expectedSample}`);
+        let execReturn = shell.execOutSync('sh', '-c', `iconv -f "${expectedEncodingNumber}" -t 1047 "${fileName}" | grep "${expectedSample}"`);
         if (execReturn.rc == 0 && execReturn.out) {
           return expectedEncodingNumber;
         }
@@ -72,7 +72,7 @@ export function detectFileEncoding(fileName: string, expectedSample: string, exp
         const commonEncodings = [819, 850];
         for (let i = 0; i < commonEncodings.length; i++) {
           const encoding = commonEncodings[i];
-          let execReturn = shell.execOutSync('sh', `iconv`, `-f`, `${encoding}`, `-t`, `1047`, `${fileName}`, `|`, `grep`, `${expectedSample}`);
+          let execReturn = shell.execOutSync('sh', '-c', `iconv -f "${encoding}" -t 1047 "${fileName}" | grep "${expectedSample}"`);
           if (execReturn.rc == 0 && execReturn.out) {
             return encoding;
           }
@@ -103,7 +103,7 @@ export function ensureFileEncoding(file: string, expectedSample: string, expecte
     // TODO  any cases we cannot find encoding?
     if (fileEncoding != expectedEncoding) {
       common.printTrace(`- Convert encoding of ${file} from ${fileEncoding} to ${expectedEncoding}.`);
-      let shellReturn = shell.execSync('sh', `iconv`, `-f`, `${fileEncoding}`, `-t`, `${expectedEncoding}`, `${file}`, `>`, `${file}.tmp`);
+      let shellReturn = shell.execSync('sh', '-c', `iconv -f "${fileEncoding}" -t "${expectedEncoding}" "${file}" > "${file}.tmp"`);
       if (!shellReturn.rc) {
         os.rename(`${file}.tmp`, file);
       }


### PR DESCRIPTION
During `zwe components install -v` the error `iconv 66: FSUM7729 missing closing """` was seen. This looks to be from either zos-fs.ts or config.ts as those are the only TS files that use iconv. So, both have been updated in their syntax to use `sh -c` style execs.