### PR TITLE
revert back zlux changes

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -14,7 +14,7 @@
     "org.zowe.zlux.zlux-core": {
       "version": "2.10.0-RC",
       "repository": "libs-snapshot-local",
-      "artifact": "zlux-core-2.10.0-20230724.143701.pax"
+      "artifact": "zlux-core-2.10.0-20230726.125125.pax"
     },
     "org.zowe.zlux.sample-angular-app": {
       "version": "2.10.0-V2.X-RC",


### PR DESCRIPTION
Reverting to a known good release for z/os components artifacts dated July 26.

Containers will be fixed in a future build.
