### PR TITLE
Fix COMPONENT_COMPAT not being honored

### DIFF
--- a/bin/libs/component.ts
+++ b/bin/libs/component.ts
@@ -227,7 +227,7 @@ export function validateConfigForComponent(componentId: string, manifest: any, c
   }
   const schemas = getSchemasForComponentConfig(manifest, componentDir);
   const validationMode = ZOWE_CONFIG.zowe.configmgr?.validation ? ZOWE_CONFIG.zowe.configmgr.validation : 'COMPONENT-COMPAT';
-  if (!schemas && validationMode == 'COMPONENT-COMPAT') { //can be undefined if not stated in manifest.yaml
+  if (!schemas && validationMode != 'COMPONENT-COMPAT') { //can be undefined if not stated in manifest.yaml
     common.printError(`Component ${componentId} is missing property manifest property schemas.configs, validation will fail`);
     return false;
   } else if (!schemas) {


### PR DESCRIPTION
Fix flipped boolean condition that would break backward compat
The zowe.configmgr.validation=COMPONENT-COMPAT option is used so that components do not need schema files (though it is highly recommended, due to being deprecated not to have one)
But, the last commit had the boolean backwards so that it was not being used correctly, leading to components without schemas being unable to load.