### PR TITLE
Update TLS settings

### DIFF
--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -882,7 +882,7 @@
           "type": "string",
           "enum": ["TLSv1.2", "TLSv1.3"],
           "default": "TLSv1.2",
-          "description": "Minimum TLS version allowed for network connections, and less than network.maxTls."
+          "description": "Minimum TLS version allowed for network connections, and less than or equal to network.maxTls."
         }
       }
     },

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -860,7 +860,7 @@
       "properties": {
         "ciphers": {
           "type": "array",
-          "description": "Acceptable TLS cipher suites for network connections.",
+          "description": "Acceptable TLS cipher suites for network connections, in IANA format.",
           "items": {
             "type": "string"
           }
@@ -874,14 +874,14 @@
         },
         "maxTls": {
           "type": "string",
-          "enum": ["TLSv1.0", "TLSv1.1", "TLSv1.2", "TLSv1.3"],
+          "enum": ["TLSv1.2", "TLSv1.3"],
           "default": "TLSv1.3",
           "description": "Maximum TLS version allowed for network connections."
         },
         "minTls": {
           "type": "string",
-          "enum": ["TLSv1.0", "TLSv1.1", "TLSv1.2", "TLSv1.3"],
-          "default": "TLSv1.3",
+          "enum": ["TLSv1.2", "TLSv1.3"],
+          "default": "TLSv1.2",
           "description": "Minimum TLS version allowed for network connections, and less than network.maxTls."
         }
       }


### PR DESCRIPTION
This PR clarifies that the cipher format is IANA, and removes TLS 1.0 and 1.1 from the enum as we decided there is no reason to allow downgrading unless there's high demand for that.
The minTls was wrongly stated as 1.3, current is 1.2