### PR TITLE
fix launcher schema failure

### DIFF
--- a/schemas/server-common.json
+++ b/schemas/server-common.json
@@ -8,13 +8,13 @@
       "$anchor": "zoweSemverVersion",
       "type": "string",
       "description": "A semantic version, see https://semver.org/",
-      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-*[a-zA-Z][0-9a-zA-Z\\-\\.]*)?(\\+[0-9a-zA-Z\\-\\.]*)?$"
+      "pattern": "^[0-9]*\\.[0-9]*\\.[0-9]*(-*[a-zA-Z][0-9a-zA-Z\\-\\.]*)?(\\+[0-9a-zA-Z\\-\\.]*)?$"
     },
     "semverRange": {
       "$anchor": "zoweSemverRange",
       "type": "string",
       "description": "A semantic version, see https://semver.org/",
-      "pattern": "^(([\\^\\~\\>\\<]?)|(>=?)|(<=?))(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-*[a-zA-Z][0-9a-zA-Z\\-\\.]*)?(\\+[0-9a-zA-Z\\-\\.]*)?$"
+      "pattern": "^(([\\^\\~\\>\\<]?)|(>=?)|(<=?))[0-9]*\\.[0-9]*\\.[0-9]*(-*[a-zA-Z][0-9a-zA-Z\\-\\.]*)?(\\+[0-9a-zA-Z\\-\\.]*)?$"
     },
     "dataset": {
       "$anchor": "zoweDataset",


### PR DESCRIPTION
For some reason, the regex in the schema used for semver checking is not working correctly.
The regex should work fine, according to regex websites, but in reality the launcher's latest version "2.0.10" fails to pass validation.
I restructured the regex to be functionally similar, yet simplified, and this allows the launcher to pass the check.
This pattern also solves https://github.com/zowe/zowe-common-c/issues/352