### PR TITLE
defaults.yaml draft for consideration

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1,0 +1,750 @@
+################################################################################
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+################################################################################
+
+#===============================================================================
+# This is a YAML configuration file for Zowe instance.
+#
+# YAML is a human-friendly data serialization language for all programming languages.
+# To learn more about YAML specifications, please check https://yaml.org/.
+#
+# Because YAML is indentation sensitive, using a validator on this file is helpful.
+# One such free, offline validator is the YAML extension within Visual Studio Code.
+#
+# Most entries allowed here are validated against and described by a schema file
+# Located at schemas/zowe-yaml-schema.json
+# Some entries are described in more detail at https://docs.zowe.org/.
+#
+# If you modify any settings listed in "zwe init --help" command, you may need to
+# re-run "zwe init" command to make them take effect.
+#===============================================================================
+
+#-------------------------------------------------------------------------------
+# Zowe global configurations
+#
+# This section includes Zowe setup information used by `zwe install` and
+# `zwe init` command, as well as default configurations for Zowe runtime.
+#-------------------------------------------------------------------------------
+zowe:
+
+  #-------------------------------------------------------------------------------
+  # These configurations are used by "zwe install" or "zwe init" commands.
+  #-------------------------------------------------------------------------------
+  setup:
+    # MVS data set related configurations
+    dataset:
+      
+      # where Zowe MVS data sets will be installed
+      prefix: IBMUSER.ZWEV2
+      
+      # PROCLIB where Zowe STCs will be copied over
+      proclib: USER.PROCLIB
+      
+      # Zowe PARMLIB
+      parmlib: ${{ zowe.setup.dataset.prefix }}.CUST.PARMLIB
+      # Holds Zowe PARMLIB members for plugins
+      parmlibMembers:
+        # For ZIS plugins
+        zis: ZWESIP00
+      
+      # JCL library where Zowe will store temporary JCLs during initialization
+      jcllib: ${{ zowe.setup.dataset.prefix }}.CUST.JCLLIB
+      # Utilities for use by Zowe and extensions
+      loadlib: ${{ zowe.setup.dataset.prefix }}.SZWELOAD
+      # APF authorized LOADLIB for Zowe
+      authLoadlib: ${{ zowe.setup.dataset.prefix }}.SZWEAUTH
+      
+      # APF authorized LOADLIB for Zowe ZIS Plugins
+      authPluginLib: ${{ zowe.setup.dataset.prefix }}.CUST.ZWESAPL
+
+    # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+    # Security related configurations. This setup is optional.
+    security:
+      # security product name. Can be RACF, ACF2 or TSS
+      product: RACF
+      # security group name
+      groups:
+        # Zowe admin user group
+        admin: ZWEADMIN
+        # Zowe STC group
+        stc: ZWEADMIN
+        # Zowe SysProg group
+        sysProg: ZWEADMIN
+      # security user name
+      users:
+        # Zowe runtime user name of main service
+        zowe: ZWESVUSR
+        # Zowe runtime user name of ZIS
+        zis: ZWESIUSR
+      # STC names
+      stcs:
+        # STC name of Zowe main service
+        zowe: ZWESLSTC
+        # STC name of Zowe ZIS
+        zis: ZWESISTC
+        # STC name of Zowe ZIS Auxiliary Server
+        aux: ZWESASTC
+
+    # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+    # Certificate related configurations
+    #
+    # There are 5 configurations cases. Please choose one from below.
+
+    # >>>> Certificate setup scenario 1
+    # PKCS12 (keystore) with Zowe generate certificates.
+    certificate:
+      # Type of certificate storage. Valid values are: PKCS12, JCEKS, JCECCAKS, JCERACFKS, JCECCARACFKS, or JCEHYBRIDRACFKS
+      type: PKCS12
+      pkcs12:
+        
+        # Keystore directory
+        directory: /var/zowe/keystore
+        # # Lock the keystore directory to only accessible by Zowe runtime user and group.
+        # lock: true
+        
+        # # Certificate alias name. Optional, default value is localhost.
+        # # Note: please use all lower cases as alias.
+        # name: localhost
+        
+        # # Keystore password. Optional, default value is password.
+        # password: password
+        
+        # # Alias name of self-signed certificate authority. Optional, default value is local_ca.
+        # # Note: please use all lower cases as alias.
+        # caAlias: local_ca
+        
+        # # Password of keystore stored self-signed certificate authority. Optional, default value is local_ca_password.
+        # caPassword: local_ca_password
+      # # Distinguished name for Zowe generated certificates. All optional.
+      # dname:
+      #   caCommonName: ""
+      #   commonName: ""
+      #   orgUnit: ""
+      #   org: ""
+      #   locality: ""
+      #   state: ""
+      #   country: ""
+      # # Validity days for Zowe generated certificates
+      # validity: 3650
+      # # Domain names and IPs should be added into certificate SAN
+      # # If this field is not defined, `zwe init` command will use
+      # # `zowe.externalDomains`.
+      # san:
+      #   # sample domain name
+      #   - dvipa.my-company.com
+      #   # sample IP address
+      #   - 12.34.56.78
+
+    # # >>>> Certificate setup scenario 2
+    # # PKCS12 (keystore) with importing certificate generated by other CA.
+    # certificate:
+    #   # Type of certificate storage. Valid values are: PKCS12, JCEKS, JCECCAKS, JCERACFKS, JCECCARACFKS, or JCEHYBRIDRACFKS
+    #   type: PKCS12
+    #   pkcs12:
+    #     
+    #     # Keystore directory
+    #     directory: /var/zowe/keystore
+    #     # Lock the keystore directory to only accessible by Zowe runtime user and group.
+    #     lock: true
+    #     # # Certificate alias name. Optional, default value is localhost.
+    #     # # Note: please use all lower cases as alias.
+    #     # name: localhost
+    #     # # Keystore password. Optional, default value is password.
+    #     # password: password
+    #     import:
+    #       
+    #       # Existing PKCS12 keystore which holds the certificate issued by external CA.
+    #       keystore: ""
+    #       
+    #       # Password of the above keystore
+    #       password: ""
+    #       
+    #       # Certificate alias will be imported
+    #       # Note: please use all lower cases as alias.
+    #       alias: ""
+    #   
+    #   # PEM format certificate authorities will also be imported and trusted.
+    #   importCertificateAuthorities:
+    #     # Path to the certificate authority signed the certificate will be imported.
+    #     - ""
+
+    # # >>>> Certificate setup scenario 3
+    # # z/OS Keyring with Zowe generated certificates.
+    # certificate:
+    #   # Type of certificate storage. Valid values are: PKCS12, JCEKS, JCECCAKS, JCERACFKS, JCECCARACFKS, or JCEHYBRIDRACFKS
+    #   type: JCERACFKS
+    #   createZosmfTrust: true
+    #   keyring:
+    #     
+    #     # keyring name
+    #     name: ZoweKeyring
+    #     
+    #     # # Label of Zowe certificate. Optional, default value is localhost.
+    #     # label: localhost
+    #     
+    #     # # label of Zowe CA certificate. Optional, default value is localca.
+    #     # caLabel: localca
+    #   # # Distinguished name for Zowe generated certificates. All optional.
+    #   # dname:
+    #   #   caCommonName: ""
+    #   #   commonName: ""
+    #   #   orgUnit: ""
+    #   #   org: ""
+    #   #   locality: ""
+    #   #   state: ""
+    #   #   country: ""
+    #   # # Validity days for Zowe generated certificates
+    #   # validity: 3650
+    #   # # Domain names and IPs should be added into certificate SAN
+    #   # # If this field is not defined, `zwe init` command will use
+    #   # # `zowe.externalDomains`.
+    #   # # **NOTE**: due to the limitation of RACDCERT command, this field should
+    #   # #           contain exactly 2 entries with the domain name and IP address.
+    #   # san:
+    #   #   - dvipa.my-company.com
+    #   #   - 12.34.56.78
+
+    # # >>>> Certificate setup scenario 4
+    # # z/OS Keyring and connect to existing certificate
+    # certificate:
+    #   # Type of certificate storage. Valid values are: PKCS12, JCEKS, JCECCAKS, JCERACFKS, JCECCARACFKS, or JCEHYBRIDRACFKS
+    #   type: JCERACFKS
+    #   keyring:
+    #     
+    #     # keyring name
+    #     name: ZoweKeyring
+    #     connect:
+    #       
+    #       # Current owner of the existing certificate, can be SITE or an user ID.
+    #       user: IBMUSER
+    #       
+    #       # Label of the existing certificate will be connected to Zowe keyring.
+    #       label: ""
+    #   
+    #   # If you have other certificate authorities want to be trusted in Zowe keyring,
+    #   # list the certificate labels here.
+    #   # **NOTE**, due to the limitation of RACDCERT command, this field should
+    #   #           contain maximum 2 entries.
+    #   importCertificateAuthorities:
+    #     - ""
+
+    # # >>>> Certificate setup scenario 5
+    # # z/OS Keyring with importing certificate stored in data set
+    # certificate:
+    #   # Type of certificate storage. Valid values are: PKCS12, JCEKS, JCECCAKS, JCERACFKS, JCECCARACFKS, or JCEHYBRIDRACFKS
+    #   type: JCERACFKS
+    #   keyring:
+    #     
+    #     # keyring name
+    #     name: ZoweKeyring
+    #     
+    #     # # Label of Zowe certificate. Optional, default value is localhost.
+    #     # label: localhost
+    #     import:
+    #       
+    #       # Name of the data set holds the certificate issued by other CA.
+    #       # This data set should be in PKCS12 format and contain private key.
+    #       dsName: ""
+    #       
+    #       # Password for the PKCS12 data set.
+    #       password: ""
+
+    # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+    # VSAM configurations if you are using VSAM as Caching Service storage
+    vsam:
+      # VSAM data set with Record-Level-Sharing enabled or not
+      # Valid values could be: NONRLS or RLS.
+      mode: NONRLS
+      # Volume name if you are using VSAM in NONRLS mode
+      volume: ""
+      # Storage class name if you are using VSAM in RLS mode
+      storageClass: ""
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  
+  # Zowe runtime (root) directory
+  #
+  # **NOTE**: if it is not specified and you passed "--update-config" argument
+  # when you run "zwe init" command, this value will be updated with the Zowe
+  # runtime where the "zwe" command is located.
+  #
+  # This value is required by ZWESLSTC to know where is Zowe runtime.
+  runtimeDirectory: ""
+
+  
+  # Where to store runtime logs
+  logDirectory: /global/zowe/logs
+
+  
+  # Zowe runtime workspace directory
+  workspaceDirectory: /global/zowe/workspace
+
+  
+  # Where extensions are installed
+  extensionDirectory: /global/zowe/extensions
+
+  
+  useConfigmgr: true
+  # Setting to true will enable:
+  # * schema-backed validation of zowe.yaml
+  # * should greatly improve startup time.
+  # * can supply multiple zowe.yaml as defaults & overrides in the format of
+  #   FILE(/my/customizations.yaml):FILE(/company/customizations.yaml):FILE(/zowe/defaults.yaml)
+  # * allows templating in zowe.yaml by putting references within ${{ }} blocks such as
+  #    rewriting the job section below as
+  #    job:
+  #      name: ${{ zowe.job.prefix }}SV
+  #      prefix: ZWE1
+  configmgr:
+    # STRICT=quit on any error, including missing schema
+    # COMPONENT-COMPAT=if component missing schema, skip it with warning instead of quit
+    validation: "COMPONENT-COMPAT"
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  # runtime z/OS job name
+  job:
+    # Prefix of component address space
+    prefix: ZWE1
+    # Zowe JES job name
+    name: ${{ zowe.job.prefix }}SV
+
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  # This is an ID you use to separate multiple Zowe installs when determining
+  # resource names used in RBAC authorization checks such as dataservices with RBAC
+  # expects this ID in SAF resources 
+  rbacProfileIdentifier: ${{ zowe.job.prefix }}
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  # This is an ID that can be used by servers that distinguish their cookies from unrelated Zowe installs, 
+  # for purposes such as to allow multiple copies of Zowe to be used within the same client
+  cookieIdentifier: ${{ zowe.rbacProfileIdentifier }}
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  
+  # You can list your external domains how you want to access Zowe.
+  # This should be the domain list you would like to put into your web browser
+  # address bar.
+  externalDomains:
+    # this should be the domain name to access Zowe APIML Gateway
+    - sample-domain.com
+  
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  # This is the port you use to access Zowe Gateway from your web browser.
+  #
+  # In many use cases, this should be same as `components.gateway.port`. But in
+  # some use cases, like containerization, this port could be different.
+  externalPort: 7554
+
+  network:
+    attls: false
+    internalAddress: ${{ ()=> { if (components.gateway.enabled) { return '127.0.0.1'; } else { return '0.0.0.0'; } }() }}
+    validatePortFree: true
+
+  launcher:
+    minUptime: 90
+    shareAs: yes
+
+  
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  # You can un-comment and define any extra environment variables as key/value
+  # pairs here.
+  # environments:
+  #   # Example of a global environment variable for all components
+  #   MY_ENV_VAR: my_env_val
+
+  #   # Another example to customize SSH port for VT Terminal Desktop app
+  #   ZWED_SSH_PORT: 22
+  #   ZWED_TN3270_PORT: 23
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  # Enable debug mode for zowe launch scripts
+  launchScript:
+    # set to "debug" or "trace" to display extra debug information
+    logLevel: "info"
+    # set to "exit" if you'd like startup to exit if any component has an error in the configure stage, otherwise zwe will warn but continue.
+    onComponentConfigureFail: "warn"
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  # Default Zowe certificate
+  #
+  # **NOTE**: these fields can be updated automatically if you pass
+  # `--update-config` to `zwe init` command. The generated value will base on
+  # your setup in `zowe.setup.certificate` section.
+  certificate:
+    keystore:
+      type: ${{ zowe.setup.certificate.type }}
+      file: ${{ zowe.setup.certificate.pkcs12.directory }}/localhost/localhost.keystore.p12
+      password: password
+      alias: localhost
+    truststore:
+      type: ${{ zowe.setup.certificate.type }}
+      file: ${{ zowe.setup.certificate.pkcs12.directory }}/localhost/localhost.truststore.p12
+      password: password
+    pem:
+      key: ${{ zowe.setup.certificate.pkcs12.directory }}/localhost/localhost.key
+      certificate: ${{ zowe.setup.certificate.pkcs12.directory }}/localhost/localhost.cer
+      certificateAuthorities: ${{ zowe.setup.certificate.pkcs12.directory }}/local_ca/local_ca.cer
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  # How we want to verify SSL certificates of services. Valid values are:
+  # - STRICT:    will validate if the certificate is trusted in our trust store and
+  #              if the certificate Command Name and Subject Alternative Name (SAN)
+  #              is validate. This is recommended for the best security.
+  # - NONSTRICT: Some servers do not support this mode.
+  #              will validate if the certificate is trusted in our trust store.
+  #              This mode does not validate certificate Common Name and Subject
+  #              Alternative Name (SAN).
+  #              
+  # - DISABLED:  disable certificate validation. This is NOT recommended for
+  #              security 
+  verifyCertificates: STRICT
+
+
+#-------------------------------------------------------------------------------
+# Java configuration
+#
+# Some Zowe components requires Java. Define the path where you have your Java
+# is installed.
+#
+# **NOTE**: this field can be updated automatically if you pass `--update-config`
+# to `zwe init` command.
+#-------------------------------------------------------------------------------
+java:
+  
+  # Path to your Java home directory
+  home: ""
+
+
+#-------------------------------------------------------------------------------
+# node.js configuration
+#
+# Some Zowe components requires node.js. Define the path where you have your
+# node.js is installed.
+#
+# **NOTE**: this field can be updated automatically if you pass `--update-config`
+# to `zwe init` command.
+#-------------------------------------------------------------------------------
+node:
+  
+  # Path to your node.js home directory
+  home: ""
+
+
+#-------------------------------------------------------------------------------
+# z/OSMF configuration
+#
+# If your Zowe instance is configured to use z/OSMF for authentication or other
+# features. You need to define how to access your z/OSMF instance.
+#-------------------------------------------------------------------------------
+zOSMF:
+  
+  # host name of your z/OSMF instance
+  host: dvipa.my-company.com
+  
+  port: 443
+  applId: IZUDFLT
+
+
+#-------------------------------------------------------------------------------
+# Zowe components default configurations
+#
+# This section includes default configurations for all Zowe components installed
+# on the Zowe instance.
+#
+# Every component should define their own section under `components` with their
+# component ID.
+#
+# For each component, they can always have "enabled" property and "certificate"
+# property. More configurations for each component can be found in component
+# manifest file.
+#-------------------------------------------------------------------------------
+components:
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  gateway:
+    enabled: true
+    address: 0.0.0.0
+    port: ${{ zowe.externalPort }}
+    debug: false
+    attls: ${{ zowe.network.attls }}
+    apiml:
+      security:
+        auth:
+          provider: zosmf
+          zosmf:
+            jwtAutoconfiguration: auto
+            serviceId: zosmf
+        authorization:
+          endpoint:
+            enabled: false
+          provider: ""
+        x509:
+          enabled: false
+    spring:
+      profiles:
+        active: ${{ components.gateway.attls ? 'attls': undefined }}
+    server:
+      internal:
+      # gateway supports internal connector
+        enabled: false
+        port: 7550
+        ssl:
+          enabled: false
+      ssl:
+        enabled: ${{ components.gateway.attls ? false : undefined }}
+        
+          # internal connector can use different certificate
+          # certificate:
+          #   keystore:
+          #     alias: ""
+
+    # If we customize this to use different external certificate, than should also
+    # define "server.internal.ssl.certificate" and enable "server.internal.ssl.enabled".
+    # certificate:
+    #   keystore:
+    #     alias: ""
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  metrics-service:
+    enabled: false
+    address: ${{ zowe.network.internalAddress }}
+    port: 7551
+    debug: false
+    attls: ${{ zowe.network.attls }}
+    spring:
+      profiles:
+        active: ${{ components['metrics-service'].attls ? 'attls': undefined }}
+    server:
+      internal:
+        ssl:
+          enabled: false
+      ssl:
+        enabled: ${{ components['metrics-service'].attls ? false : undefined }}
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  cloud-gateway:
+    enabled: false
+    address: ${{ zowe.network.internalAddress }}
+    port: 7563
+    debug: false
+    attls: ${{ zowe.network.attls }}
+    spring:
+      profiles:
+        active: ${{ components['cloud-gateway'].attls ? 'attls': undefined }}
+    server:
+      internal:
+        ssl:
+          enabled: false
+      ssl:
+        enabled: ${{ components['cloud-gateway'].attls ? false : undefined }}
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  api-catalog:
+    enabled: "${{ ()=> { if (components.gateway.enabled || components['cloud-gateway'].enabled) { return true; } else { return false; } }() }}"
+    address: ${{ zowe.network.internalAddress }}
+    port: 7552
+    debug: false
+    attls: ${{ zowe.network.attls }}
+    spring:
+      profiles:
+        active: ${{ components['api-catalog'].attls ? 'attls': undefined }}
+    server:
+      internal:
+        ssl:
+          enabled: false
+      ssl:
+        enabled: ${{ components['api-catalog'].attls ? false : undefined }}
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  discovery:
+    enabled: "${{ ()=> { if (components.gateway.enabled || components['cloud-gateway'].enabled) { return true; } else { return false; } }() }}"
+    address: ${{ zowe.network.internalAddress }}
+    port: 7553
+    debug: false
+    attls: ${{ zowe.network.attls }}
+    spring:
+      profiles:
+        active: ${{ components.discovery.attls ? 'attls': undefined }}
+    server:
+      internal:
+        ssl:
+          enabled: false
+      ssl:
+        enabled: ${{ components.discovery.attls ? false : undefined }}
+
+    # Define this value to match your number of Discovery StatefulSet if you are running containerized Zowe
+    # replicas: 1
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  caching-service:
+    enabled: true
+    address: ${{ zowe.network.internalAddress }}
+    port: 7555
+    debug: false
+    attls: ${{ zowe.network.attls }}
+    storage:
+      evictionStrategy: reject
+      # can be inMemory, VSAM, redis or infinispan
+      mode: VSAM
+      size: 10000
+      vsam:
+        # your VSAM data set created by "zwe init vsam" command or ZWECSVSM JCL
+        # this is required if storage mode is VSAM
+        name: ""
+      infinispan:
+        # this is required if storage mode is infinispan
+        jgroups:
+          port: 7600
+    spring:
+      profiles:
+        active: ${{ components['caching-service'].attls ? 'attls': undefined }}
+    server:
+      internal:
+        ssl:
+          enabled: false
+      ssl:
+        enabled: ${{ components['caching-service'].attls ? false : undefined }}
+
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  app-server:
+    enabled: true
+    address: ${{ zowe.network.internalAddress }}
+    port: 7556
+    attls: ${{ zowe.network.attls }}
+    node:
+      https:
+        ipAddresses:
+          - ${{ components['app-server'].address }}
+    agent:
+      host: ${{ components.zss.address }}
+    # we can customize any component with custom certificate
+    # the missing definitions will be picked from "zowe.certificate"
+    # certificate:
+    #   keystore:
+    #     alias: app-server
+    #   pem:
+    #     key: ${{ zowe.setup.certificate.pkcs12.directory }}/localhost/localhost.keystore.app-server.key
+    #     certificate: ${{ zowe.setup.certificate.pkcs12.directory }}/localhost/localhost.keystore.app-server.cer-ebcdic
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  zss:
+    enabled: true
+    address: ${{ zowe.network.internalAddress }}
+    port: 7557
+    crossMemoryServerName: ZWESIS_STD
+    tls: "${{ !zowe.network.attls }}"
+    attls: ${{ zowe.network.attls }}
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  jobs-api:
+    enabled: false
+    debug: false
+    port: 7558
+    attls: ${{ zowe.network.attls }}
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  files-api:
+    enabled: false
+    debug: false
+    port: 7559
+    attls: ${{ zowe.network.attls }}
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  explorer-jes:
+    enabled: true
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  explorer-mvs:
+    enabled: true
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  explorer-uss:
+    enabled: true
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  # Each extension can have dedicated definition similar to core components.
+  # my-extension:
+  #   enabled: true
+
+
+#-------------------------------------------------------------------------------
+# Zowe high availability instances customizations
+#
+# This section includes customizations for each Zowe high availability instance.
+#
+# You can start each HA instance with `zwe start --ha-instance <ha-instance>`.
+#-------------------------------------------------------------------------------
+# haInstances:
+#
+#   # HA instance ID
+#   lpar1:
+#     # hostname where this instance will be started
+#     hostname: lpar1.my-company.com
+#     # Your &SYSNAME for this LPAR
+#     # This sysname will be used to route your JES command to target system.
+#     sysname: LPR1
+#     # for this HA instance, we did not customize "components", so it will use default value.
+  
+#   # HA instance ID, we will start 2 instances on LPAR2
+#   # **NOTE**, we can only start one gateway in same LPAR.
+#   lpar2a:
+#     # hostname where this instance will be started
+#     hostname: lpar2.my-company.com
+#     # Your &SYSNAME for this LPAR
+#     # This sysname will be used to route your JES command to target system.
+#     sysname: LPR2
+
+#     # These configurations will overwrite highest level default "components" configuration
+#     components:
+#       discovery:
+#         # use customized port on this instance
+#         port: 17553
+#       api-catalog:
+#         port: 17552
+#       app-server:
+#         # no app-server in this instance
+#         enabled: false
+#       zss:
+#         # no app-server in this instance
+#         enabled: false
+#       jobs-api:
+#         port: 18545
+#         enabled: true
+#       files-api:
+#         port: 18547
+#         enabled: true
+#       caching-service:
+#         port: 17555
+#
+#   lpar2b:
+#     hostname: lpar2.my-company.com
+#     # your &SYSNAME for this LPAR
+#     sysname: LPR2
+
+#     # These configurations will overwrite highest level default "components" configuration
+#     components:
+#       gateway:
+#         enabled: false
+#       discovery:
+#         enabled: false
+#       api-catalog:
+#         enabled: false
+#       app-server:
+#         enabled: false
+#         port: 28544
+#       zss:
+#         port: 28542
+#       jobs-api:
+#         enabled: true
+#       files-api:
+#         enabled: false
+#       caching-service:
+#         enabled: false

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -4,7 +4,8 @@
   "title": "Zowe configuration file",
   "description": "Configuration file for Zowe (zowe.org) version 2.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
+  "required": [ "zowe" ],
   "properties": {
     "zowe": {
       "type": "object",
@@ -423,6 +424,15 @@
           "additionalProperties": false,
           "description": "Optional, advanced network configuration parameters",
           "properties": {
+            "attls": {
+              "type": "boolean",
+              "description": "Instructs each server to use AT-TLS to the extent they are capable.",
+              "default": false
+            },
+            "internalAddress": {
+              "type": "string",
+              "description": "The IP in which each server should bind to."
+            },
             "vipaIp": {
               "type": "string",
               "description": "The IP address which all of the Zowe servers will be binding to. If you are using multiple DIPVA addresses, do not use this option."
@@ -723,6 +733,15 @@
           "$ref": "#/$defs/certificate",
           "description": "Certificate for current component."
         },
+        "address": {
+          "type": "string",
+          "description": "Instructs the component's server(s) to bind to the IP address given"
+        },
+        "attls": {
+          "type": "boolean",
+          "description": "Instructs the component's server(s) to use AT-TLS to the extent they are capable",
+          "default": false
+        }
         "launcher": {
           "type": "object",
           "description": "Set behavior of how the Zowe launcher will handle this particular component",


### PR DESCRIPTION
This PR has a few ideas for consideration,

1) A zowe-level object for describing network behavior all servers should attempt to do, such as to bind to a specific ip or to enable attls
2) component-level attributes to do the same things, at a per-component level
3) A file which is not an example yaml, but rather a defaults yaml. This file REQUIRES the configmgr, because it is trying to simplify and automate config better by using configmgr's templating ability, as well as that using a 'default' with customizations provided in a different file requires the ocnfigmgr's multi-file ability.

This is just some ideas for consideration, and someone else can continue this work if they desire, even contributing to this branch.

I don't like adding more top-level things to the component schema, because it limits what extensions can do in their own component space. the safest way to add more stuff to a component from zowe is to stick it all in `component[componentname].launcher`
such as to put any zowe.foo thing into `component[componentname].launcher.foo`
so, my idea of `component[componentname].attls` is probably bad and could instead be `component[componentname].launcher.network.attls`