### PR TITLE
Compatibility fix for pr 3270

### DIFF
--- a/bin/commands/init/certificate/index.sh
+++ b/bin/commands/init/certificate/index.sh
@@ -120,6 +120,14 @@ if [ -n "${zosmf_host}" -a -n "${zosmf_port}" ]; then
   create_zosmf_trust=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.createZosmfTrust")
   if [ "${create_zosmf_trust}" = "true" ]; then
     do_trust_zosmf="--trust-zosmf"
+  # backward compat for if missing.
+  elif [ -z "${create_zosmf_trust}" ]; then
+    if [ "${verify_certificates}" = "STRICT" -o "${verify_certificates}" = "NONSTRICT" ]; then
+      do_trust_zosmf="--trust-zosmf"
+    else
+      zosmf_host=
+      zosmf_port=
+    fi
   else
     zosmf_host=
     zosmf_port=


### PR DESCRIPTION
PR https://github.com/zowe/zowe-install-packaging/pull/3270 added a new parameter and expects it to be present, or else skips zosmf cert setup. Our backward compat story isnt great when using example-zowe.yaml because there is no guarantee upgrades will take in new parameters from there.
As a result, for backward compat, we introduce the old behavior in case the new parameter is missing.