### PR TITLE
Duplicate log messages into syslog according to zowe.sysMessages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the Zowe Installer will be documented in this file.
 
 ## `2.11.0`
 
+### New features and enhancements
+- Enhancement: Duplicate log messages into syslog according to "zowe.sysMessages" array [#93](https://github.com/zowe/launcher/pull/93)
+
 ### Minor enhancements/defect fixes
 - Bugfix: Fixed that Zowe would allow newer Java versions to generate PKCS12 keystores that was not compatible with some components. Newer versions of Java by default create PKCS12 keystores that aren't compatible with GSK / SystemSSL which components such as ZSS use, but include flags to restore a compatibility mode, which Zowe now uses. (#3507)
 

--- a/example-zowe.yaml
+++ b/example-zowe.yaml
@@ -352,10 +352,10 @@ zowe:
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   # You can define any Zowe message portions to be checked for and the whole message added to the system log 
-  sysMessages:
-  #   Some examples
+  # sysMessages:
+  #   # Some examples
   #   - "ZWES1601I"
-  #   Not limited to Zowe message ID's
+  #   # Not limited to Zowe message ID's
   #   - "ERROR"
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/example-zowe.yaml
+++ b/example-zowe.yaml
@@ -352,9 +352,29 @@ zowe:
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   # You can define any Zowe message portions to be checked for and the whole message added to the system log 
-  # sysMessages:
-  #   # Some examples
-  #   - "ZWES1601I"
+  sysMessages:
+  #   # Zowe starting
+    - "ZWEL0021I"
+  #   # Zowe started
+    - "ZWEL0018I"
+    - "ZWEL0006I"
+  #   # Zowe ready to use
+    - "ZWES1601I"
+  #   # Zowe stopping
+    - "ZWEL0008I"
+  #   # Zowe stopped
+    - "ZWEL0022I"
+  #   # Zowe components starting
+    - "ZWEL0001I"
+  #   # Zowe components stopped
+    - "ZWEL0002I"
+  #   # API ML components ready
+    - "ZWEAM000I"
+  #   # App server ready
+    - "ZWED0031I"
+  #   # ZSS ready
+    - "ZWES1013I"
+
   #   # Not limited to Zowe message ID's
   #   - "ERROR"
 

--- a/example-zowe.yaml
+++ b/example-zowe.yaml
@@ -351,6 +351,14 @@ zowe:
   #   ZWED_TN3270_PORT: 23
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  # You can define any Zowe message portions to be checked for and the whole message added to the system log 
+  sysMessages:
+  #   Some examples
+  #   - "ZWES1601I"
+  #   Not limited to Zowe message ID's
+  #   - "ERROR"
+
+  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   # Enable debug mode for zowe launch scripts
   launchScript:
     # set to "debug" or "trace" to display extra debug information

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -478,7 +478,7 @@
             },
             "unsafeDisableZosVersionCheck": {
               "type": "boolean",
-              "description": "Used to allow Zowe to warn, instead of error, when running on a version of zOS that this version of Zowe hasn't been verified as working with",
+              "description": "Used to allow Zowe to warn, instead of error, when running on a version of z/OS that this version of Zowe hasn't been verified as working with",
               "default": false
             }
           }
@@ -534,9 +534,9 @@
           "description": "Customize how Zowe should validate certificates used by components or other services.",
           "enum": ["STRICT", "NONSTRICT", "DISABLED"]
         },
-        "sysMessages" {
+        "sysMessages": {
           "type": "array",
-          "description": "List of strings to find in log messages that when matched will be additionally logged into the system's log (such as syslog on zos)"
+          "description": "List of Zowe message portions when matched will be additionally logged into the system's log (such as syslog on z/OS). Note: Some messages extremely early in the Zowe lifecycle may not be added to the system's log",
           "uniqueItems": true,
           "items": {
             "type": "string"

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -534,6 +534,14 @@
           "description": "Customize how Zowe should validate certificates used by components or other services.",
           "enum": ["STRICT", "NONSTRICT", "DISABLED"]
         },
+        "sysMessages" {
+          "type": "array",
+          "description": "List of strings to find in log messages that when matched will be additionally logged into the system's log (such as syslog on zos)"
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "useConfigmgr": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
`zowe.sysMessages` is a new array that allows you to select messages that when found by the launcher will be duplicated into the system's log + zowe's own log, instead of just zowe's own log.

related PRs:
https://github.com/zowe/zowe-common-c/pull/391
https://github.com/zowe/launcher/pull/93