### PR TITLE
Allow pem to be present but empty when keyring

### DIFF
--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -791,24 +791,24 @@
           "description": "Certificate in PEM format.",
           "properties": {
             "key": {
-              "$ref": "/schemas/v2/server-common#zowePath",
+              "type": "string",
               "description": "Path to the certificate private key stored in PEM format."
             },
             "certificate": {
-              "$ref": "/schemas/v2/server-common#zowePath",
+              "type": "string",
               "description": "Path to the certificate stored in PEM format."
             },
             "certificateAuthorities": {
               "description": "List of paths to the certificate authorities stored in PEM format.",
               "oneOf": [{
-                  "$ref": "/schemas/v2/server-common#zowePath",
+                  "type": "string",
                   "description": "Paths to the certificate authorities stored in PEM format. You can separate multiple certificate authorities by comma."
                 },
                 {
                   "type": "array",
                   "description": "Path to the certificate authority stored in PEM format.",
                   "items": {
-                    "$ref": "/schemas/v2/server-common#zowePath"
+                    "type": "string"
                   }
                 }
               ]

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -789,7 +789,6 @@
           "type": "object",
           "additionalProperties": false,
           "description": "Certificate in PEM format.",
-          "required": ["key", "certificate"],
           "properties": {
             "key": {
               "$ref": "/schemas/v2/server-common#zowePath",


### PR DESCRIPTION
In v2.10, the schema behavior changed on zowe.certificate to declare desired behavior after simplifying keyrings slightly:
* if you are using keyrings, you really shouldnt have a pem section
* if you arent using keyrings, you currently require a pem section

but, prior to v2.10, you needed a pem section with keyrings due to a flaw in a server, which has been fixed.

the schema became stricter at that time, yet probably not in a beneficial way.
having a pem section when its not needed isnt really harmful to zowe, its mostly just pointless. we could revert to the old schema behavior without consequence which will ease upgrade behavior.