### PR TITLE
Add stdout during component install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the Zowe Installer will be documented in this file.
 
 - Updated ZWEWRF03 workflow to be up to date with the installed software
 
+## `2.8.0`
+
+### New features and enhancements
+- Component installation can now print stdout of install scripts [#3361](https://github.com/zowe/zowe-install-packaging/pull/3361)
+
 ## `2.7.0`
 
 ### New features and enhancements

--- a/bin/commands/components/install/process-hook/index.ts
+++ b/bin/commands/components/install/process-hook/index.ts
@@ -38,8 +38,17 @@ export function execute(componentName: string) {
     const result = shell.execOutSync('sh', '-c', `. ${ZOWE_CONFIG.zowe.runtimeDirectory}/bin/libs/configmgr-index.sh && . ${scriptPath} ; export rc=$? ; export -p`);
     if (result.rc==0) {
       varlib.getEnvironmentExports(result.out, true);
+      const outLines = result.out.split('\n');
+      common.printFormattedInfo("ZWELS", "zwe-components-install-process-hook", `- commands.install output from ${componentName} is:`);
+      common.printMessage(outLines.filter(line => !line.startsWith('export ')).join('\n'));
+      common.printFormattedDebug("ZWELS", "zwe-components-install-process-hook", outLines.filter(line => line.startsWith('export ')).join('\n'));
     } else {
       common.printError(`install script ended with error, rc=${result.rc}`);
+      if (result.out) {
+        const outLines = result.out.split('\n');
+        common.printFormattedInfo("ZWELS", "zwe-components-install-process-hook", `- commands.install output from ${componentName} is:`);
+        common.printMessage(outLines.filter(line => !line.startsWith('export ')).join('\n'));
+      }
       std.exit(result.rc);
     }
 


### PR DESCRIPTION
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
- [x] Feature <!-- non-breaking change which adds functionality -->


#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
Users report the desire to have components print output during installation.
We started doing this recently during configuration, but not installation.
Intentionally or not, configmgr=false does print stdout during installation, but not configmgr=true.
So, this PR enhances the TS code to add lines similar to those of configure, but for install.

#### Does this PR introduce a breaking change?
- [x] No

