### PR TITLE
build: install-verify PTF updates; include APIML vars in install-fmid

### DIFF
--- a/tests/installation/src/__tests__/basic/install-ptf.ts
+++ b/tests/installation/src/__tests__/basic/install-ptf.ts
@@ -26,17 +26,21 @@ describe(testSuiteName, () => {
   });
 
   test('install and verify', async () => {
+    const apimlOidcVars =  {
+      'zowe_apiml_security_oidc_client_id': process.env['OKTA_CLIENT_ID'],
+      'zowe_apiml_security_oidc_client_secret': process.env['OKTA_CLIENT_SECRET'],
+      'zowe_apiml_security_oidc_registry': process.env['OIDC_REGISTRY'],
+      'zowe_apiml_security_oidc_introspect_url': `https://${process.env['OKTA_HOSTNAME']}/oauth2/default/v1/introspect`,
+    };
     await installAndVerifySmpePtf(
       testSuiteName,
       process.env.TEST_SERVER,
+      apimlOidcVars,
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
-        'zowe_apiml_security_oidc_client_id': process.env['OKTA_CLIENT_ID'],
-        'zowe_apiml_security_oidc_client_secret': process.env['OKTA_CLIENT_SECRET'],
-        'zowe_apiml_security_oidc_registry': process.env['OIDC_REGISTRY'],
-        'zowe_apiml_security_oidc_introspect_url': `https://${process.env['OKTA_HOSTNAME']}/oauth2/default/v1/introspect`,
         'zowe_custom_for_test': 'true',
         'zowe_lock_keystore': 'false',
+        ...apimlOidcVars
       }
     );
   }, TEST_TIMEOUT_SMPE_PTF);

--- a/tests/installation/src/__tests__/extended/security-systems/ptf/acf2.ts
+++ b/tests/installation/src/__tests__/extended/security-systems/ptf/acf2.ts
@@ -35,6 +35,7 @@ describe(testSuiteName, () => {
     await installAndVerifySmpePtf(
       testSuiteName,
       testServer,
+      {},
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
         'zowe_custom_for_test': 'true',

--- a/tests/installation/src/__tests__/extended/security-systems/ptf/racf.ts
+++ b/tests/installation/src/__tests__/extended/security-systems/ptf/racf.ts
@@ -34,6 +34,7 @@ describe(testSuiteName, () => {
     await installAndVerifySmpePtf(
       testSuiteName,
       testServer,
+      {},
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
         'zowe_custom_for_test': 'true',

--- a/tests/installation/src/__tests__/extended/security-systems/ptf/ts.ts
+++ b/tests/installation/src/__tests__/extended/security-systems/ptf/ts.ts
@@ -35,6 +35,7 @@ describe(testSuiteName, () => {
     await installAndVerifySmpePtf(
       testSuiteName,
       testServer,
+      {},
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
         'zowe_custom_for_test': 'true',

--- a/tests/installation/src/utils.ts
+++ b/tests/installation/src/utils.ts
@@ -396,16 +396,20 @@ export async function installAndVerifyExtension(testcase: string, serverId: stri
 }
 
 /**
- * Install and verify SMPE PTF
+ * Install and verify SMPE PTF. Separate variables for FMID and PTF install operations.
  *
  * @param  {String}    testcase 
  * @param  {String}    serverId
- * @param  {Object}    extraVars
+ * @param  {Object}    extraFmidVars
+ * @param  {Object}    extraPtfVars
  */
-export async function installAndVerifySmpePtf(testcase: string, serverId: string, extraVars: {[key: string]: any} = {}): Promise<void> {
-  debug(`installAndVerifySmpePtf(${testcase}, ${serverId}, ${JSON.stringify(extraVars)})`);
+export async function installAndVerifySmpePtf(testcase: string, serverId: string, 
+                                              extraFmidVars: {[key: string]: any} = {}, 
+                                              extraPtfVars: {[key: string]: any} = {}): Promise<void> {
+  debug(`installAndVerifySmpePtf(${testcase}, ${serverId}, FMID: ${JSON.stringify(extraFmidVars)}, PTF: ${JSON.stringify(extraPtfVars)})`);
 
   debug(`run install-fmid.yml on ${serverId}`);
+ 
   const resultFmid = await runAnsiblePlaybook(
     testcase,
     'install-fmid.yml',
@@ -413,6 +417,7 @@ export async function installAndVerifySmpePtf(testcase: string, serverId: string
     {
       'zowe_build_remote': ZOWE_FMID,
       'skip_start': 'true',
+       ...extraFmidVars
     }
   );
 
@@ -423,7 +428,7 @@ export async function installAndVerifySmpePtf(testcase: string, serverId: string
     testcase,
     'install-ptf.yml',
     serverId,
-    extraVars
+    extraPtfVars
   );
 
   expect(resultPtf.code).toBe(0);
@@ -435,7 +440,7 @@ export async function installAndVerifySmpePtf(testcase: string, serverId: string
   // clean up sanity test folder
   cleanupSanityTestReportDir();
 
-  if (extraVars && extraVars['skip_start'] && extraVars['skip_start'] === 'true') {
+  if (extraPtfVars && extraPtfVars['skip_start'] && extraPtfVars['skip_start'] === 'true') {
     debug('running install-ptf.yml playbook with skip_start=true, skip verify');
 
   } else {

--- a/tests/installation/src/utils.ts
+++ b/tests/installation/src/utils.ts
@@ -404,8 +404,8 @@ export async function installAndVerifyExtension(testcase: string, serverId: stri
  * @param  {Object}    extraPtfVars
  */
 export async function installAndVerifySmpePtf(testcase: string, serverId: string, 
-                                              extraFmidVars: {[key: string]: any} = {}, 
-                                              extraPtfVars: {[key: string]: any} = {}): Promise<void> {
+  extraFmidVars: {[key: string]: any} = {}, 
+  extraPtfVars: {[key: string]: any} = {}): Promise<void> {
   debug(`installAndVerifySmpePtf(${testcase}, ${serverId}, FMID: ${JSON.stringify(extraFmidVars)}, PTF: ${JSON.stringify(extraPtfVars)})`);
 
   debug(`run install-fmid.yml on ${serverId}`);
@@ -417,7 +417,7 @@ export async function installAndVerifySmpePtf(testcase: string, serverId: string
     {
       'zowe_build_remote': ZOWE_FMID,
       'skip_start': 'true',
-       ...extraFmidVars
+      ...extraFmidVars
     }
   );
 


### PR DESCRIPTION
Updates the install-ptf automations to use 2 sets of `extraVars` - one for FMID playbook, the other for PTF playbook. 

Historically, we only supported one set of extraVars which was passed to the PTF playbook and ignored in the fmid playbook, but in other installs the vars are passed to the FMID playbook. In some cases new variable definitions may break when certain vars are not passed to FMID, and re-using vars intended for the PTF playbook is not viable either.