### PR TITLE
Warn on java over max supported version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
 
+## `2.9.0`
+
+#### Minor enhancements/defect fixes
+- Enhancement: Warn when detecting a java version newer than what's officially known to work.
+
 ## `2.8.0`
 
 ### New features and enhancements

--- a/bin/libs/java.sh
+++ b/bin/libs/java.sh
@@ -91,6 +91,9 @@ require_java() {
 
 
 validate_java_home() {
+  java_min_version=8
+  java_max_warn=8
+
   java_home="${1:-${JAVA_HOME}}"
 
   if [ -z "${java_home}" ]; then
@@ -121,14 +124,17 @@ validate_java_home() {
   too_low=
   if [ ${java_major_version} -lt 1 ]; then
     too_low="true"
-  elif [ ${java_major_version} -eq 1 -a ${java_minor_version} -lt 8 ]; then
+  elif [ ${java_major_version} -eq 1 -a ${java_minor_version} -lt ${java_min_version} ]; then
     too_low="true"
   fi
   if [ "${too_low}" = "true" ]; then
     print_error "Java ${java_version_short} is less than the minimum level required of Java 8 (1.8.0)."
     return 1
   fi
-  print_debug "Java ${java_version_short} is supported."
-
+  if [ ${java_minor_version} -gt ${java_max_warn} ]; then
+    print_error "Warning: Java version ${java_version_short} is greater than the maximum known working version of Java ${java_max_warn}."
+  else
+    print_debug "Java ${java_version_short} is supported."
+  fi
   print_debug "Java check is successful."
 }

--- a/bin/libs/java.ts
+++ b/bin/libs/java.ts
@@ -17,6 +17,8 @@ import * as shell from './shell';
 import * as config from './config';
 
 const JAVA_MIN_VERSION=8;
+const JAVA_MAX_WARN=8; //warn if newer than this
+//const JAVA_MAX_ERROR=8; //error on this.
 
 export function ensureJavaIsOnPath(): void {
   let path=std.getenv('PATH') || '/bin:.:/usr/bin';
@@ -129,6 +131,8 @@ export function validateJavaHome(javaHome:string|undefined=std.getenv("JAVA_HOME
     if (tooLow) {
       common.printError(`Java ${javaVersionShort} is less than the minimum level required of Java ${JAVA_MIN_VERSION}.`);
       return false;
+    } else if (javaMajorVersion > JAVA_MAX_WARN) {
+      common.printError(`Java version ${javaVersionShort} is greater than the maximum known working version of Java ${JAVA_MAX_WARN}.`); 
     }
 
     common.printDebug(`Java ${javaVersionShort} is supported.`);

--- a/bin/libs/java.ts
+++ b/bin/libs/java.ts
@@ -132,10 +132,10 @@ export function validateJavaHome(javaHome:string|undefined=std.getenv("JAVA_HOME
       common.printError(`Java ${javaVersionShort} is less than the minimum level required of Java ${JAVA_MIN_VERSION}.`);
       return false;
     } else if (javaMajorVersion > JAVA_MAX_WARN) {
-      common.printError(`Java version ${javaVersionShort} is greater than the maximum known working version of Java ${JAVA_MAX_WARN}.`); 
+      common.printError(`Warning: Java version ${javaVersionShort} is greater than the maximum known working version of Java ${JAVA_MAX_WARN}.`); 
+    } else {
+      common.printDebug(`Java ${javaVersionShort} is supported.`);
     }
-
-    common.printDebug(`Java ${javaVersionShort} is supported.`);
     common.printDebug(`Java check is successful.`);
     return true;
   } catch (e) {


### PR DESCRIPTION
This PR adds a simple test on java version.
Currently we error out if a java under our supported version is used.
But, if someone uses a java version newer than we know works, the code does run and then could have some error later, without people having any clue java could be the reason for the error.
So, this code just adds a warning if we detect java is newer than what we know works. The execution still continues, but now people will be warned.