### PR TITLE
Improvement of regex for dataset name, member and jobname

### DIFF
--- a/schemas/server-common.json
+++ b/schemas/server-common.json
@@ -20,7 +20,7 @@
       "$anchor": "zoweDataset",
       "type": "string",
       "description": "A 44-char all caps dotted ZOS name",
-      "pattern": "^([A-Z0-9\\$\\#\\@]){1,8}(\\.([A-Z0-9\\$\\#\\@]){1,8}){0,11}$",
+      "pattern": "^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$",
       "minLength": 3,
       "maxLength": 44
     },
@@ -28,14 +28,14 @@
       "$anchor": "zoweDatasetMember",
       "type": "string",
       "description": "A 1-8-char all caps dataset member name",
-      "pattern": "^([A-Z0-9\\$\\#\\@]){1,8}$",
+      "pattern": "^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$",
       "minLength": 1,
       "maxLength": 8
     },
     "jobname": {
       "$anchor": "zoweJobname",
       "type": "string",
-      "pattern": "^([A-Z0-9\\$\\#\\@]){1,8}$",
+      "pattern": "^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$",
       "minLength": 3,
       "maxLength": 8
     },


### PR DESCRIPTION
Signed-off-by: Martin Zeithaml <Martin.Zeithaml@broadcom.com>

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
- [x] Bugfix <!-- non-breaking change which fixes an issue -->

#### Relevant issues
Fixes #3172 

#### Changes proposed in this PR

##### Dataset regex

- Dataset: ```^([A-Z\$\#\@]){1}([A-Z0-9\$\#\@\-]){0,7}(\.([A-Z\$\#\@]){1}([A-Z0-9\$\#\@\-]){0,7}){0,11}$```
  - Dataset segment: ```([A-Z\$\#\@]){1}([A-Z0-9\$\#\@\-]){0,7}```
    - Mandatory char: ```[A-Z\$\#\@]){1}``` => can not start with number
    - Optional chars: ```[A-Z0-9\$\#\@\-]){0,7}```
  - Continue with ```.``` and another segment
  - Hyphen (new in z/OS 2.4.0) can be on position 2-8, this is legal name for dataset: ```DS.A-.B-```

##### Jobname and member

- Jobname and dataset member: ```^([A-Z\$\#\@]){1}([A-Z0-9\$\#\@]){0,7}$```
  - Mandatory char ```([A-Z\$\#\@]){1}``` => can not start with number
  - Optional chars: ```([A-Z0-9\$\#\@]){0,7}```


#### Does this PR introduce a breaking change?
- [x] No

#### Manual test
**Old** is the current regex, **new** is updated.
Old regex is accepting numbers on position 1 and does not accept hyphen as legal char:
```
Old [ Ok    ] THESE.SOULD.BE.OK
New [ Ok    ] THESE.SOULD.BE.OK

Old [ Ok    ] A.B
New [ Ok    ] A.B

Old [ Ok    ] HLQ
New [ Ok    ] HLQ

Old [ Ok    ] HLQ.ABC.LIB
New [ Ok    ] HLQ.ABC.LIB

Old [ Ok    ] VALID.DATASET.NAME
New [ Ok    ] VALID.DATASET.NAME

Old [ Ok    ] #.@.$
New [ Ok    ] #.@.$

Old [ Ok    ] #A.@B.$C
New [ Ok    ] #A.@B.$C

Old [ Ok    ] ZOWE.PROD.R121
New [ Ok    ] ZOWE.PROD.R121

Old [ Ok    ] USERID.CURRENT.JCL
New [ Ok    ] USERID.CURRENT.JCL

Old [ Wrong ] USER-ID.MY.JCL
New [ Ok    ] USER-ID.MY.JCL

Old [ Ok    ] TSDUMP.US345678.TEMPL.BOTH.ABEND
New [ Ok    ] TSDUMP.US345678.TEMPL.BOTH.ABEND

Old [ Ok    ] A.B.C
New [ Ok    ] A.B.C

Old [ Wrong ] A.B-C.D.REXX
New [ Ok    ] A.B-C.D.REXX

Old [ Wrong ] THIS.IS.FINE-
New [ Ok    ] THIS.IS.FINE-

Old [ Wrong ] THIS.IS.ALS0-.FINE.#-
New [ Ok    ] THIS.IS.ALS0-.FINE.#-

Old [ Wrong ] ZOWE.Z-F-S.V2-5-0.#1
New [ Ok    ] ZOWE.Z-F-S.V2-5-0.#1

Old [ Wrong ] THESENAMES.SOULD.FAIL
New [ Wrong ] THESENAMES.SOULD.FAIL

Old [ Ok    ] 0.1
New [ Wrong ] 0.1

Old [ Wrong ] *.QWERTY
New [ Wrong ] *.QWERTY

Old [ Wrong ] LONG56789.A
New [ Wrong ] LONG56789.A

Old [ Wrong ] INVALID.1.
New [ Wrong ] INVALID.1.

Old [ Wrong ] INVALID.%.DSN
New [ Wrong ] INVALID.%.DSN

Old [ Wrong ] INVALID.
New [ Wrong ] INVALID.

Old [ Ok    ] 00000000
New [ Wrong ] 00000000

Old [ Wrong ] #..@.$
New [ Wrong ] #..@.$

Old [ Wrong ] #.@..$
New [ Wrong ] #.@..$

Old [ Wrong ] #.@.$..A..B...C....D
New [ Wrong ] #.@.$..A..B...C....D
```
