### PR TITLE
build: revert manifest to earlier point for v2.10.0

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -14,7 +14,7 @@
     "org.zowe.zlux.zlux-core": {
       "version": "2.10.0-RC",
       "repository": "libs-snapshot-local",
-      "artifact": "zlux-core-2.10.0-20230727.130803.pax"
+      "artifact": "zlux-core-2.10.0-20230724.143701.pax"
     },
     "org.zowe.zlux.sample-angular-app": {
       "version": "2.10.0-V2.X-RC",


### PR DESCRIPTION
Reverting to a known good release for z/os components.

Containers will be fixed in a future build.