### PR TITLE
Make configure.sh print to STDOUT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Zowe Installer will be documented in this file.
 
 - Updated ZWEWRF03 workflow to be up to date with the installed software
 
+## `2.5.0`
+
+#### Minor enhancements/defect fixes
+- component configure stages will now have their STDOUT printed when running at the INFO level of zwe verbosity.
+
+
 ## `2.4.0`
 
 ### New features and enhancements

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -356,7 +356,10 @@ function configureComponents(componentEnvironments?: any, enabledComponents?:str
           }
 
           if (result.rc == 0) {
-            common.printFormattedDebug("ZWELS", "zwe-internal-start-prepare,configure_components", result.out);
+            const outLines = result.out.split('\n');
+            common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare,configure_components", `- commands.configure output from ${componentId} is:`);
+            console.log(outLines.filter(line => !line.startsWith('export ')).join('\n'));
+            common.printFormattedDebug("ZWELS", "zwe-internal-start-prepare,configure_components", outLines.filter(line => line.startsWith('export ')).join('\n'));
           }
         } else {
           common.printFormattedError("ZWELS", "zwe-internal-start-prepare,configure_components", `Error ZWEL0172E: Component ${componentId} has commands.configure defined but the file is missing.`);

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -358,7 +358,7 @@ function configureComponents(componentEnvironments?: any, enabledComponents?:str
           if (result.rc == 0) {
             const outLines = result.out.split('\n');
             common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare,configure_components", `- commands.configure output from ${componentId} is:`);
-            console.log(outLines.filter(line => !line.startsWith('export ')).join('\n'));
+            common.printMessage(outLines.filter(line => !line.startsWith('export ')).join('\n'));
             common.printFormattedDebug("ZWELS", "zwe-internal-start-prepare,configure_components", outLines.filter(line => line.startsWith('export ')).join('\n'));
           }
         } else {


### PR DESCRIPTION
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
- [x] Feature <!-- non-breaking change which adds functionality -->

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
This PR takes the output of the configure.sh command, minus lines that start with 'export ', and prints them.
There was a common complaint that extenders wanted to print out stuff during configure.sh but couldnt without turning up verbosity, and doing that would print many things they didn't think users wanted to see.

I believe the logs were previously hidden due to a limitation or uncertainty around the fact that we make the script echo out all the env vars it has set (you'll see a ton of export foo, export bar...). All I do is filter the output so that the code still uses the exports, but just prints out everything except them (except in trace mode, in which everything was always printed)

This change will increase verbosity of standard zowe operation because some configure.sh files were already doing echos that were previously hidden. However, this almost seems like a bugfix because now we're just respecting the component's desire to echo.

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [x] No
