### PR TITLE
build: make APIML_OIDC vars default for all builds

### DIFF
--- a/tests/installation/src/__tests__/basic/install-fmid.ts
+++ b/tests/installation/src/__tests__/basic/install-fmid.ts
@@ -31,10 +31,6 @@ describe(testSuiteName, () => {
       process.env.TEST_SERVER,
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
-        'zowe_apiml_security_oidc_client_id': process.env['OKTA_CLIENT_ID'],
-        'zowe_apiml_security_oidc_client_secret': process.env['OKTA_CLIENT_SECRET'],
-        'zowe_apiml_security_oidc_registry': process.env['OIDC_REGISTRY'],
-        'zowe_apiml_security_oidc_introspect_url': `https://${process.env['OKTA_HOSTNAME']}/oauth2/default/v1/introspect`,
         'zowe_custom_for_test': 'true',
         'zowe_lock_keystore': 'false',
       }

--- a/tests/installation/src/__tests__/basic/install-ptf.ts
+++ b/tests/installation/src/__tests__/basic/install-ptf.ts
@@ -26,21 +26,13 @@ describe(testSuiteName, () => {
   });
 
   test('install and verify', async () => {
-    const apimlOidcVars =  {
-      'zowe_apiml_security_oidc_client_id': process.env['OKTA_CLIENT_ID'],
-      'zowe_apiml_security_oidc_client_secret': process.env['OKTA_CLIENT_SECRET'],
-      'zowe_apiml_security_oidc_registry': process.env['OIDC_REGISTRY'],
-      'zowe_apiml_security_oidc_introspect_url': `https://${process.env['OKTA_HOSTNAME']}/oauth2/default/v1/introspect`,
-    };
     await installAndVerifySmpePtf(
       testSuiteName,
       process.env.TEST_SERVER,
-      apimlOidcVars,
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
         'zowe_custom_for_test': 'true',
         'zowe_lock_keystore': 'false',
-        ...apimlOidcVars
       }
     );
   }, TEST_TIMEOUT_SMPE_PTF);

--- a/tests/installation/src/__tests__/basic/install.ts
+++ b/tests/installation/src/__tests__/basic/install.ts
@@ -31,10 +31,6 @@ describe(testSuiteName, () => {
       process.env.TEST_SERVER,
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
-        'zowe_apiml_security_oidc_client_id': process.env['OKTA_CLIENT_ID'],
-        'zowe_apiml_security_oidc_client_secret': process.env['OKTA_CLIENT_SECRET'],
-        'zowe_apiml_security_oidc_registry': process.env['OIDC_REGISTRY'],
-        'zowe_apiml_security_oidc_introspect_url': `https://${process.env['OKTA_HOSTNAME']}/oauth2/default/v1/introspect`,
         'zowe_custom_for_test': 'true',
         'zowe_lock_keystore': 'false',
       }

--- a/tests/installation/src/__tests__/extended/security-systems/ptf/acf2.ts
+++ b/tests/installation/src/__tests__/extended/security-systems/ptf/acf2.ts
@@ -35,7 +35,6 @@ describe(testSuiteName, () => {
     await installAndVerifySmpePtf(
       testSuiteName,
       testServer,
-      {},
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
         'zowe_custom_for_test': 'true',

--- a/tests/installation/src/__tests__/extended/security-systems/ptf/racf.ts
+++ b/tests/installation/src/__tests__/extended/security-systems/ptf/racf.ts
@@ -34,7 +34,6 @@ describe(testSuiteName, () => {
     await installAndVerifySmpePtf(
       testSuiteName,
       testServer,
-      {},
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
         'zowe_custom_for_test': 'true',

--- a/tests/installation/src/__tests__/extended/security-systems/ptf/ts.ts
+++ b/tests/installation/src/__tests__/extended/security-systems/ptf/ts.ts
@@ -35,7 +35,6 @@ describe(testSuiteName, () => {
     await installAndVerifySmpePtf(
       testSuiteName,
       testServer,
-      {},
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
         'zowe_custom_for_test': 'true',

--- a/tests/installation/src/constants.ts
+++ b/tests/installation/src/constants.ts
@@ -39,4 +39,11 @@ export const TEST_TIMEOUT_SMPE_PTF: number = 120 * 60 * 1000;
 export const KEYSTORE_MODE_KEYSTORE = 'KEYSTORE_MODE_KEYSTORE';
 export const KEYSTORE_MODE_KEYRING = 'KEYSTORE_MODE_KEYRING';
 
+export const APIML_OIDC_VARS =  {
+  'zowe_apiml_security_oidc_client_id': process.env['OKTA_CLIENT_ID'] || 'dummy_id_from_constants_ts',
+  'zowe_apiml_security_oidc_client_secret': process.env['OKTA_CLIENT_SECRET'] || 'dummy_secret_from_constants_ts',
+  'zowe_apiml_security_oidc_registry': process.env['OIDC_REGISTRY'] || 'dummy_registry_from_constants_ts',
+  'zowe_apiml_security_oidc_introspect_url': `https://${process.env['OKTA_HOSTNAME']}/oauth2/default/v1/introspect`,
+};
+
 // debug(`process.env >>>>>>>>>>>>>>>>>>>>>>>>>>\n${JSON.stringify(process.env)}\n<<<<<<<<<<<<<<<<<<<<<<<`);

--- a/tests/installation/src/utils.ts
+++ b/tests/installation/src/utils.ts
@@ -21,6 +21,7 @@ import {
   ANSIBLE_ROOT_DIR,
   SANITY_TEST_REPORTS_DIR,
   INSTALL_TEST_REPORTS_DIR,
+  APIML_OIDC_VARS,
 } from './constants';
 
 /**
@@ -209,7 +210,7 @@ async function installAndVerifyZowe(testcase: string, installPlaybook: string, s
     testcase,
     installPlaybook,
     serverId,
-    extraVars
+    { ...APIML_OIDC_VARS , ...extraVars}
   );
 
   expect(resultInstall.code).toBe(0);
@@ -335,7 +336,7 @@ export async function installAndVerifyDockerBuild(testcase: string, serverId: st
     testcase,
     'install-docker.yml',
     serverId,
-    extraVars
+    { ...extraVars, ...APIML_OIDC_VARS }
   );
 
   expect(resultInstall.code).toBe(0);
@@ -403,10 +404,8 @@ export async function installAndVerifyExtension(testcase: string, serverId: stri
  * @param  {Object}    extraFmidVars
  * @param  {Object}    extraPtfVars
  */
-export async function installAndVerifySmpePtf(testcase: string, serverId: string, 
-  extraFmidVars: {[key: string]: any} = {}, 
-  extraPtfVars: {[key: string]: any} = {}): Promise<void> {
-  debug(`installAndVerifySmpePtf(${testcase}, ${serverId}, FMID: ${JSON.stringify(extraFmidVars)}, PTF: ${JSON.stringify(extraPtfVars)})`);
+export async function installAndVerifySmpePtf(testcase: string, serverId: string,  extraPtfVars: {[key: string]: any} = {}): Promise<void> {
+  debug(`installAndVerifySmpePtf(${testcase}, ${serverId}, ${JSON.stringify(extraPtfVars)})`);
 
   debug(`run install-fmid.yml on ${serverId}`);
  
@@ -417,7 +416,7 @@ export async function installAndVerifySmpePtf(testcase: string, serverId: string
     {
       'zowe_build_remote': ZOWE_FMID,
       'skip_start': 'true',
-      ...extraFmidVars
+      ...APIML_OIDC_VARS
     }
   );
 
@@ -428,7 +427,7 @@ export async function installAndVerifySmpePtf(testcase: string, serverId: string
     testcase,
     'install-ptf.yml',
     serverId,
-    extraPtfVars
+    { ...extraPtfVars, ...APIML_OIDC_VARS }
   );
 
   expect(resultPtf.code).toBe(0);
@@ -468,7 +467,7 @@ export async function installAndGenerateApiDocs(testcase: string, serverId: stri
     testcase,
     'install.yml',
     serverId,
-    extraVars
+    { ...extraVars, ...APIML_OIDC_VARS }
   );
 
   expect(resultInstall.code).toBe(0);
@@ -514,7 +513,7 @@ export async function showZoweRuntimeLogs(serverId: string, extraVars: {[key: st
       'doesn\'t matter',
       'show-logs.yml',
       serverId,
-      extraVars
+      { ...extraVars, ...APIML_OIDC_VARS }
     );
   } catch (e) {
     debug(`showZoweRuntimeLogs failed: ${e}`);


### PR DESCRIPTION
Some of our test builds are failing due to missing oidc vars. We toggle OIDC enablement on/off based on `oidc_enable` var, but even when false the Ansible playbooks still expect all oidc vars to be set. This change makes it so APIML_OIDC vars are always set across all installations, and we continue to rely on the `oidc_enable` var to modify the behavior of APIML within the tests. When `oidc_enable` is false, the set variables will be ignored, when true, they will be picked up. 

In the case where the ENV for OIDC is unset (a likely error condition), a dummy value is used which indicates where it was set, in case further debugging is required.