### PR TITLE
trace get launch components

### DIFF
--- a/bin/commands/internal/get-launch-components/index.ts
+++ b/bin/commands/internal/get-launch-components/index.ts
@@ -14,6 +14,7 @@ import * as common from '../../../libs/common';
 import * as config from '../../../libs/config';
 
 export function execute(): string {
+  common.printTrace("enter internal:get-launch-components:execute");
   common.requireZoweYaml();
 
   //TODO dont really need to do this if i can just use component.findAllLaunchComponents()

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -46,6 +46,7 @@ const ZOWE_CONFIG=config.getZoweConfig();
 // - link component runtime under zowe <runtime>/components
 // - `commands.configureInstance` is deprecated in v2
 function prepareRunningInContainer() {
+  common.printTrace("enter internal:start:prepare:prepareRunningInContainer");
   // gracefully shutdown all processes
   common.printFormattedDebug("ZWELS", "zwe-internal-start-prepare,prepare_running_in_container", "Register SIGTERM handler for graceful shutdown.");
   os.signal(os.SIGTERM, sys.gracefullyShutdown);
@@ -71,6 +72,7 @@ function prepareRunningInContainer() {
 
 // Prepare log directory
 function prepareLogDirectory() {
+  common.printTrace("enter internal:start:prepare:prepareLogDirectory");
   const logDir = std.getenv('ZWE_zowe_logDirectory');
   if (logDir) {
     os.mkdir(logDir, 0o750);
@@ -83,6 +85,7 @@ function prepareLogDirectory() {
 
 // Prepare workspace directory
 function prepareWorkspaceDirectory() {
+  common.printTrace("enter internal:start:prepare:prepareWorkspaceDirectory");
   const zwePrivateWorkspaceEnvDir=`${workspaceDirectory}/.env`;
   std.setenv('ZWE_PRIVATE_WORKSPACE_ENV_DIR', zwePrivateWorkspaceEnvDir);
   const zweStaticDefinitionsDir=`${workspaceDirectory}/api-mediation/api-defs`;
@@ -117,6 +120,7 @@ function prepareWorkspaceDirectory() {
 
 // Global validations
 function globalValidate(enabledComponents:string[]): void {
+  common.printTrace("enter internal:start:prepare:globalValidate");
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare,global_validate", "process global validations ...");
 
   // validate_runtime_user
@@ -191,6 +195,7 @@ function globalValidate(enabledComponents:string[]): void {
 
 // Validate component properties if script exists
 function validateComponents(enabledComponents:string[]): any {
+  common.printTrace("enter internal:start:prepare:validateComponents");
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare,validate_components", "process component validations ...");
 
   const componentEnvironments = {};
@@ -254,6 +259,7 @@ function validateComponents(enabledComponents:string[]): any {
 
 // Run setup/configure on components if script exists
 function configureComponents(componentEnvironments?: any, enabledComponents?:string[]) {
+  common.printTrace("enter internal:start:prepare:configureComponents");
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare,configure_components", "process component configurations ...");
 
   const zwePrivateWorkspaceEnvDir = std.getenv('ZWE_PRIVATE_WORKSPACE_ENV_DIR');
@@ -420,6 +426,7 @@ if (zoweVersion) {
 }
 
 export function execute() {
+  common.printTrace("enter internal:start:prepare:execute");
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `Zowe version: v${zoweVersion}`);
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `build and hash: ${runtimeManifest.build.branch}#${runtimeManifest.build.number} (${runtimeManifest.build.commitHash})`);
 

--- a/bin/libs/common.ts
+++ b/bin/libs/common.ts
@@ -53,6 +53,7 @@ function getLogLevel(name:string, defaultLevel:LOG_LEVEL):LOG_LEVEL {
 
 
 export function requireZoweYaml() {
+  printTrace("enter libs:common:requireZoweYaml");
   const configFiles = std.getenv('ZWE_CLI_PARAMETER_CONFIG');
   if (!configFiles) {
     printErrorAndExit(`Error ZWEL0108E: Zowe YAML config file is required.`);

--- a/bin/libs/component.ts
+++ b/bin/libs/component.ts
@@ -56,6 +56,7 @@ export function getEnabledComponents(): string[] {
 }
 
 export function getManifestPath(componentDir: string): string|undefined {
+  common.printTrace("enter libs:component:getManifestPath");
   if (fs.fileExists(`${componentDir}/manifest.yaml`)) {
     return `${componentDir}/manifest.yaml`;
   } else if (fs.fileExists(`${componentDir}/manifest.yml`)) {
@@ -301,6 +302,7 @@ export function detectIfComponentTagged(componentDir: string): boolean {
 }
 
 export function findAllInstalledComponents(): string {
+  common.printTrace("enter libs:component:findAllInstalledComponents");
   let components='';
   let subDirectories = fs.getSubdirectories(`${runtimeDirectory}/components`);
   if (subDirectories) {
@@ -325,6 +327,7 @@ export function findAllInstalledComponents(): string {
 }
 
 export function findAllInstalledComponents2(): string[] {
+  common.printTrace("enter libs:component:findAllInstalledComponents2");
   let components:string[] = [];
   let subDirectories = fs.getSubdirectories(`${runtimeDirectory}/components`);
   if (subDirectories) {
@@ -349,10 +352,12 @@ export function findAllInstalledComponents2(): string[] {
 }
 
 export function findAllEnabledComponents(): string {
+  common.printTrace("enter libs:component:findAllEnabledComponents");
   return findAllEnabledComponents2().join(',');
 }
 
 export function findAllEnabledComponents2(): string[] {
+  common.printTrace("enter libs:component:findAllEnabledComponents2");
   let installedComponentsEnv=std.getenv('ZWE_INSTALLED_COMPONENTS');
   let installedComponents = installedComponentsEnv ? installedComponentsEnv.split(',') : null;
   if (!installedComponents) {

--- a/bin/libs/component.ts
+++ b/bin/libs/component.ts
@@ -45,6 +45,7 @@ const PLUGIN_DEF_SCHEMAS = `${runtimeDirectory}/components/app-server/schemas/pl
 
 
 export function getEnabledComponents(): string[] {
+  common.printTrace("enter libs:component:getEnabledComponents");
   let components = Object.keys(ZOWE_CONFIG.components);
   let enabled:string[] = [];
   components.forEach((key:string) => {
@@ -68,6 +69,7 @@ export function getManifestPath(componentDir: string): string|undefined {
 }
 
 export function findComponentDirectory(componentId: string): string|undefined {
+  common.printTrace("enter libs:component:findComponentDirectory");
   if (fs.directoryExists(`${runtimeDirectory}/components/${componentId}`)) {
     return `${runtimeDirectory}/components/${componentId}`;
   } else if (extensionDirectory && fs.directoryExists(`${extensionDirectory}/${componentId}`)) {
@@ -159,6 +161,7 @@ export function getPluginDefinition(pluginRootPath:string) {
 
 
 export function getManifest(componentDirectory: string): any {
+  common.printTrace("enter libs:component:getManifest");
   let manifestPath = getManifestPath(componentDirectory);
 
   if (manifestPath) {
@@ -223,6 +226,7 @@ export function getSchemasForComponentConfig(manifest: any, componentDir: string
 }
 
 export function validateConfigForComponent(componentId: string, manifest: any, componentDir: string, configPath: string): boolean {
+  common.printTrace("enter libs:component:validateConfigForComponent");
   if (configPath.startsWith('/')) { //likely input is merged yaml
     configPath=`FILE(${configPath})`; 
   }
@@ -393,6 +397,7 @@ export function findAllLaunchComponents2(): string[] {
 }
 
 export function processComponentApimlStaticDefinitions(componentDir: string): boolean {
+  common.printTrace("enter libs:component:processComponentApimlStaticDefinitions");
   const STATIC_DEF_DIR=std.getenv('ZWE_STATIC_DEFINITIONS_DIR');
   if (!STATIC_DEF_DIR) {
     common.printError("Error: ZWE_STATIC_DEFINITIONS_DIR is required to process component definitions for API Mediation Layer.");
@@ -778,6 +783,7 @@ function resolveEnvParameter(input: string): string {
 
 
 export function processComponentAppfwPlugin(componentDir: string): boolean {
+  common.printTrace("enter libs:component:processComponentAppfwPlugin");
   const manifest = getManifest(componentDir);
   if (manifest && manifest.appfwPlugins) {
     for (let i = 0; i < manifest.appfwPlugins.length; i++) {
@@ -816,6 +822,7 @@ export function processComponentAppfwPlugin(componentDir: string): boolean {
  defined will be passed to install-app.sh for proper installation.
 */
 export function processComponentGatewaySharedLibs(componentDir: string): boolean {
+  common.printTrace("enter libs:component:processComponentGatewaySharedLibs");
   const gatewaySharedLibs = std.getenv('ZWE_GATEWAY_SHARED_LIBS');
   fs.mkdirp(gatewaySharedLibs, 0o770);
 
@@ -868,6 +875,7 @@ export function processComponentGatewaySharedLibs(componentDir: string): boolean
  defined will be passed to install-app.sh for proper installation.
 */
 export function processComponentDiscoverySharedLibs(componentDir: string): boolean {
+  common.printTrace("enter libs:component:processComponentDiscoverySharedLibs");
   const discoverySharedLibs = std.getenv('ZWE_DISCOVERY_SHARED_LIBS');
   fs.mkdirp(discoverySharedLibs, 0o770);
 

--- a/bin/libs/config.ts
+++ b/bin/libs/config.ts
@@ -89,6 +89,7 @@ export function zosConvertEnvDirFileEncoding(file: string) {
 // compatible instance.env files from zowe.yaml.
 //
 export function generateInstanceEnvFromYamlConfig(haInstance: string) {
+  common.printTrace("enter libs:config:generateInstanceEnvFromYamlConfig");
   let zwePrivateWorkspaceEnvDir = std.getenv('ZWE_PRIVATE_WORKSPACE_ENV_DIR');
   if (!zwePrivateWorkspaceEnvDir) {
     zwePrivateWorkspaceEnvDir=`${workspaceDirectory}/.env`
@@ -232,6 +233,7 @@ export function sanitizeHaInstanceId(): string|undefined {
 }
 
 export function applyEnviron(environ: any): void {
+  common.printTrace("enter libs:config:applyEnviron");
   let keys = Object.keys(environ);
   keys.forEach(function(key:string) {
     common.printMessage(`applyEnviron setting ${key}=${environ[key]}`);

--- a/bin/libs/config.ts
+++ b/bin/libs/config.ts
@@ -41,6 +41,7 @@ const runtimeDirectory=configmgr.ZOWE_CONFIG.zowe.runtimeDirectory;
 const workspaceDirectory=configmgr.ZOWE_CONFIG.zowe.workspaceDirectory;
 
 export function getZoweConfig(): any {
+  common.printTrace("enter libs:config:getZoweConfig");
   return configmgr.ZOWE_CONFIG;
 }
 
@@ -212,6 +213,7 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
 
 // check and sanitize ZWE_CLI_PARAMETER_HA_INSTANCE
 export function sanitizeHaInstanceId(): string|undefined {
+  common.printTrace("enter libs:config:sanitizeHaInstaceId");
   // ignore default value passed from ZWESLSTC
   let zweCliParameterHaInstance = std.getenv('ZWE_CLI_PARAMETER_HA_INSTANCE');
   if (zweCliParameterHaInstance == "{{ha_instance_id}}" || zweCliParameterHaInstance == "__ha_instance_id__") {
@@ -244,7 +246,7 @@ export function applyEnviron(environ: any): void {
 //       "zwe internal start prepare" is the only special case where we may need to define some variables before calling
 //       this function. The reason is to properly prepare the directories, logging, etc.
 export function loadEnvironmentVariables(componentId?: string) {
-
+  common.printTrace("enter libs:config:loadEnvironmentVariables");
   // check and sanitize zweCliParameterHaInstance
   sanitizeHaInstanceId();
   std.setenv('ZWE_zowe_workspaceDirectory',workspaceDirectory);

--- a/bin/libs/configmgr.ts
+++ b/bin/libs/configmgr.ts
@@ -24,7 +24,13 @@ const ZOWE_CONFIG_NAME = 'zowe-server-base';
 const CONFIG_REVISIONS = {};
 
 export const CONFIG_MGR = new ConfigManager();
-CONFIG_MGR.setTraceLevel(0);
+if (std.getenv('ZWE_PRIVATE_LOG_LEVEL_ZWELS') == 'TRACE') {
+  CONFIG_MGR.setTraceLevel(2);
+} else if (std.getenv('ZWE_PRIVATE_LOG_LEVEL_ZWELS') == 'DEBUG') {
+  CONFIG_MGR.setTraceLevel(1);
+} else {
+  CONFIG_MGR.setTraceLevel(0);
+}
 
 //these show the list of files used for zowe config prior to merging into a unified one.
 // ZWE_CLI_PARAMETER_CONFIG gets updated to point to the unified one once written.

--- a/bin/libs/container.ts
+++ b/bin/libs/container.ts
@@ -28,6 +28,7 @@ std.setenv('ZWE_PRIVATE_CONTAINER_KEYSTORE_DIRECTORY', '/home/zowe/keystore');
 // prepare all environment variables used in containerization
 // these variables shouldn't be modified
 export function prepareContainerRuntimeEnvironments():void {
+  common.printTrace("enter libs:container:prepareContainerRuntimeEnvironments");
   // to fix issues:
   // - https://github.com/zowe/api-layer/issues/1768
   // - https://github.com/spring-cloud/spring-cloud-netflix/issues/3941

--- a/bin/libs/container.ts
+++ b/bin/libs/container.ts
@@ -17,6 +17,7 @@ import * as sys from './sys';
 import * as component from './component';
 import * as config from './config';
 import * as network from './network';
+import * as common from './common';
 
 std.setenv('ZWE_PRIVATE_CONTAINER_HOME_DIRECTORY', '/home/zowe');
 std.setenv('ZWE_PRIVATE_CONTAINER_RUNTIME_DIRECTORY', '/home/zowe/runtime');

--- a/bin/libs/fs.ts
+++ b/bin/libs/fs.ts
@@ -166,6 +166,7 @@ export function getFilesInDirectory(path: string): string[]|undefined {
 }
 
 export function getSubdirectories(path: string): string[]|undefined {
+  common.printTrace("enter libs:fs:getSubdirectories");
   let returnArray = os.readdir(path);
   let subdirs:string[] = [];
   if (!returnArray[1]) { //no error
@@ -182,6 +183,7 @@ export function getSubdirectories(path: string): string[]|undefined {
 }
 
 export function directoryExists(path: string, silenceNotFound?: boolean): boolean {
+  common.printTrace("enter libs:fs:directoryExists");
   let returnArray = os.stat(path);
   if (!returnArray[1]) { //no error
     return ((returnArray[0].mode & os.S_IFMT) == os.S_IFDIR)
@@ -194,6 +196,7 @@ export function directoryExists(path: string, silenceNotFound?: boolean): boolea
 }
 
 export function fileExists(path: string, silenceNotFound?: boolean): boolean {
+  common.printTrace("enter libs:fs:fileExists");
   let returnArray = os.stat(path);
   if (!returnArray[1]) { //no error
     return ((returnArray[0].mode & os.S_IFMT) == os.S_IFREG)

--- a/bin/libs/fs.ts
+++ b/bin/libs/fs.ts
@@ -66,6 +66,7 @@ export function resolvePath(...parts:string[]): string {
 }
 
 export function mkdirp(path:string, mode?: number): number {
+  common.printTrace("enter libs:fs:mkdirp");
   const parts = path.split('/');
   let dir = '/';
   for (let i = 0; i < parts.length; i++) {
@@ -150,6 +151,7 @@ export function createFileFromBuffer(path: string, mode: number, buff?: Uint8Arr
 }
 
 export function getFilesInDirectory(path: string): string[]|undefined {
+  common.printTrace("enter libs:fs:getFilesInDirectory");
   let returnArray = os.readdir(path);
   let files:string[] = [];
   if (!returnArray[1]) { //no error
@@ -219,6 +221,7 @@ export function pathExists(path: string): boolean {
 }
 
 export function pathHasPermissions(path: string, mode: number): boolean {
+  common.printTrace("enter libs:fs:pathHasPermissions");
   let returnArray = os.stat(path);
   if (!returnArray[1]) { //no error
     return (returnArray[0].mode & mode) === mode;
@@ -297,6 +300,7 @@ export function areDirectoriesAccessible(directories: string): number {
 }
 
 export function isDirectoryWritable(directory: string): boolean {
+  common.printTrace("enter libs:fs:isDirectoryWritable");
   return pathHasPermissions(directory, os.S_IFDIR | S_IWUSR);
 }
 

--- a/bin/libs/java.ts
+++ b/bin/libs/java.ts
@@ -56,6 +56,7 @@ export function detectJavaHome(): string|undefined {
 
 let _javaCheckComplete = false;
 export function requireJava() {
+  common.printTrace("enter libs:java:requireJava");
   if ((_javaCheckComplete === true) && std.getenv('JAVA_HOME')) {
     return;
   }
@@ -80,6 +81,7 @@ export function requireJava() {
 }
 
 export function validateJavaHome(javaHome:string|undefined=std.getenv("JAVA_HOME")): boolean {
+  common.printTrace("enter libs:java:validateJavaHome");
   if (!javaHome) {
     common.printError("Cannot find java. Please define JAVA_HOME environment variable.");
     return false;

--- a/bin/libs/network.ts
+++ b/bin/libs/network.ts
@@ -21,6 +21,7 @@ import * as zosfs from './zos-fs';
 
 // get ping command, could be empty
 export function getPing(): string|undefined {
+  common.printTrace("enter libs:network:getPing");
   let ping = shell.which('ping');
 
   // z/OS
@@ -113,6 +114,7 @@ export function isPortAvailable(port: number): boolean {
 // get current IP address
 const ipv4Regexp = /[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/;
 export function getIpAddress(hostname: string): string|undefined {
+  common.printTrace("enter libs:network:getIpAddress");
   let ip;
 
   // dig is preferred than ping

--- a/bin/libs/node.ts
+++ b/bin/libs/node.ts
@@ -62,6 +62,7 @@ export function detectNodeHome(): string|undefined {
 
 let _checkComplete = false;
 export function requireNode() {
+  common.printTrace("enter libs:node:requireNode");
   if ((_checkComplete === true) && std.getenv('NODE_HOME')) {
     return;
   }
@@ -86,6 +87,7 @@ export function requireNode() {
 }
 
 export function validateNodeHome(nodeHome:string|undefined=std.getenv("NODE_HOME")): boolean {
+  common.printTrace("enter libs:node:validateNodeHome");
   if (!nodeHome) {
     common.printError("Cannot find node. Please define NODE_HOME environment variable.");
     return false;

--- a/bin/libs/sys.ts
+++ b/bin/libs/sys.ts
@@ -23,6 +23,7 @@ std.setenv('ZWE_PWD', pwd[0] ? pwd[0] : '/');
 // Return system name in lower case
 let sysname:string;
 export function getSysname(): string|undefined {
+  common.printTrace("enter libs:sys:getSysname");
   if (typeof sysname == 'string') {
     return sysname.toLowerCase();
   }

--- a/bin/libs/var.ts
+++ b/bin/libs/var.ts
@@ -241,6 +241,7 @@ export function getEnvironments(): string {
 //
 // All variables defined in env file will be exported.
 export function sourceEnv(envFile: string): boolean {
+  common.printTrace("enter libs:var:sourceEnv");
   //TODO i hope encoding is correct here
   
   let fileContents = xplatform.loadFileUTF8(envFile,xplatform.AUTO_DETECT);
@@ -248,6 +249,7 @@ export function sourceEnv(envFile: string): boolean {
 }
 
 export function setExports(envFileContents: string): boolean {
+  common.printTrace("enter libs:var:setExports");
   let fileLines = envFileContents.split('\n');
   fileLines.forEach((line: string)=> {
     setExport(line);

--- a/bin/libs/var.ts
+++ b/bin/libs/var.ts
@@ -201,6 +201,7 @@ const declareFilter=/^declare -x (run_zowe_start_component_id=|ZWELS_START_COMPO
 const keyFilter=/^(run_zowe_start_component_id|ZWELS_START_COMPONENT_ID|ZWE_LAUNCH_COMPONENTS|env_file|key|line|service|logger|level|expected_log_level_val|expected_log_level_var|display_log|message|utils_dir|print_formatted_function_available|LINENO|ENV|opt|OPTARG|OPTIND|LOGNAME|USER|SSH_|SHELL|PWD|OLDPWD|PS1|ENV|LS_COLORS|_)$/
 
 export function getEnvironmentExports(input?:string, doExport?: boolean): string {
+  common.printTrace("enter libs:var:getEnvironmentExports");
   let exports:string[]=[];
   if (!input) {
     let envvars = std.getenviron();
@@ -288,6 +289,7 @@ export function setExport(envFileLine: string): boolean {
 
 // Takes in a single parameter - the name of the variable
 export function isVariableSet(variableName: string, message?: string): boolean {
+  common.printTrace("enter libs:var:isVariableSet");
   if (!message) {
     message=`${variableName} is not defined or empty.`
   }
@@ -338,6 +340,7 @@ export function validateThis(cmd: string, origin: string): number {
 }
 
 export function checkRuntimeValidationResult(origin: string) {
+  common.printTrace("enter libs:var:checkRuntimeValidationResult");
   // Summary errors check, exit if errors found
   let prevErr = std.getenv("ZWE_PRIVATE_ERRORS_FOUND");
   let prevErrCount = !prevErr ? 0 : Number(prevErr);

--- a/bin/libs/zos-fs.ts
+++ b/bin/libs/zos-fs.ts
@@ -19,6 +19,7 @@ import * as shell from './shell';
 
 // Get file encoding from z/OS USS tagging
 export function getFileEncoding(filePath: string): number|undefined {
+  common.printTrace("enter libs:zosfs:getFileEncoding");
   //zos.changeTag(file, id)
   let returnArray = os.stat(filePath);
   if (!returnArray[1] && ((returnArray[0].mode & os.S_IFREG) == os.S_IFREG)) { //no error, and is file
@@ -48,6 +49,7 @@ export function getFileEncoding(filePath: string): number|undefined {
 // - detect manifest encoding by checking result "name"
 //   detectFileEncoding "/path/to/zowe/components/my-component/manifest.yaml" "name"
 export function detectFileEncoding(fileName: string, expectedSample: string, expectedEncoding?: number|string): number {
+  common.printTrace("enter libs:zosfs:detectFileEncoding");
   let autoEncoding = expectedEncoding == 'auto' || expectedEncoding == 'AUTO';
   let expectedEncodingNumber= typeof expectedEncoding == 'string' ? stringlib.ENCODING_NAME_TO_CCSID[expectedEncoding.toUpperCase()] : expectedEncoding;
 

--- a/bin/libs/zosmf.ts
+++ b/bin/libs/zosmf.ts
@@ -17,6 +17,7 @@ import * as common from './common';
 import * as shell from './shell';
 
 export function validateZosmfHostAndPort(zosmfHost: string, zosmfPort: number): boolean {
+  common.printTrace("enter libs:zosmf:validateZosmfHostANdPort");
   if (!zosmfHost) {
     common.printError('z/OSMF host is not set.');
     return false;
@@ -50,6 +51,7 @@ export function validateZosmfHostAndPort(zosmfHost: string, zosmfPort: number): 
 
 //TODO isnt this completely backwards?
 export function validateZosmfAsAuthProvider(zosmfHost: string, zosmfPort: number, authProvider: string): boolean {
+  common.printTrace("enter libs:zosmf:validateZosmfAsAuthProvider");
   if (zosmfHost && zosmfPort) {
     if (authProvider == 'zosmf') {
       common.printError("z/OSMF is not configured. Using z/OSMF as authentication provider is not supported.");

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -112,7 +112,7 @@
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.configmgr": {
-      "version": "~0.4.2-v2.x_staging",
+      "version": "~0.4.99-TEST-CONFIGMGR-TRACING-FOR-29E",
       "artifact": "*.pax"
     },
     "org.zowe.configmgr-rexx": {


### PR DESCRIPTION
This PR accomplishes 2 things:
- Adds simple trace messages to track entry into functions used for get-launch-components. Lately I have observed that if Zowe is to fail at startup in some way, this function is often an indicator and tracing it will hopefully reveal the cause
- Makes configmgr tracing tied to zwe tracing, which it always should have been but I guess I didn't realize how to do it at the time.