### PR TITLE
Fix launcher schema that prevented customizing shareAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to the Zowe Installer will be documented in this file.
 
 #### Minor enhancements/defect fixes
 - When zwe components install detects that the given component is already installed, it will suggest you to run zwe components upgrade instead.
+- Launcher parameters such as "shareAs" could not be customized globally due to zowe.launcher schema being wrong with some parameters nested inside another.
+- Launcher parameters within an individual component were not documented to exist despite the launcher allowing per-component customization.
 
 ## `2.6.0`
 

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -463,19 +463,18 @@
               "description": "Intervals of seconds to wait before restarting a component if it fails before the minUptime value.",
               "items": {
                 "type": "integer"  
-              },
-              "minUptime": {
-                "type": "integer",
-                "default": 90,
-                "description": "The minimum amount of seconds before a component is considered running and the restart counter is reset."
-              },
-              "shareAs": {
-                "type": "string",
-                "description": "Determines which SHAREAS mode should be used when starting a component",
-                "enum": ["no", "yes", "must", ""],
-                "default": "yes"
-
               }
+            },
+            "minUptime": {
+              "type": "integer",
+              "default": 90,
+              "description": "The minimum amount of seconds before a component is considered running and the restart counter is reset."
+            },
+            "shareAs": {
+              "type": "string",
+              "description": "Determines which SHAREAS mode should be used when starting a component",
+              "enum": ["no", "yes", "must", ""],
+              "default": "yes"
             }
           }
         },
@@ -723,6 +722,31 @@
         "certificate": {
           "$ref": "#/$defs/certificate",
           "description": "Certificate for current component."
+        },
+        "launcher": {
+          "type": "object",
+          "description": "Set behavior of how the Zowe launcher will handle this particular component",
+          "additionalProperties": true,
+          "properties": {
+            "restartIntervals": {
+              "type": "array",
+              "description": "Intervals of seconds to wait before restarting a component if it fails before the minUptime value.",
+              "items": {
+                "type": "integer"  
+              }
+            },
+            "minUptime": {
+              "type": "integer",
+              "default": 90,
+              "description": "The minimum amount of seconds before a component is considered running and the restart counter is reset."
+            },
+            "shareAs": {
+              "type": "string",
+              "description": "Determines which SHAREAS mode should be used when starting a component",
+              "enum": ["no", "yes", "must", ""],
+              "default": "yes"
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
Fixing launcher schema. zowe.launcher had properties wrongly nested within another, while component-level launcher customization was not even in the schema but the launcher does check for it.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->


- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
- [x] Bugfix <!-- non-breaking change which fixes an issue -->

#### Relevant issues
#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [x] No

<!-- If yes, please describe the impact and migration path below.-->
