### PR TITLE
Fixed typos in parameter help

### DIFF
--- a/.dependency/zwe_doc_generation/md-content.js
+++ b/.dependency/zwe_doc_generation/md-content.js
@@ -46,7 +46,7 @@ function generateDocumentationForNode(curNode, assembledParentNode) {
             docContent += createDocContent(assembledDocNode[docType.fileName].content, docType);
             const parentDocContent = createDocContent(assembledDocNode[docType.fileName].parentContent, docType);
             if (parentDocContent) {
-                docContent += SUB_SECTION_HEADER_PREFIX + 'Inherited from parent command' + SEPARATOR + parentDocContent;
+                docContent += SEPARATOR + SUB_SECTION_HEADER_PREFIX + 'Inherited from parent command' + SEPARATOR + parentDocContent;
             }
         }
 

--- a/bin/commands/components/search/.parameters
+++ b/bin/commands/components/search/.parameters
@@ -1,5 +1,5 @@
 component-name,component|o|string|||||Component name to search for.
 component-id,id|d|string|||||Component id to search for.
-registry|r|string|||||Specifies the registry to searh within instead of the default. The registry must be compatible with the manager used.
+registry|r|string|||||Specifies the registry to search within instead of the default. The registry must be compatible with the manager used.
 handler||string|||||Specifies the registry handler name used with the package registry, instead of the default. The handler must be compatible with the registry used.
 

--- a/bin/commands/components/uninstall/.parameters
+++ b/bin/commands/components/uninstall/.parameters
@@ -1,4 +1,4 @@
 component-name,component|o|string|required||||The name of an installed component.
-registry|r|string|||||Specifies the registry to searh within instead of the default. The registry must be compatible with the manager used.
+registry|r|string|||||Specifies the registry to search within instead of the default. The registry must be compatible with the manager used.
 handler||string|||||Specifies the registry handler name used with the package registry, instead of the default. The handler must be compatible with the registry used.
 dry-run|d|boolean|||||Whether or not to perform the upgrade versus just checking if an upgrade is available

--- a/bin/commands/components/upgrade/.parameters
+++ b/bin/commands/components/upgrade/.parameters
@@ -1,4 +1,4 @@
 component-file,component|o|string|required||||Either a path or component name. The path must be to a component package or directory. If a name is specified instead, install checks the zowe package registry.
-registry|r|string|||||Specifies the registry to searh within instead of the default. The registry must be compatible with the manager used.
+registry|r|string|||||Specifies the registry to search within instead of the default. The registry must be compatible with the manager used.
 handler||string|||||Specifies the registry handler name used with the package registry, instead of the default. The handler must be compatible with the registry used.
 dry-run|d|boolean|||||Whether or not to perform the upgrade versus just checking if an upgrade is available


### PR DESCRIPTION
Fixes github.com/zowe/docs-site/pull/2918/ in the code, so users of zwe will also benefit.