### PR TITLE
Move path spam to dbug message

### DIFF
--- a/bin/libs/config.ts
+++ b/bin/libs/config.ts
@@ -232,7 +232,7 @@ export function sanitizeHaInstanceId(): string|undefined {
 export function applyEnviron(environ: any): void {
   let keys = Object.keys(environ);
   keys.forEach(function(key:string) {
-    common.printMessage(`applyEnviron setting ${key}=${environ[key]}`);
+    common.printDebug(`applyEnviron setting ${key}=${environ[key]}`);
     std.setenv(key, environ[key]);
   });
 }

--- a/bin/libs/fs.ts
+++ b/bin/libs/fs.ts
@@ -85,9 +85,9 @@ export function mkdirp(path:string, mode?: number): number {
     }
   }
 
-  common.printMessage('paths='+JSON.stringify(paths));
+  common.printDebug('paths='+JSON.stringify(paths));
   if (firstMissingDir >= paths.length) { return 0; }
-  common.printMessage('firstMissingDir='+paths[firstMissingDir]);
+  common.printDebug('firstMissingDir='+paths[firstMissingDir]);
 
   for (let i = firstMissingDir; i < paths.length; i++) {
     let rc = os.mkdir(paths[i], mode ? mode : 0o777);


### PR DESCRIPTION
While testing 2.8 code, I noticed that there's a lot of spam in the logs like:
`paths=["/","/u","/`
It comes from a message that was meant for debugging, but wasnt debug-level, so I fixed that.