### PR TITLE
Parameters handling

### DIFF
--- a/bin/commands/init/mvs/index.ts
+++ b/bin/commands/init/mvs/index.ts
@@ -60,7 +60,9 @@ export function execute(allowOverwrite?: boolean) {
         common.printErrorAndExit(`Error ZWEL0157E: ${datasetDef.configKey} (zowe.setup.dataset.${datasetDef.configKey}) is not defined in Zowe YAML configuration file.`, undefined, 157);
       }
     }
-
+    if (allowOverwrite === undefined){
+      allowOverwrite = std.getenv("ZWE_CLI_PARAMETER_ALLOW_OVERWRITE")
+    }
     if (!skip) {
       const datasetExists=zosdataset.isDatasetExists(ds);
       if (datasetExists) {

--- a/bin/commands/init/security/index.ts
+++ b/bin/commands/init/security/index.ts
@@ -109,6 +109,8 @@ export function execute(dryRun?: boolean, ignoreSecurityFailures?: boolean) {
 
   // submit job
   let jobHasFailures;
+  dryRun = std.getenv("ZWE_CLI_PARAMETER_SECURITY_DRY_RUN");
+  ignoreSecurityFailures = std.getenv("ZWE_CLI_PARAMETER_IGNORE_SECURITY_FAILURES");
   if (dryRun == true) {
     common.printMessage(`Dry-run mode, security setup is NOT performed on the system.`);
     common.printMessage(`Please submit ${jcllib}(${tmpdsm}) manually.`);

--- a/bin/commands/init/stc/index.ts
+++ b/bin/commands/init/stc/index.ts
@@ -91,6 +91,7 @@ export function execute(allowOverwrite: boolean = false) {
       common.printErrorAndExit(`Error ZWEL0143E:  Cannot find data set member ${prefix}.${SAMP_LIB}(${mb}). You may need to re-run 'zwe install'.`, undefined, 143);
     }
   });
+  allowOverwrite = std.getenv("ZWE_CLI_PARAMETER_ALLOW_OVERWRITE");
   target_proclibs.forEach((mb: string) => {
     // JCL for preview purpose
     jclExistence=zosdataset.isDatasetExists(`${jcllib}(${mb})`);


### PR DESCRIPTION
I went thru subcommands and there was a problem with handling of sub-parameters.

E.g.:
`zwe init mvs -c zowe.yaml` and `zwe init mvs -c zowe.yaml --allow-overwrite` same behavior (message that you need to use `--allow-overwrite`)
But when used/omitted `--allow-overwrite' in `zwe init mvs -c zowe.yaml`, it was working as expected.

I was not sure why some `execute` function are defined with parameter(s) and some without parameters, so if possible, it would be nice to unify it when merging.

## mvs
* --allow-overwrite _(parameter)_
* init/index.ts: initMvs.execute() _(how it is called from init)_
* init/mvs/index.ts: execute(allowOverwrite) _(how it is defined in the subcommand)_ 
  * `allowOverwrite` expected as input parameter, which is not provided _(what I see as a problem)_

## security
* --security-dry-run
* --ignore-security-failures
* init/index.ts: initSecurity.execute()
* init/security/index.ts: execute(dryRun?: boolean, ignoreSecurityFailures?: boolean)
  * `dryRun` and `ignoreSecurityFailures` expected as input parameter, which is not provided

## stc
* --allow-overwrite
* init/index.ts: initStc.execute()
* init/stc/index.ts: execute(allowOverwrite: boolean = false)
  * `allowOverwrite` expected as input parameter, which is not provided and defaulted to `false`
