### PR TITLE
Add listuser to zwesecur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
 
+## `2.12.0`
+
+#### Minor enhancements/defect fixes
+- Enhancement: The job ZWESECUR now assigns the STC user the READ permission to the SAF resource IRR.RADMIN.LISTUSER. Previously this had to be done manually. (#3583)
+
 ## `2.11.0`
 
 ### New features and enhancements

--- a/workflows/templates/ZWESECUR.vtl
+++ b/workflows/templates/ZWESECUR.vtl
@@ -350,6 +350,15 @@
   PERMIT OMVSAPPL CLASS(APPL) ID(&ZOWEUSER.) ACCESS(READ)
   SETROPTS RACLIST(APPL) REFRESH
 
+
+/* permit Zowe main server to read the OMVS segment of other users.  */
+/* this is used in the ZSS /omvs API which allows Zowe programs to   */
+/* know the user's home directory for convenience in editors         */
+  RLIST   FACILITY IRR.RADMIN.LISTUSER ALL
+  RDEFINE FACILITY IRR.RADMIN.LISTUSER UACC(NONE)
+  PERMIT IRR.RADMIN.LISTUSER CLASS(FACILITY) ACCESS(READ) ID(&ZOWEUSER.)
+
+  
 /* permit Zowe main server to set job name                           */
   RLIST   FACILITY BPX.JOBNAME ALL
   RDEFINE FACILITY BPX.JOBNAME UACC(NONE)
@@ -583,6 +592,12 @@ SET RESOURCE(APL)
 RECKEY OMVSAPPL ADD(SERVICE(READ) ROLE(&STCGRP.) ALLOW)
 F ACF2,REBUILD(APL)
 *
+* permit Zowe main server to read the OMVS segment of other users.  
+* this is used in the ZSS /omvs API which allows Zowe programs to   
+* know the user's home directory for convenience in editors
+SET RESOURCE (FAC)
+RECKEY IRR ADD(RADMIN.LISTUSER SERVICE(READ) ROLE(&STCGRP.) ALLOW)
+*
 * Allow STCGRP role access to BPX.JOBNAME
 RECKEY BPX ADD(JOBNAME SERVICE(READ) ROLE(&STCGRP.) ALLOW)
 F ACF2,REBUILD(FAC)
@@ -792,6 +807,13 @@ $$
   TSS PER(&ZOWEUSER.) IBMFAC(BPX.DAEMON) ACCESS(UPDATE)
   TSS WHOHAS IBMFAC(BPX.SERVER)
   TSS PER(&ZOWEUSER.) IBMFAC(BPX.SERVER) ACCESS(UPDATE)
+
+/* permit Zowe main server to read the OMVS segment of other users.  
+/* this is used in the ZSS /omvs API which allows Zowe programs to   
+/* know the user's home directory for convenience in editors
+  TSS ADD(&FACACID.) IBMFAC(IRR.)
+  TSS WHOHAS IBMFAC(IRR.RADMIN.LISTUSER)
+  TSS PER(&ZOWEUSER.) IBMFAC(IRR.RADMIN.LISTUSER) ACCESS(READ)
 
 /* permit Zowe main server to create a user's security environment   */
 /* comment out the following line if the OMVSAPPL is not defined     */

--- a/workflows/templates/ZWESECUR.vtl
+++ b/workflows/templates/ZWESECUR.vtl
@@ -356,7 +356,8 @@
 /* know the user's home directory for convenience in editors         */
   RLIST   FACILITY IRR.RADMIN.LISTUSER ALL
   RDEFINE FACILITY IRR.RADMIN.LISTUSER UACC(NONE)
-  PERMIT IRR.RADMIN.LISTUSER CLASS(FACILITY) ACCESS(READ) ID(&ZOWEUSER.)
+  PERMIT IRR.RADMIN.LISTUSER CLASS(FACILITY) ACCESS(READ) - 
+    ID(&ZOWEUSER.)
 
   
 /* permit Zowe main server to set job name                           */


### PR DESCRIPTION
As part of an effort in https://github.com/zowe/docs-site/pull/3058/files?short_path=ae41809#diff-ae41809c60154e4229220cc1ec0be591d1bd9cb3b1971d7d9159f485a0153a58 to improve security documentation, we discovered in https://github.com/zowe/zss/issues/649 that the listuser permission required by zowe was not present in ZWESECUR, requiring manual permission setting for it to work. This change is to automate granting that permission to the STC.