### PR TITLE
Add zosmf scheme option for at-tls in api ml

### DIFF
--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -288,7 +288,7 @@ done
 
 echo "[$SCRIPT_NAME] process commands.install hooks"
 # not all core components has commands.install
-for component in app-server; do
+for component in app-server common-java-lib; do
   echo "[$SCRIPT_NAME] - ${component}"
   # FIXME: these environment variables are changed in v2
   ZOWE_ROOT_DIR=${ZOWE_ROOT_DIR} \

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -288,7 +288,7 @@ done
 
 echo "[$SCRIPT_NAME] process commands.install hooks"
 # not all core components has commands.install
-for component in app-server common-java-lib; do
+for component in app-server; do
   echo "[$SCRIPT_NAME] - ${component}"
   # FIXME: these environment variables are changed in v2
   ZOWE_ROOT_DIR=${ZOWE_ROOT_DIR} \

--- a/bin/libs/configmgr.ts
+++ b/bin/libs/configmgr.ts
@@ -506,6 +506,7 @@ const SPECIAL_ENV_MAPS = {
   ZWE_java_home:'JAVA_HOME',
   ZWE_zOSMF_host: 'ZOSMF_HOST',
   ZWE_zOSMF_port: 'ZOSMF_PORT',
+  ZWE_zOSMF_scheme: 'ZOSMF_SCHEME',
   ZWE_zOSMF_applId: 'ZOSMF_APPLID'
 };
 

--- a/bin/libs/configmgr.ts
+++ b/bin/libs/configmgr.ts
@@ -506,7 +506,6 @@ const SPECIAL_ENV_MAPS = {
   ZWE_java_home:'JAVA_HOME',
   ZWE_zOSMF_host: 'ZOSMF_HOST',
   ZWE_zOSMF_port: 'ZOSMF_PORT',
-  ZWE_zOSMF_scheme: 'ZOSMF_SCHEME',
   ZWE_zOSMF_applId: 'ZOSMF_APPLID'
 };
 

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -97,7 +97,7 @@
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.sdk.common-java-lib-package": {
-      "version": "~2.0.0-SNAPSHOT",
+      "version": "^2.0.0-SNAPSHOT",
       "artifact": "common-java-lib-*.zip",
       "exclusions": ["*PR*.zip"]
     },

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -578,6 +578,10 @@
           "$ref": "#/$defs/port",
           "description": "Port number of your z/OSMF instance."
         },
+        "scheme": {
+          "$ref" : "#/$defs/scheme",
+          "description": "Scheme used to connect to z/OSMF instance. Optional for outbout AT-TLS, defaults to https"
+        },
         "applId": {
           "type": "string",
           "description": "Appl ID of your z/OSMF instance."
@@ -626,6 +630,14 @@
       "type": "integer",
       "minimum": 0,
       "maximum": 65535
+    },
+    "scheme": {
+      "type": "string",
+      "enum": [
+        "http",
+        "https"
+      ],
+      "default": "https"
     },
     "certificate": {
       "oneOf": [


### PR DESCRIPTION
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [ ] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [ ] Feature

#### Relevant issues

Linked to [api-layer/2795](https://github.com/zowe/api-layer/issues/2795)

#### Changes proposed in this PR
- Include the option to optionally define the scheme used in the z/OSMF URL. So far this will only be used for the AT-TLS support, in case there is an outbound rule defined such as in the connection between API Gateway and z/OSMF/
Other components or the installation may decide to use it, especially if eventually there is a centralized way of managing AT-TLS support across all Zowe components.
- common-java-lib runs install.sh script to set program-controlled flag

Documentation will be updated in an upcoming PR to docs-site.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [ X] No

#### Is there a related doc issue or Pull Request? 

Will be updated once the PR is created in docs-site

Doc issue/PR number: 

#### Other information

