### PR TITLE
Bigfix that log directory not created before component validation

### DIFF
--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -71,7 +71,7 @@ function prepareRunningInContainer() {
 
 // Prepare log directory
 function prepareLogDirectory() {
-  const logDir = std.getenv('ZWE_zowe_logDirectory');
+  const logDir = ZOWE_CONFIG.zowe.logDirectory;
   if (logDir) {
     os.mkdir(logDir, 0o750);
     if (!fs.isDirectoryWritable(logDir)) {


### PR DESCRIPTION
zwe internal start prepare had logic to create the log directory before any components were handled.
Unfortunately, it was trying to find the log directory to create by using an environment variable that was not yet set. Instead, we should read from the yaml config that was already loaded. This change does the same behavior that was intended, but should actually work instead of returning `undefined`.