### PR TITLE
test: add external root ca to keyring in test automation

### DIFF
--- a/playbooks/all_host_vars_list.yml
+++ b/playbooks/all_host_vars_list.yml
@@ -68,7 +68,7 @@ zowe_jobs_explorer_port: 7560
 zowe_keyring_alias: ZoweKeyring
 zowe_keyring_certname: ZoweCert
 zowe_keyring_external_intermediate_ca:
-zowe_keyring_external_root_ca:
+zowe_keyring_external_root_ca: brcmso
 zowe_keystore_alias: localhost
 zowe_keystore_dir: ~/.zowe/keystore
 zowe_keystore_password: password

--- a/playbooks/host_vars/marist-3.yml
+++ b/playbooks/host_vars/marist-3.yml
@@ -4,3 +4,5 @@ zowe_sanity_test_testcases: "./test/**/!(api-doc-gen).js"
 zowe_apiml_security_x509_enabled: true
 zowe_apiml_security_oidc_enabled: true
 zos_zosmf_ca: ZOSMFCA
+
+zowe_configure_ignore_security_failures: true # Required for keyring tests - only Root cert passed, missing intermediate RC=4

--- a/playbooks/host_vars/marist-4.yml
+++ b/playbooks/host_vars/marist-4.yml
@@ -12,3 +12,5 @@ zowe_install_logs_dir: /ZOWE/logs
 
 zowe_smpe_volser: ZOWE03
 zowe_caching_vsam_volume: ZOWE03
+
+zowe_configure_ignore_security_failures: true # Required for keyring tests - only Root cert passed, missing intermediate RC=4

--- a/playbooks/roles/configfmid/defaults/main.yml
+++ b/playbooks/roles/configfmid/defaults/main.yml
@@ -104,7 +104,7 @@ zowe_keystore_password: password
 zowe_keyring_alias: ZoweKeyring
 zowe_keyring_certname: ZoweCert
 zowe_keyring_external_intermediate_ca:
-zowe_keyring_external_root_ca:
+zowe_keyring_external_root_ca: brcmso
 zowe_keystore_alias: localhost
 zowe_jcllib:
 zowe_proclib_dsname: auto

--- a/playbooks/roles/configure/defaults/main.yml
+++ b/playbooks/roles/configure/defaults/main.yml
@@ -105,7 +105,7 @@ zowe_keystore_password: password
 zowe_keyring_alias: ZoweKeyring
 zowe_keyring_certname: ZoweCert
 zowe_keyring_external_intermediate_ca:
-zowe_keyring_external_root_ca:
+zowe_keyring_external_root_ca: brcmso
 zowe_keystore_alias: localhost
 zowe_jcllib:
 zowe_proclib_dsname: auto

--- a/playbooks/roles/custom_for_test/defaults/main.yml
+++ b/playbooks/roles/custom_for_test/defaults/main.yml
@@ -105,7 +105,7 @@ zowe_keystore_password: password
 zowe_keyring_alias: ZoweKeyring
 zowe_keyring_certname: ZoweCert
 zowe_keyring_external_intermediate_ca:
-zowe_keyring_external_root_ca:
+zowe_keyring_external_root_ca: brcmso
 zowe_keystore_alias: localhost
 zowe_jcllib:
 zowe_proclib_dsname: auto


### PR DESCRIPTION
Same as PR #3514 , but for v2.x/staging line.