### PR TITLE
Add getesm to build

### DIFF
--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -171,7 +171,7 @@ jobs:
         with:
           manifest-file-path: ${{ github.workspace }}/manifest.json
           default-target-path: .pax/binaryDependencies/
-          expected-count: 29
+          expected-count: 30
       
       # this step is not doing a publish, we are just utilizing this actions to get the PUBLISH_TARGET_PATH, 
       # and it will be used in the next step: [Download 3] Download SMPE build log

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -249,6 +249,13 @@ mv ./content/templates .
 chmod +x templates/*.rex
 
 mkdir -p "${ZOWE_ROOT_DIR}/bin/utils"
+getesm=$(find "${ZOWE_ROOT_DIR}/files" -type f \( -name "getesm*.pax" \) | head -n 1)
+echo "[$SCRIPT_NAME] extract getesm $getesm"
+cd "${ZOWE_ROOT_DIR}/bin/utils"
+pax -ppx -rf "${getesm}"
+rm "${getesm}"
+cd "${BASE_DIR}"
+
 configmgr=$(find "${ZOWE_ROOT_DIR}/files" -type f \( -name "configmgr-2*.pax" \) | head -n 1)
 echo "[$SCRIPT_NAME] extract configmgr $configmgr"
 cd "${ZOWE_ROOT_DIR}/bin/utils"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to the Zowe Installer will be documented in this file.
 ## `2.13.0`
 
 ### New features and enhancements
+- Enhancement: Added utility "getesm" into bin/utils. When run it outputs to STDOUT which ESM your system is using. (#3662)
 
 #### Minor enhancements/defect fixes
 - Bugfix: Workflow files in the Zowe PAX are now ASCII-encoded. Fixes [#3591](https://github.com/zowe/zowe-install-packaging/issues/3591).
+
 
 ## `2.12.0`
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -56,6 +56,7 @@ Please be aware of using functions marked as `@experimental`. These functions ma
 
 - `bin/utils/opercmd.rex`: To issue operator command on z/OS. This script can only run on z/OS.
 - `bin/utils/curl.js`: This is node.js script works similar to popular Linux tool `curl`. It can make HTTP/HTTPS request and display response.
+- `bin/utils/getesm`: Executable to get the name of External Security Manager
 
 Please be aware of using utilities marked as `@experimental`. These utilities may be changed or improved in the future, and they may not be stable enough for extenders to use if they target to support multiple versions of Zowe.
 

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -111,6 +111,10 @@
       "artifact": "cloud-gateway-*.zip",
       "exclusions": ["*PR*.zip"]
     },
+    "org.zowe.getesm": {
+      "version": "^2.0.0-V2.X-STAGING",
+      "artifact": "*.pax"
+    },
     "org.zowe.configmgr": {
       "version": "^2.0.0-V2.X-STAGING",
       "artifact": "*.pax"


### PR DESCRIPTION
This puts the new utility "getesm" into bin/utils
getesm was added to zowe-common-c here https://github.com/zowe/zowe-common-c/pull/415

it is not currently used by anything and has no side effects.
it could be called by new code or by users to simply print out which ESM they are using to the STDOUT of a terminal.

it could also be used as a smoke test in the event of configmgr or zss failing.
it is a C program just like them, so if they are failing, it can be used to prove if any trivial C program will run on a system.