### PR TITLE
workflow for updating zowe component versions

### DIFF
--- a/.github/workflows/updateZoweVersionsAndCreatePR.yml
+++ b/.github/workflows/updateZoweVersionsAndCreatePR.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: lts/*
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/updateZoweVersionsAndCreatePR.yml
+++ b/.github/workflows/updateZoweVersionsAndCreatePR.yml
@@ -38,10 +38,9 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Install Dependencies
+      - name: Update Package Lists
         run: |
           sudo apt-get update -y
-          sudo apt install gh
 
       - name: Create Branch
         run: |

--- a/.github/workflows/updateZoweVersionsAndCreatePR.yml
+++ b/.github/workflows/updateZoweVersionsAndCreatePR.yml
@@ -81,7 +81,7 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
           git add "manifest.json.template"
-          git commit -m "Update component versions"
+          git commit -m "Update zowe component versions"
           git push origin HEAD
 
       - name: Create Pull Request

--- a/.github/workflows/updateZoweVersionsAndCreatePR.yml
+++ b/.github/workflows/updateZoweVersionsAndCreatePR.yml
@@ -1,0 +1,96 @@
+name: Update Zowe Component Versions and Create PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release Version (x.x.x)'
+        required: true
+      zowe_version:
+        description: "Zowe Version Tag"
+        default: zowe-v2-lts
+        required: true
+        type: choice
+        options:
+        - zowe-v1-lts
+        - zowe-v2-lts
+
+jobs:
+  update_versions_and_create_pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set Default Branch Environment Variable
+        run: |
+          if [[ "${{ github.event.inputs.zowe_version }}" == "zowe-v1-lts" ]]; then
+            echo "defaultBranch=v1.x/staging" >> $GITHUB_ENV
+          else
+            echo "defaultBranch=v2.x/staging" >> $GITHUB_ENV
+          fi
+
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.defaultBranch }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt install gh
+
+      - name: Create Branch
+        run: |
+          branch_name="v${{ github.event.inputs.version }}/rc"
+          git checkout -b "$branch_name"
+
+      - name: Get and Change Component Versions
+        id: get_versions
+        run: |
+          declare -A repoAndComponent
+          repoAndComponent[imperative]=imperative
+          repoAndComponent[cli]=zowe-cli
+          repoAndComponent[cics-for-zowe-cli]=zowe-cli-cics-plugin
+          repoAndComponent[db2-for-zowe-cli]=zowe-cli-db2-plugin
+          repoAndComponent[perf-timing]=perf-timing
+          repoAndComponent[mq-for-zowe-cli]=zowe-cli-mq-plugin
+          repoAndComponent[zos-ftp-for-zowe-cli]=zowe-cli-ftp-plugin
+
+          zowe_version=${{ github.event.inputs.zowe_version }}
+
+          echo "This PR updates the following package versions in manifest.json.template for \`$zowe_version\`" >> description.txt
+          echo "| Updated Package | Old Version | New Version |" >> description.txt
+          echo "| --- | --- | --- |" >> description.txt
+          for component in "${!repoAndComponent[@]}"; do
+              repo="${repoAndComponent[$component]}"
+              current_version=$(grep -A 2 "\"repository\": \"$repo\"" manifest.json.template | awk -F '"' '/"tag":/ {print $4}')
+              new_version=v$(npm view @zowe/$component "dist-tags.$zowe_version")
+              if [[ "$new_version" != "$current_version" ]]; then
+                  echo "|$component | $current_version | $new_version|" >> description.txt
+                  # Replaces the version number. If it doesn't match on the first line after the component, it goes to the next line and checks again.
+                  sed -i -E "/\"repository\": \"$repo\"/{n;s/(\"tag\": \").*(\",)/\1$new_version\2/}" manifest.json.template
+              fi
+          done
+
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git add "manifest.json.template"
+          git commit -m "Update component versions"
+          git push origin HEAD
+
+      - name: Create Pull Request
+        run: |
+          version="${{ github.event.inputs.version }}"
+          branch_name="v$version/rc"
+          pr_title="Update versions for $version"
+          body_file=description.txt
+          gh pr create --base ${{ env.defaultBranch }} --head "$branch_name" --title "$pr_title" --body-file "$body_file" --reviewer atorrise
+          echo "Pull Request created successfully"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### PR type
What type of changes does your PR introduce to Zowe?
- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [x] Other... Please describe:
This PR proposes a new github action for this repo

### Changes proposed in this PR
This PR introduces a new workflow, `updateZoweVersionsAndCreatePR.yml`, which takes two inputs and uses them to automatically update zowe-scoped packages within `manifest.json.template` for either `v1.x/staging` or `v2.x/staging` depending on use case. This GHA will help the CLI team with our release process. 

![image](https://github.com/zowe/zowe-cli-standalone-package/assets/112635587/f23e4241-67fa-44e5-b313-d4c1023d19d0)
<br>
 `updateZoweVersionsAndCreatePR.yml` most notably achieves the following: 
- Determines which branch, `v1.x/staging` or `v2.x/staging` to checkout
- Creates a new branch with name `vX.x.x/rc`
- Gets and keeps track of changed component versions that match the input zowe-version tag
- Amends the `manifest.json.template` file to reflect any updates
- Commits changes and creates a pull request with a table in its description that denotes all of the updated versions
- Assigns a reviewer to the newly created PR


### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [x] No

> **Note**
>**Additional Comments and Requirements**
>- Before merging this in, the reviewer needs to be changed from myself, for testing purposes, to OJ
>- Example PRs this workflow produces can be found here: https://github.com/ATorrise/zowe-install-packaging/pulls
>- There are some permissions that need to be granted for workflows in order for the GHA to work :
>![image](https://github.com/zowe/zowe-install-packaging/assets/112635587/1eac6479-74bf-4ddc-9114-caea00ef38c0)

> **Important**
>**Question**
>- It doesn't seem like this repo's `v1.x/staging` branch really gets modified anymore as the `manifest.json.template` file in this branch seems to just tag each component with `zowe-v1-lts`. Should I remove the ability to change the `v1.x/staging` branch from this workflow? 

