### PR TITLE
Fix tar archive extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the Zowe Installer will be documented in this file.
 
 - Updated ZWEWRF03 workflow to be up to date with the installed software
 
+## `2.6.0`
+
+#### Minor enhancements/defect fixes
+- Tar archived components would not be installed when zowe.useConfigmgr=true was set.
+
 ## `2.5.0
 
 ### New features and enhancements

--- a/bin/commands/components/install/extract/index.ts
+++ b/bin/commands/components/install/extract/index.ts
@@ -98,7 +98,7 @@ export function execute(componentFile: string, autoEncoding?: string, upgrade?: 
       java.requireJava();
       result = shell.execSync('sh', '-c', `cd ${tmpDir} && jar xf ${componentFile}`);
     } else if (componentFile.endsWith('.tar')) {
-      result = shell.execSync('sh', '-c', `_CEE_RUNOPTS="FILETAG() POSIX(ON)" pax -x tar -rf "${componentFile}"`);
+      result = shell.execSync('sh', '-c', `_CEE_RUNOPTS="FILETAG() POSIX(ON)" cd ${tmpDir} && pax -x tar -rf "${componentFile}"`);
     }
     if (result.rc) {
       common.printError(`Extract completed with rc=${result.rc}`);


### PR DESCRIPTION
Trying to do `zwe components install` on a tar archive was failing because tar extracts relative to the directory you are in and unlike what we did with pax, accidentally the `cd` command was ommitted from the tar extraction command.