### PR TITLE
Suggest zwe components upgrade upon installing a component twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the Zowe Installer will be documented in this file.
 
 - Updated ZWEWRF03 workflow to be up to date with the installed software
 
+## `2.7.0`
+
+#### Minor enhancements/defect fixes
+- When zwe components install detects that the given component is already installed, it will suggest you to run zwe components upgrade instead.
+
 ## `2.6.0`
 
 #### Minor enhancements/defect fixes

--- a/bin/commands/components/install/extract/.errors
+++ b/bin/commands/components/install/extract/.errors
@@ -1,7 +1,7 @@
 ZWEL0139E|139|Failed to create directory %s.
 ZWEL0153E|153|Cannot install Zowe component to system root directory.
 ZWEL0154E|154|Temporary directory is empty.
-ZWEL0155E|155|Component %s already exists in %s.
+ZWEL0155E|155|Component %s already exists in %s. If you meant to upgrade this component, run the command 'zwe components upgrade' instead.
 ZWEL0167E|167|Cannot find component name from %s package manifest.
 ZWEL0204E|204|Symlink creation failure, error=%s
 ZWEL0313E|313|Cannot file component file %s.

--- a/bin/commands/components/install/extract/index.sh
+++ b/bin/commands/components/install/extract/index.sh
@@ -124,7 +124,7 @@ print_debug "- Component name found as ${component_name}"
 export ZWE_COMPONENTS_INSTALL_EXTRACT_COMPONENT_NAME="${component_name}"
 if [ -e "${component_name}" ]; then
   rm -fr "${tmp_ext_dir}"
-  print_error_and_exit "Error ZWEL0155E: Component ${component_name} already exists in ${target_dir}." "" 155
+  print_error_and_exit "Error ZWEL0155E: Component ${component_name} already exists in ${target_dir}. If you meant to upgrade this component, run the command 'zwe components upgrade' instead." "" 155
 fi
 
 print_debug "- Rename temporary directory to ${component_name}."

--- a/bin/commands/components/install/extract/index.ts
+++ b/bin/commands/components/install/extract/index.ts
@@ -157,7 +157,7 @@ export function execute(componentFile: string, autoEncoding?: string, upgrade?: 
   if (fs.pathExists(destinationDir)) {
     if (!upgrade) {
       fs.rmrf(tmpDir);
-      common.printErrorAndExit(`Error ZWEL0155E: Component ${componentName} already exists in ${targetDir}.`, undefined, 155);
+      common.printErrorAndExit(`Error ZWEL0155E: Component ${componentName} already exists in ${targetDir}. If you meant to upgrade this component, run the command "zwe components upgrade" instead.`, undefined, 155);
     } else {
       if (fs.pathExists(bkpDir)) {
         fs.rmrf(bkpDir);

--- a/bin/commands/components/install/extract/index.ts
+++ b/bin/commands/components/install/extract/index.ts
@@ -157,7 +157,7 @@ export function execute(componentFile: string, autoEncoding?: string, upgrade?: 
   if (fs.pathExists(destinationDir)) {
     if (!upgrade) {
       fs.rmrf(tmpDir);
-      common.printErrorAndExit(`Error ZWEL0155E: Component ${componentName} already exists in ${targetDir}. If you meant to upgrade this component, run the command "zwe components upgrade" instead.`, undefined, 155);
+      common.printErrorAndExit(`Error ZWEL0155E: Component ${componentName} already exists in ${targetDir}. If you meant to upgrade this component, run the command 'zwe components upgrade' instead.`, undefined, 155);
     } else {
       if (fs.pathExists(bkpDir)) {
         fs.rmrf(bkpDir);


### PR DESCRIPTION
It's easy for people to encounter error 155 when installing a component twice, because people can be lead to think the way to upgrade a component is just to install a new version using `zwe components install`. the actual command is `zwe components upgrade`. but, error 155 will be printed on doing an install for an already installed component, and so I improved the message to suggest the user to use `upgrade` instead, if they meant to upgrade.

- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
- [x] Feature <!-- non-breaking change which adds functionality -->

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [x] No
