### PR TITLE
build: force node-18 tests to run on zzow04 only

### DIFF
--- a/.github/scripts/cicd_test/make_matrix.sh
+++ b/.github/scripts/cicd_test/make_matrix.sh
@@ -12,91 +12,97 @@
 
 case $install_test_choice in
 
-    "Convenience Pax")
-    test_file="$CONVENIENCE_PAX_TESTFILE"
-    ;;
+"Convenience Pax")
+  test_file="$CONVENIENCE_PAX_TESTFILE"
+  ;;
 
-    "SMPE FMID")
-    test_file="$SMPE_FMID_TESTFILE"
-    ;;
+"SMPE FMID")
+  test_file="$SMPE_FMID_TESTFILE"
+  ;;
 
-    "SMPE PTF")
-    test_file="$SMPE_PTF_TESTFILE"
-    ;;
+"SMPE PTF")
+  test_file="$SMPE_PTF_TESTFILE"
+  ;;
 
-    "Extensions")
-    test_file="$EXTENSIONS_TESTFILE"
-    ;;
+"Extensions")
+  test_file="$EXTENSIONS_TESTFILE"
+  ;;
 
-    "Keyring")
-    test_file="$KEYRING_TESTFILE"
-    ;;
-    
-    "z/OS node v14")
-    test_file="$ZOS_NODE_V14_TESTFILE"
-    ;;
+"Keyring")
+  test_file="$KEYRING_TESTFILE"
+  ;;
 
-    "z/OS node v16")
-    test_file="$ZOS_NODE_V16_TESTFILE"
-    ;;
-	
-	"z/OS node v18")
-	test_file="$ZOS_NODE_V18_TESTFILE"
-	;;
+"z/OS node v14")
+  test_file="$ZOS_NODE_V14_TESTFILE"
+  ;;
 
-    "Non-strict Verify External Certificate")
-    test_file="$NON_STRICT_VERIFY_EXTERNAL_CERTIFICATE_TESTFILE"
-    ;;
+"z/OS node v16")
+  test_file="$ZOS_NODE_V16_TESTFILE"
+  ;;
 
-    "Install PTF Twice")
-    test_file="$INSTALL_PTF_TWICE_TESTFILE"
-    ;;
+"z/OS node v18")
+  test_file="$ZOS_NODE_V18_TESTFILE"
+  test_force_system="zzow04"
+  ;;
 
-    "VSAM Caching Storage Method")
-    test_file="$VSAM_CACHING_STORAGE_METHOD_TESTFILE"
-    ;;
+"Non-strict Verify External Certificate")
+  test_file="$NON_STRICT_VERIFY_EXTERNAL_CERTIFICATE_TESTFILE"
+  ;;
 
-    "Infinispan Caching Storage Method")
-    test_file="$INFINISPAN_CACHING_STORAGE_METHOD_TESTFILE"
-    ;;
+"Install PTF Twice")
+  test_file="$INSTALL_PTF_TWICE_TESTFILE"
+  ;;
 
-    "Generate API Documentation")
-    test_file="$GENERAL_API_DOCUMENTATION_TESTFILE"
-    ;;
+"VSAM Caching Storage Method")
+  test_file="$VSAM_CACHING_STORAGE_METHOD_TESTFILE"
+  ;;
 
-    "Config Manager")
-    test_file="$CONFIG_MANAGER_TESTFILE"
-    ;;
-    
-    "Zowe Nightly Tests")
-    test_file="$ZOWE_NIGHTLY_TESTS_FULL"
-    dont_parse_test_server=true
-    ;;
+"Infinispan Caching Storage Method")
+  test_file="$INFINISPAN_CACHING_STORAGE_METHOD_TESTFILE"
+  ;;
 
-    "Zowe Release Tests")
-    test_file="$ZOWE_RELEASE_TESTS_FULL"
-    dont_parse_test_server=true
-    ;;
-    
-    *)
-    echo "Something went wrong when parsing install test choice input"
-    exit 1
-    ;;
+"Generate API Documentation")
+  test_file="$GENERAL_API_DOCUMENTATION_TESTFILE"
+  ;;
+
+"Config Manager")
+  test_file="$CONFIG_MANAGER_TESTFILE"
+  ;;
+
+"Zowe Nightly Tests")
+  test_file="$ZOWE_NIGHTLY_TESTS_FULL"
+  dont_parse_test_server=true
+  ;;
+
+"Zowe Release Tests")
+  test_file="$ZOWE_RELEASE_TESTS_FULL"
+  dont_parse_test_server=true
+  ;;
+
+*)
+  echo "Something went wrong when parsing install test choice input"
+  exit 1
+  ;;
 esac
 
-if [[ -z "$dont_parse_test_server" ]]; then
+# this variable may be set for individual tests above. If using nightly/release, see cicd-test.yml workflow
+if [[ ! -z "$test_force_system" ]]; then
+  TEST_FILE_SERVER="$test_file($test_force_system)"
+else
+  if [[ -z "$dont_parse_test_server" ]]; then
     if [[ "$test_server" == "Any zzow servers" ]]; then
-        test_server="zzow0"$(echo $(($RANDOM % 3 + 2)) )
+      test_server="zzow0"$(echo $(($RANDOM % 3 + 2)))
     fi
     TEST_FILE_SERVER="$test_file($test_server)"
-else
+  else
     any_occurrence=$(echo $test_file | grep -o "(any)" | wc -l)
     interim_test_file_server=$test_file
     for i in $(seq $any_occurrence); do
-        interim_test_file_server=$(echo $interim_test_file_server | sed "s#(any)#(zzow0$(echo $(($RANDOM % 3 + 2)) ))#")
+      interim_test_file_server=$(echo $interim_test_file_server | sed "s#(any)#(zzow0$(echo $(($RANDOM % 3 + 2))))#")
     done
 
     TEST_FILE_SERVER=$(echo $interim_test_file_server | sed "s#(all)#(zzow02,zzow03,zzow04)#g")
+  fi
 fi
 
 # this is the final string that can be recognizable by the matrix processing script down below
@@ -106,13 +112,11 @@ echo "TEST_FILE_SERVER is "$TEST_FILE_SERVER
 TEST_FILE_SERVER=$TEST_FILE_SERVER | tr -d "[:space:]"
 
 MATRIX_JSON_STRING="{\"include\":["
-for each_test_file_server in $(echo "$TEST_FILE_SERVER" | sed "s/;/ /g")
-do
-    test_file=$(echo "$each_test_file_server" | cut -d "(" -f1)
-    for test_server in $(echo "$each_test_file_server" | cut -d "(" -f2 | cut -d ")" -f1 | sed "s/,/ /g")
-    do
-        MATRIX_JSON_STRING="$MATRIX_JSON_STRING{\"test\":\"$test_file\",\"server\":\"marist-$test_server\"},"
-    done
+for each_test_file_server in $(echo "$TEST_FILE_SERVER" | sed "s/;/ /g"); do
+  test_file=$(echo "$each_test_file_server" | cut -d "(" -f1)
+  for test_server in $(echo "$each_test_file_server" | cut -d "(" -f2 | cut -d ")" -f1 | sed "s/,/ /g"); do
+    MATRIX_JSON_STRING="$MATRIX_JSON_STRING{\"test\":\"$test_file\",\"server\":\"marist-$test_server\"},"
+  done
 done
 
 # remove trailing comma

--- a/.github/workflows/cicd-test.yml
+++ b/.github/workflows/cicd-test.yml
@@ -85,7 +85,7 @@ env:
   CONFIG_MANAGER_TESTFILE: extended/config-manager/enable-config-manager.ts
   GENERAL_API_DOCUMENTATION_TESTFILE: basic/install-api-gen.ts
   ZOWE_NIGHTLY_TESTS_FULL: basic/install.ts(all);basic/install-ptf.ts(all)
-  ZOWE_RELEASE_TESTS_FULL: basic/install.ts(all);basic/install-ptf.ts(all);basic/install-ext.ts(any);extended/keyring.ts(all);extended/node-versions/node-v14.ts(any);extended/node-versions/node-v16.ts(any);extended/node-versions/node-v18.ts(any):extended/certificates/nonstrict-verify-external-certificate.ts(any);extended/caching-storages/infinispan-storage.ts(any);extended/config-manager/enable-config-manager.ts(any)
+  ZOWE_RELEASE_TESTS_FULL: basic/install.ts(all);basic/install-ptf.ts(all);basic/install-ext.ts(any);extended/keyring.ts(all);extended/node-versions/node-v14.ts(any);extended/node-versions/node-v16.ts(any);extended/node-versions/node-v18.ts(zzow04):extended/certificates/nonstrict-verify-external-certificate.ts(any);extended/caching-storages/infinispan-storage.ts(any);extended/config-manager/enable-config-manager.ts(any)
 
 jobs:
   display-dispatch-event-id:

--- a/tests/installation/src/__tests__/extended/node-versions/node-v18.ts
+++ b/tests/installation/src/__tests__/extended/node-versions/node-v18.ts
@@ -15,7 +15,8 @@ import {
 } from '../../../utils';
 import { TEST_TIMEOUT_CONVENIENCE_BUILD } from '../../../constants';
 
-const testServer = 'marist-4';
+// Only runs on zzow04 at time of change (04.2023). See cicd-test.yml and make_matrix.sh.
+const testServer = process.env.TEST_SERVER;
 const testSuiteName = 'Test convenience build installation with node.js v18';
 describe(testSuiteName, () => {
   beforeAll(() => {


### PR DESCRIPTION
Updates make_matrix, cicd-test.yml, and node-18.ts to force the Node 18 tests to only run against zzow04. Other systems not supported at this time.

Shell script changes noisy due to whitespace, see: 

make_matrix.sh lines 45 and 88-91
