### PR TITLE
Small typo fix

### DIFF
--- a/bin/libs/config.ts
+++ b/bin/libs/config.ts
@@ -95,7 +95,7 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
   }
 
   // delete old files to avoid potential issues
-  common.printFormattedTrace( "ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `deleting old files under ${zwePrivateWorkspaceEnvDir}`);
+  common.printFormattedTrace( "ZWELS", "bin/libs/config.ts,generate_instance_env_from_yaml_config", `deleting old files under ${zwePrivateWorkspaceEnvDir}`);
   let foundFiles = fs.getFilesInDirectory(zwePrivateWorkspaceEnvDir);
   if (foundFiles) {
     foundFiles.forEach((file:string)=> {
@@ -111,12 +111,12 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
   //TODO use configmgr to write json and ha json, and components json
   
   // prepare .zowe.json and .zowe-<ha-id>.json
-  common.printFormattedTrace("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `config-converter yaml convert --ha ${haInstance} ${cliParameterConfig}`);
+  common.printFormattedTrace("ZWELS", "bin/libs/config.ts,generate_instance_env_from_yaml_config", `config-converter yaml convert --ha ${haInstance} ${cliParameterConfig}`);
   let result = shell.execOutSync('node', `${runtimeDirectory}/bin/utils/config-converter/src/cli.js`, `yaml`, `convert`, `--wd`, zwePrivateWorkspaceEnvDir, `--ha`, haInstance, cliParameterConfig, `--verbose`);
 
-  common.printFormattedTrace("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `- Exit code: ${result.rc}: ${result.out}`);
+  common.printFormattedTrace("ZWELS", "bin/libs/config.ts,generate_instance_env_from_yaml_config", `- Exit code: ${result.rc}: ${result.out}`);
   if ( !fs.fileExists(`${zwePrivateWorkspaceEnvDir}/.zowe.json`)) {
-    common.printFormattedError( "ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `ZWEL0140E: Failed to translate Zowe configuration (${cliParameterConfig}).`);
+    common.printFormattedError( "ZWELS", "bin/libs/config.ts,generate_instance_env_from_yaml_config", `ZWEL0140E: Failed to translate Zowe configuration (${cliParameterConfig}).`);
     std.exit(140);
   }
 
@@ -126,9 +126,9 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
   
 
   // convert YAML configurations to backward compatible .instance-<ha-id>.env files
-  common.printFormattedTrace("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `config-converter yaml env --ha ${haInstance}`);
+  common.printFormattedTrace("ZWELS", "bin/libs/config.ts,generate_instance_env_from_yaml_config", `config-converter yaml env --ha ${haInstance}`);
   const envs = configmgr.getZoweConfigEnv(haInstance);
-  common.printFormattedTrace("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `- Output: ${JSON.stringify(envs, null, 2)}`);
+  common.printFormattedTrace("ZWELS", "bin/libs/config.ts,generate_instance_env_from_yaml_config", `- Output: ${JSON.stringify(envs, null, 2)}`);
   const envKeys = Object.keys(envs);
   let envFileArray=[];
   
@@ -145,7 +145,7 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
     let rc = fs.mkdirp(folderName, 0o700);
     if (rc) {
       //TODO error code
-      common.printFormattedError("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `Failed to make env var folder for component=${currentComponent}`);
+      common.printFormattedError("ZWELS", "bin/libs/config.ts,generate_instance_env_from_yaml_config", `Failed to make env var folder for component=${currentComponent}`);
     }
     let componentFileArray = [];
     componentFileArray.push('#!/bin/sh');
@@ -194,7 +194,7 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
     const componentFileContent = componentFileArray.join('\n');
     rc = xplatform.storeFileUTF8(`${folderName}/.instance-${haInstance}.env`, xplatform.AUTO_DETECT, componentFileContent);
     if (rc) { 
-      common.printFormattedError("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `ZWEL0140E: Failed to translate Zowe configuration (${cliParameterConfig}).`);
+      common.printFormattedError("ZWELS", "bin/libs/config.ts,generate_instance_env_from_yaml_config", `ZWEL0140E: Failed to translate Zowe configuration (${cliParameterConfig}).`);
       std.exit(140);
       return;
     }
@@ -203,7 +203,7 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
   let envFileContent = envFileArray.join('\n');
   let rc = xplatform.storeFileUTF8(`${zwePrivateWorkspaceEnvDir}/.instance-${haInstance}.env`, xplatform.AUTO_DETECT, envFileContent);
   if (rc) {
-    common.printFormattedError("ZWELS", "bin/libs/config.sh,generate_instance_env_from_yaml_config", `ZWEL0140E: Failed to translate Zowe configuration (${cliParameterConfig}).`);
+    common.printFormattedError("ZWELS", "bin/libs/config.ts,generate_instance_env_from_yaml_config", `ZWEL0140E: Failed to translate Zowe configuration (${cliParameterConfig}).`);
     std.exit(140);
     return;
   }

--- a/bin/libs/sys.sh
+++ b/bin/libs/sys.sh
@@ -112,7 +112,7 @@ find_all_child_processes() {
 wait_for_process_exit() {
   pid="${1}"
 
-  print_formatted_debug "ZWELS" "sys-utils.sh,wait_for_process_exit:${LINENO}" "waiting for process $pid to exit"
+  print_formatted_debug "ZWELS" "sys.sh,wait_for_process_exit:${LINENO}" "waiting for process $pid to exit"
 
   iterator_index=0
   max_iterator_index=30
@@ -123,13 +123,13 @@ wait_for_process_exit() {
     found=$(ps -p ${pid} -o pid 2>/dev/null | tail -n +2)
   done
   if [ -n "${found}" ]; then
-    print_formatted_debug "ZWELS" "sys-utils.sh,wait_for_process_exit:${LINENO}" "process $pid does NOT exit before timeout"
+    print_formatted_debug "ZWELS" "sys.sh,wait_for_process_exit:${LINENO}" "process $pid does NOT exit before timeout"
     return 1
   elif [ ${iterator_index} -eq 0 ]; then
-    print_formatted_debug "ZWELS" "sys-utils.sh,wait_for_process_exit:${LINENO}" "process $pid does NOT exist or already exited"
+    print_formatted_debug "ZWELS" "sys.sh,wait_for_process_exit:${LINENO}" "process $pid does NOT exist or already exited"
     return 0
   else
-    print_formatted_debug "ZWELS" "sys-utils.sh,wait_for_process_exit:${LINENO}" "process $pid exited gracefully"
+    print_formatted_debug "ZWELS" "sys.sh,wait_for_process_exit:${LINENO}" "process $pid exited gracefully"
     return 0
   fi
 }
@@ -145,16 +145,16 @@ wait_for_process_exit() {
 gracefully_shutdown() {
   pid=${1:-${ZWE_GRACEFULLY_SHUTDOWN_PID:-1}}
 
-  print_formatted_debug "ZWELS" "sys-utils.sh,gracefully_shutdown:${LINENO}" "SIGTERM signal received, shutting down process ${pid} and all child processes"
+  print_formatted_debug "ZWELS" "sys.sh,gracefully_shutdown:${LINENO}" "SIGTERM signal received, shutting down process ${pid} and all child processes"
   if [ -n "${pid}" ]; then
     children=$(find_all_child_processes $pid)
-    print_formatted_debug "ZWELS" "sys-utils.sh,gracefully_shutdown:${LINENO}" "propagate SIGTERM to all children: ${children}"
+    print_formatted_debug "ZWELS" "sys.sh,gracefully_shutdown:${LINENO}" "propagate SIGTERM to all children: ${children}"
     # send SIGTERM to all children
     kill -15 ${children} 2>/dev/null
     for pid in ${children}; do
       wait_for_process_exit $pid
     done
-    print_formatted_debug "ZWELS" "sys-utils.sh,gracefully_shutdown:${LINENO}" "all child processes exited"
+    print_formatted_debug "ZWELS" "sys.sh,gracefully_shutdown:${LINENO}" "all child processes exited"
   fi
 
   exit 0

--- a/bin/libs/sys.ts
+++ b/bin/libs/sys.ts
@@ -114,10 +114,10 @@ export function waitForProcessExit(pid: number): boolean {
   }
   
   if (shellReturn.rc == 0) {
-    common.printFormattedDebug("ZWELS", "sys-utils.sh,wait_for_process_exit:", `process ${pid} does NOT exit before timeout`);
+    common.printFormattedDebug("ZWELS", "sys.ts,wait_for_process_exit:", `process ${pid} does NOT exit before timeout`);
     return false;
   } else {
-    common.printFormattedDebug("ZWELS", "sys-utils.sh,wait_for_process_exit:", `process ${pid} no longer exists`);
+    common.printFormattedDebug("ZWELS", "sys.ts,wait_for_process_exit:", `process ${pid} no longer exists`);
     return true;
   }
 }
@@ -138,14 +138,14 @@ export function gracefullyShutdown(pid?: number): boolean {
   }
   if (pid >= 1) {
     let children = findAllChildProcesses(pid);
-    common.printFormattedDebug("ZWELS", "sys-utils.sh,gracefully_shutdown", "SIGTERM signal received, shutting down process ${pid} and all child processes");
+    common.printFormattedDebug("ZWELS", "sys.ts,gracefully_shutdown", "SIGTERM signal received, shutting down process ${pid} and all child processes");
 
     // send SIGTERM to all children
     os.kill(pid, 15);
     children.forEach((pid:number)=>{
       waitForProcessExit(pid);
     });
-    common.printFormattedDebug("ZWELS", "sys-utils.sh,gracefully_shutdown", "all child processes exited");
+    common.printFormattedDebug("ZWELS", "sys.ts,gracefully_shutdown", "all child processes exited");
     return true;
   }
   return false;


### PR DESCRIPTION
Couple of trace messages had either wrong suffix or file reference.

Note: Also in the TS files we are referencing functions from shell: e.g. `generate_instance_env_from_yaml_config` instead of `generateInstanceEnvFromYamlConfig`.