### PR TITLE
Fix pwd for install scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,12 @@ All notable changes to the Zowe Installer will be documented in this file.
 
 ## `2.8.0`
 
-#### Minor enhancements/defect fixes
-- Bugfix: Component environment variables would not be aliased to the "_configs_" shorthand when the component had a configure script, but not a validate script, and zowe.useConfigmgr was enabled.
-
-## `2.8.0`
-
 ### New features and enhancements
 - Component installation can now print stdout of install scripts [#3361](https://github.com/zowe/zowe-install-packaging/pull/3361)
+
+#### Minor enhancements/defect fixes
+- Bugfix: Component environment variables would not be aliased to the "_configs_" shorthand when the component had a configure script, but not a validate script, and zowe.useConfigmgr was enabled.
+- Buffix: When zowe.useConfigmgr=true, component installation would not run the installation script from the component root directory, but instead from the place zwe was executed, causing relative path differences versus zowe.useConfigmgr=false.
 
 ## `2.7.0`
 

--- a/bin/commands/components/install/process-hook/index.ts
+++ b/bin/commands/components/install/process-hook/index.ts
@@ -34,8 +34,9 @@ export function execute(componentName: string) {
   if (installScript) {
     common.printMessage(`Process ${installScript} defined in manifest commands.install:`);
     const scriptPath = pathoid.join(targetDir, componentName, installScript);
+    const componentRoot = pathoid.join(targetDir, componentName);
     // run commands
-    const result = shell.execOutSync('sh', '-c', `. ${ZOWE_CONFIG.zowe.runtimeDirectory}/bin/libs/configmgr-index.sh && . ${scriptPath} ; export rc=$? ; export -p`);
+    const result = shell.execOutSync('sh', '-c', `. ${ZOWE_CONFIG.zowe.runtimeDirectory}/bin/libs/configmgr-index.sh && cd ${componentRoot} && . ${scriptPath} ; export rc=$? ; export -p`);
     if (result.rc==0) {
       varlib.getEnvironmentExports(result.out, true);
       const outLines = result.out.split('\n');


### PR DESCRIPTION
<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->


#### PR type
- [x] Bugfix <!-- non-breaking change which fixes an issue -->

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
It was observed in an extension that the extension would not run correctly when zowe.useConfigmgr=true, because the extension used relative paths and the value of $PWD was different depending on zowe.useConfigmgr. when false, it was the component root dir. When true, it was the place zwe was executed from. This is a mistake and fixed by doing a `cd` to the component root before executing the install script.