### PR TITLE
lock in cloud-gateway-package

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -105,7 +105,7 @@
       "artifact": "apiml-sample-extension-*.zip"
     },
     "org.zowe.apiml.cloud-gateway-package": {
-      "version": "^2.6.0",
+      "version": "2.6.3",
       "artifact": "cloud-gateway-*.zip"
     },
     "org.zowe.configmgr-rexx": {


### PR DESCRIPTION
Signed-off-by: MarkAckert <mark.ackert@broadcom.com>
Remove a version matching character, lock in package version - `^`