### PR TITLE
Load each components' default YAML files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
 
+## `2.10.0`
+
+### New features and enhancements
+- Added ability for any component to deliver a YAML file conforming to Zowe's schema which will apply default values for that component. At startup, zwe will write a templated, merged yaml to each components' environment workspace directory, and the environment variables set for each component can now include values from a default YAML file if it exists.
+
 ## `2.9.0`
 
 ### New features and enhancements

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -114,7 +114,6 @@ function prepareWorkspaceDirectory(enabledComponents: string[]) {
   // TODO delete this or get this from configmgr instead.
   
   config.generateInstanceEnvFromYamlConfig(zweCliParameterHaInstance);
-  enabledComponents.forEach((component) =>  config.generateInstanceEnvFromYamlConfig(zweCliParameterHaInstance, component));
 }
 
 // Global validations
@@ -196,6 +195,7 @@ function validateComponents(enabledComponents:string[]): {[componentId: string]:
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare,validate_components", "process component validations ...");
 
   const componentConfigs = {};
+  const zweCliParameterHaInstance = std.getenv('ZWE_CLI_PARAMETER_HA_INSTANCE');
   
   // reset error counter
   let privateErrors = 0;
@@ -210,19 +210,8 @@ function validateComponents(enabledComponents:string[]): {[componentId: string]:
     if (componentDir) {
       const manifest = component.getManifest(componentDir);
 
-
-      //TODO HERE:
-      /*
-        i need to put the component's defaults.yaml at the start of the currentl list.
-        then i need to write the merged result to a file.
-        this is the file that particular component should get.
-        the environment variables it gets should be based upon this too.
-
-
-      */
-      
-      const {path: mergedComponentPath, name: configName} = component.validateConfigForComponent(componentId, manifest, componentDir, std.getenv('ZWE_CLI_PARAMETER_CONFIG'));
-      
+      const {path: mergedComponentPath, name: configName, contents: configContents } = component.validateConfigForComponent(componentId, manifest, componentDir, std.getenv('ZWE_CLI_PARAMETER_CONFIG'));
+      config.generateInstanceEnvFromYamlConfig(zweCliParameterHaInstance, componentId, configContents);
 
       // check validate script
       const validateScript = manifest.commands ? manifest.commands.validate : undefined;

--- a/bin/libs/config.ts
+++ b/bin/libs/config.ts
@@ -86,12 +86,19 @@ export function zosConvertEnvDirFileEncoding(file: string) {
 
 // Prepare configuration for current HA instance, and generate backward
 // compatible instance.env files from zowe.yaml.
+// if componentId given, assumes merged-yaml is present in that .env folder for setting env vars specific to this component.
 //
-export function generateInstanceEnvFromYamlConfig(haInstance: string) {
+export function generateInstanceEnvFromYamlConfig(haInstance: string, componentId?: string) {
   let zwePrivateWorkspaceEnvDir = std.getenv('ZWE_PRIVATE_WORKSPACE_ENV_DIR');
   if (!zwePrivateWorkspaceEnvDir) {
     zwePrivateWorkspaceEnvDir=`${workspaceDirectory}/.env`
-    std.setenv('zwePrivateWorkspaceEnvDir', zwePrivateWorkspaceEnvDir);
+    std.setenv('ZWE_PRIVATE_WORKSPACE_ENV_DIR', zwePrivateWorkspaceEnvDir);
+  }
+  let configPath = cliParameterConfig;
+  if (componentId) {
+    std.setenv('ZWE_PRIVATE_WORKSPACE_ENV_DIR_TMP', zwePrivateWorkspaceEnvDir);
+    zwePrivateWorkspaceEnvDir+=`/${componentId}`;
+    configPath = `${zwePrivateWorkspaceEnvDir}/.zowe-merged.yaml`;
   }
 
   // delete old files to avoid potential issues
@@ -111,12 +118,12 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
   //TODO use configmgr to write json and ha json, and components json
   
   // prepare .zowe.json and .zowe-<ha-id>.json
-  common.printFormattedTrace("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `config-converter yaml convert --ha ${haInstance} ${cliParameterConfig}`);
-  let result = shell.execOutSync('node', `${runtimeDirectory}/bin/utils/config-converter/src/cli.js`, `yaml`, `convert`, `--wd`, zwePrivateWorkspaceEnvDir, `--ha`, haInstance, cliParameterConfig, `--verbose`);
+  common.printFormattedTrace("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `config-converter yaml convert --ha ${haInstance} ${configPath}`);
+  let result = shell.execOutSync('node', `${runtimeDirectory}/bin/utils/config-converter/src/cli.js`, `yaml`, `convert`, `--wd`, zwePrivateWorkspaceEnvDir, `--ha`, haInstance, configPath, `--verbose`);
 
   common.printFormattedTrace("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `- Exit code: ${result.rc}: ${result.out}`);
   if ( !fs.fileExists(`${zwePrivateWorkspaceEnvDir}/.zowe.json`)) {
-    common.printFormattedError( "ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `ZWEL0140E: Failed to translate Zowe configuration (${cliParameterConfig}).`);
+    common.printFormattedError( "ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `ZWEL0140E: Failed to translate Zowe configuration (${configPath}).`);
     std.exit(140);
   }
 
@@ -194,7 +201,7 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
     const componentFileContent = componentFileArray.join('\n');
     rc = xplatform.storeFileUTF8(`${folderName}/.instance-${haInstance}.env`, xplatform.AUTO_DETECT, componentFileContent);
     if (rc) { 
-      common.printFormattedError("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `ZWEL0140E: Failed to translate Zowe configuration (${cliParameterConfig}).`);
+      common.printFormattedError("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `ZWEL0140E: Failed to translate Zowe configuration (${configPath}).`);
       std.exit(140);
       return;
     }
@@ -203,9 +210,14 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
   let envFileContent = envFileArray.join('\n');
   let rc = xplatform.storeFileUTF8(`${zwePrivateWorkspaceEnvDir}/.instance-${haInstance}.env`, xplatform.AUTO_DETECT, envFileContent);
   if (rc) {
-    common.printFormattedError("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `ZWEL0140E: Failed to translate Zowe configuration (${cliParameterConfig}).`);
+    common.printFormattedError("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `ZWEL0140E: Failed to translate Zowe configuration (${configPath}).`);
     std.exit(140);
     return;
+  }
+
+  //restore used env var
+  if (componentId) {
+    std.setenv('ZWE_PRIVATE_WORKSPACE_ENV_DIR', std.getenv('ZWE_PRIVATE_WORKSPACE_ENV_DIR_TMP'));
   }
 }
 

--- a/bin/libs/config.ts
+++ b/bin/libs/config.ts
@@ -40,11 +40,11 @@ const runtimeDirectory=configmgr.ZOWE_CONFIG.zowe.runtimeDirectory;
 //const extensionDirectory=ZOWE_CONFIG.zowe.extensionDirectory;
 const workspaceDirectory=configmgr.ZOWE_CONFIG.zowe.workspaceDirectory;
 
-export function getZoweConfig(): any {
+export function getZoweConfig(): configmgr.ZoweConfig {
   return configmgr.ZOWE_CONFIG;
 }
 
-export function updateZoweConfig(updateObj: any, writeUpdate: boolean, arrayMergeStrategy: number): any {
+export function updateZoweConfig(updateObj: configmgr.ZoweConfig, writeUpdate: boolean, arrayMergeStrategy: number): any {
   return configmgr.updateZoweConfig(updateObj, writeUpdate, arrayMergeStrategy);
 }
 
@@ -88,7 +88,7 @@ export function zosConvertEnvDirFileEncoding(file: string) {
 // compatible instance.env files from zowe.yaml.
 // if componentId given, assumes merged-yaml is present in that .env folder for setting env vars specific to this component.
 //
-export function generateInstanceEnvFromYamlConfig(haInstance: string, componentId?: string) {
+export function generateInstanceEnvFromYamlConfig(haInstance: string, componentId?: string, config?:configmgr.ZoweConfig) {
   let zwePrivateWorkspaceEnvDir = std.getenv('ZWE_PRIVATE_WORKSPACE_ENV_DIR');
   if (!zwePrivateWorkspaceEnvDir) {
     zwePrivateWorkspaceEnvDir=`${workspaceDirectory}/.env`
@@ -134,7 +134,7 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string, componentI
 
   // convert YAML configurations to backward compatible .instance-<ha-id>.env files
   common.printFormattedTrace("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `config-converter yaml env --ha ${haInstance}`);
-  const envs = configmgr.getZoweConfigEnv(haInstance);
+  const envs = configmgr.getZoweConfigEnv(haInstance, config);
   common.printFormattedTrace("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `- Output: ${JSON.stringify(envs, null, 2)}`);
   const envKeys = Object.keys(envs);
   let envFileArray=[];

--- a/schemas/manifest-schema.json
+++ b/schemas/manifest-schema.json
@@ -223,7 +223,25 @@
     "configs": {
       "type": "object",
       "additionalProperties": true,
-      "description": "Component can define it's own configuration in this section in desired hierarchy. This is the brief guidance for component user to learn what are the configurations and what are the default values. Any configurations defined here can be placed into 'zowe.yaml' 'components.<component-name>' section for customization. You can choose to put configurations into 'components.myextension' or 'haInstance.<ha-instance>.components.myextension' of 'zowe.yaml'. Component can use auto-generate environment variables in lifecycle scripts to learn how the component is configured for current HA instance."
+      "description": "Component can define it's own configuration in this section in desired hierarchy. This is the brief guidance for component user to learn what are the configurations and what are the default values. Any configurations defined here can be placed into 'zowe.yaml' 'components.<component-name>' section for customization. You can choose to put configurations into 'components.myextension' or 'haInstance.<ha-instance>.components.myextension' of 'zowe.yaml'. Component can use auto-generate environment variables in lifecycle scripts to learn how the component is configured for current HA instance.",
+      "properties": {
+        "defaults": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Defines the location of a YAML config file in the schema of the Zowe configuration, which will be joined together with other configuration files at runtime, overriding Zowe's defaults but in turn being overridden by the user's customizations."
+            },
+            {
+              "type": "array",
+              "description": "Defines multiple YAML config files to be treated as the default configuration for this component.",
+              "items": {
+                "type": "string",
+                "description": "Defines the location of a YAML config file in the schema of the Zowe configuration, which will be joined together with other configuration files at runtime, overriding Zowe's defaults but in turn being overridden by the user's customizations."
+              }
+            }
+          ]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
- [x] Feature <!-- non-breaking change which adds functionality -->

#### Relevant issues

Assists with https://github.com/zowe/community/issues/1857

#### Changes proposed in this PR
This PR allows for components to ship default YAML files which zwe will incorporate into the overall yaml config for when that particular component loads. Components need no code changes to take advantage of this. They will still receive env vars to use. However, they will now have env vars that consider values from their own defaults.yaml file, and will also have a merged yaml file available to them in `workspace`/.env/`componentname`

The purpose of this is to:
* reduce configuration values the user needs to see by default
* Allow servers to take configuration out of code and put it into yaml templates
* Allow users to see those defaults from those yamls, and then be better equipped to build their own yaml customizations.

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [x] No

<!-- If yes, please describe the impact and migration path below.-->
