### PR TITLE
bin/utils/date-add.rex: formatting in general pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
 
+## `2.13.0`
+#### Minor enhancements/defect fixes
+- Enhancement: `/bin/utils/date-add.rex` utility is accepting the date formatting as combination of YY|YYYY, MM, DD and any separator.
+
 ## `2.11.0`
 
 ### New features and enhancements

--- a/bin/libs/certificate.sh
+++ b/bin/libs/certificate.sh
@@ -884,8 +884,8 @@ EOF
   fi
 
   date_add_util="${ZWE_zowe_runtimeDirectory}/bin/utils/date-add.rex"
-  validity_ymd=$("${date_add_util}" ${validity} 1234-56-78)
-  validity_mdy=$("${date_add_util}" ${validity} 56/78/34)
+  validity_ymd=$("${date_add_util}" ${validity} YYYY-MM-DD)
+  validity_mdy=$("${date_add_util}" ${validity} MM/DD/YY)
 
   # option 2 needs further changes on JCL
   racf_connect1="s/dummy/dummy/"

--- a/bin/utils/date-add.rex
+++ b/bin/utils/date-add.rex
@@ -13,19 +13,58 @@
 
 /*
  * Parameters:
- *   1: how many days in the future
- *   2: date format.
- *      For example, 1234-56-78 will be YYYY-MM-DD.
- *      For example, 56/78/34 will be MM/DD/YY.
+ *   1: days: how many days in the future or past
+ *        negative number for past
+ *   2: dformat: date format
+ *        Combination of YY|YYYY, MM and DD and (optional) any separator
+ *        For example: YYYY-MM-DD, MM/DD/YY, DD.MM.YY, YYMMDD...
  *
- * Example: date-add.rexx 7 1234-56-78
+ * Examples:
+ *   date-add.rex 7 YYYY-MM-DD
+ *   date-add.rex -1 MM/DD/YY
  */
 
 arg options
-parse var options days format
+parse upper var options days dformat
 
-today = Date('Base')
+ERR_DATE.1 = "YY or YYYY (year)"
+ERR_DATE.2 = "MM (month)"
+ERR_DATE.3 = "DD (day)"
+
+if datatype(days) \= "NUM" then do
+  say "ERROR: expected numeric value for days: '"days"'"
+  exit 1
+end
+/* YYMMDD -> YYYY/MM/DD */
+if length(dformat) < 6 | length(dformat) > 10 then do
+  len = 'short'
+  if length(dformat) > 10 then
+    len = 'long'
+  say "ERROR: invalid date format: '"||dformat||"' is too "||len
+  exit 1
+end
+else do i = 1 to 3
+  if pos(word(ERR_DATE.i, 1), dformat) = 0 then do
+    say "ERROR: invalid date format: '"||dformat||,
+        "' is missing "||ERR_DATE.i
+    exit 1
+  end
+end
+
+today = Date("Base")
 target = today + days
-ISOTarget = Date('Standard', target, 'Base')
-result = Translate(format, ISOTarget, '12345678')
-say result
+ISOTarget = Date("Standard", target, "Base")
+
+/* ISOTarget YYYYMMDD                                  */
+/*           12344578 => YYYY = 1234, MM = 56, DD = 78 */
+
+if pos("YYYY", dformat) = 0 then
+  dformat = overlay("34", dformat, pos("YY", dformat))
+else
+  dformat = overlay("1234", dformat, pos("YYYY", dformat))
+dformat = overlay("56", dformat, pos("MM", dformat))
+dformat = overlay("78", dformat, pos("DD", dformat))
+
+res = translate(dformat, ISOTarget, "12345678")
+say res
+exit 0


### PR DESCRIPTION
<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [x] Feature <!-- non-breaking change which adds functionality -->


#### Relevant issues
<!-- Link to a relevant GitHub issue if any. If this PR applies to multiple issues, preface each issue reference with the "Fixes" keyword. For example, Fixes #123, Fixes #456. -->

Fixes current state.

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->

There is a small utility for adding days to current date. It is written in REXX due to lack of possibilities in shell.
However, the formatting pattern is numeric, which is not easy to read and understand:
```
validity_ymd=$("${date_add_util}" ${validity} 1234-56-78)
```
New behavior will allow this:
```
validity_ymd=$("${date_add_util}" ${validity} YYYY-MM-DD)
```

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [x] No