### PR TITLE
React to component configure bad RCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ All notable changes to the Zowe Installer will be documented in this file.
 
 - Updated ZWEWRF03 workflow to be up to date with the installed software
 
-## `2.5.0
+## 2.6.0
+
+#### Minor enhancements/defect fixes
+- When a component configure script failed during startup, no warning would be printed. Starting in 2.6, a warning will be printed and there's also an option to prevent Zowe from continuing startup when this failure is seen, by setting `zowe.launchScript.onComponentConfigureFail` to "exit"
+
+## 2.5.0
 
 ### New features and enhancements
 

--- a/bin/commands/internal/start/prepare/.errors
+++ b/bin/commands/internal/start/prepare/.errors
@@ -1,2 +1,3 @@
 ZWEL0141E|141|User %s does not have write permission on %s.
 ZWEL0302W||You are running the Zowe process under user id IZUSVR. This is not recommended and may impact your z/OS MF server negatively.
+ZWEL0317E||Component %s commands.configure ended with rc=%s.

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -362,6 +362,11 @@ function configureComponents(componentEnvironments?: any, enabledComponents?:str
           } else {
             //not printformattederror because it makes silly long strings like "ERROR: 2022-12-07 20:00:47 <ZWELS:50791391> me ERROR (zwe-internal-start-prepare,configure_components) Error ZWEL0317E: Component app-server commands.configure ended with rc=22."
             common.printError(`Error ZWEL0317E: Component ${componentId} commands.configure ended with rc=${result.rc}.`);
+            if (result.out) {
+              const outLines = result.out.split('\n');
+              common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare,configure_components", `- commands.configure output from ${componentId} is:`);
+              common.printMessage(outLines.filter(line => !line.startsWith('export ')).join('\n'));
+            }
             if (ZOWE_CONFIG.zowe.launchScript?.onComponentConfigureFail == 'exit') {
               std.exit(1);
             }

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -360,7 +360,8 @@ function configureComponents(componentEnvironments?: any, enabledComponents?:str
             common.printMessage(outLines.filter(line => !line.startsWith('export ')).join('\n'));
             common.printFormattedDebug("ZWELS", "zwe-internal-start-prepare,configure_components", outLines.filter(line => line.startsWith('export ')).join('\n'));
           } else {
-            common.printFormattedError(`ZWELS`, `zwe-internal-start-prepare,configure_components`, `Error ZWEL0317E: Component ${componentId} commands.configure ended with rc=${result.rc}.`);
+            //not printformattederror because it makes silly long strings like "ERROR: 2022-12-07 20:00:47 <ZWELS:50791391> me ERROR (zwe-internal-start-prepare,configure_components) Error ZWEL0317E: Component app-server commands.configure ended with rc=22."
+            common.printError(`Error ZWEL0317E: Component ${componentId} commands.configure ended with rc=${result.rc}.`);
             if (ZOWE_CONFIG.zowe.launchScript?.onComponentConfigureFail == 'exit') {
               std.exit(1);
             }

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -355,13 +355,15 @@ function configureComponents(componentEnvironments?: any, enabledComponents?:str
                 shell.execSync('chmod', `700`, `"${zwePrivateWorkspaceEnvDir}/${componentName}/.${zweCliParameterHaInstance}.env"`);
               }
             }
-          }
-
-          if (result.rc == 0) {
             const outLines = result.out.split('\n');
             common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare,configure_components", `- commands.configure output from ${componentId} is:`);
             common.printMessage(outLines.filter(line => !line.startsWith('export ')).join('\n'));
             common.printFormattedDebug("ZWELS", "zwe-internal-start-prepare,configure_components", outLines.filter(line => line.startsWith('export ')).join('\n'));
+          } else {
+            common.printFormattedError(`ZWELS`, `zwe-internal-start-prepare,configure_components`, `Error ZWEL0317E: Component ${componentId} commands.configure ended with rc=${result.rc}.`);
+            if (ZOWE_CONFIG.zowe.launchScript?.onComponentConfigureFail == 'exit') {
+              std.exit(1);
+            }
           }
         } else {
           common.printFormattedError("ZWELS", "zwe-internal-start-prepare,configure_components", `Error ZWEL0172E: Component ${componentId} has commands.configure defined but the file is missing.`);

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -516,7 +516,8 @@
             "onComponentConfigureFail": {
               "type": "string",
               "description": "Chooses how 'zwe start' behaves if a component configure script fails",
-              "enum": ["warn", "exit"]
+              "enum": ["warn", "exit"],
+              "default": "warn"
             }
           }
         },

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -512,6 +512,11 @@
               "type": "string",
               "description": "Log level for Zowe launch scripts.",
               "enum": ["", "info", "debug", "trace"]
+            },
+            "onComponentConfigureFail": {
+              "type": "string",
+              "description": "Chooses how 'zwe start' behaves if a component configure script fails",
+              "enum": ["warn", "exit"]
             }
           }
         },


### PR DESCRIPTION
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
- [x] Feature <!-- non-breaking change which adds functionality -->

#### Changes proposed in this PR
This PR checks the RC of running component.configure scripts for when rc is not 0. Previously, when not 0, the component would be silently ignored. Now, at minimum there is a warning message. But the schema is also updated to include the option to have zowe exit instead of continuing in case the user wants increased confidence.

#### Does this PR introduce a breaking change?
- [x] No
