### PR TITLE
Default to using configmgr

### DIFF
--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -226,6 +226,7 @@ echo "[$SCRIPT_NAME] create dummy zowe.yaml for install"
 cat <<EOT >> "${BASE_DIR}/zowe.yaml"
 zowe:
   extensionDirectory: "${ZOWE_ROOT_DIR}/components"
+  useConfigmgr: false
 EOT
 
 echo "[$SCRIPT_NAME] extract components"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
 
+## `2.9.0`
+
+### New features and enhancements
+- Users who have not set the value of "zowe.useConfimgr" will have the behavior now set to "true" rather than the previous "false". If you wish to use false still, just set "zowe.useConfigmgr=false" explicitly.
+
 ## `2.8.0`
 
 ### New features and enhancements

--- a/bin/libs/common.sh
+++ b/bin/libs/common.sh
@@ -36,7 +36,11 @@ check_configmgr_enabled() {
       echo "true"
     else
       USE_CONFIGMGR=$(shell_read_yaml_config "${ZWE_CLI_PARAMETER_CONFIG}" 'zowe' 'useConfigmgr')
-      echo $USE_CONFIGMGR  
+      if [ "${USE_CONFIGMGR}" = "false" ]; then
+        echo "false"
+      else
+        echo "true"
+      fi
     fi
   fi
 }


### PR DESCRIPTION
This PR changes the behavior of zwe to prefer using configmgr unless zowe.useConfigmgr is explicitly set to false.

Previously, new installs had zowe.useConfigmgr=true but old installs may have been missing the property entirely.
With this change, if the property is missing, instead of using "false", the code will now use "true".

This causes everyone to be using configmgr by default, wherever the code uses it. For example, startup, but not yet `init`.

TODO: guarantee this doesnt affect containers, as configmgr doesnt exist there yet.