### PR TITLE
Fix 2.4 workspace permissions regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the Zowe Installer will be documented in this file.
 
 - Updated ZWEWRF03 workflow to be up to date with the installed software
 
+## `2.5.0`
+
+#### Minor enhancements/defect fixes
+- zwe was not guaranteeing that the workspace folder had 770 permission when zowe.useConfigmgr=true was set
+
 ## `2.4.0`
 
 ### New features and enhancements

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -102,6 +102,8 @@ function prepareWorkspaceDirectory() {
   fs.mkdirp(zweStaticDefinitionsDir, 0o770);
   fs.mkdirp(zweGatewaySharedLibs, 0o770);
   fs.mkdirp(zweDiscoverySharedLibs, 0o770);
+  //ensure 770 in case directories already existed
+  shell.execSync('chmod', `770`, workspaceDirectory, zweStaticDefinitionsDir, zweGatewaySharedLibs, zweDiscoverySharedLibs);
 
   shell.execSync('cp', `${runtimeDirectory}/manifest.json`, workspaceDirectory);
 


### PR DESCRIPTION
In v2.4, the launcher was setting workspace permissions to 750 while in the zwe code, permissions were `chmod 770` when configmgr=false, but when configmgr=true, `mkdir` with `770` was used instead. This is not equivalent, because if the directories already existed, then the permissions were not set. This fixes it by just calling `chmod` to be 100% sure the  permissions are good.