### PR TITLE
Update ZE component versions for 2.13.0

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -389,7 +389,7 @@
       "componentGroup": "Zowe Visual Studio Code Extension",
       "entries": [{
         "repository": "vscode-extension-for-zowe",
-        "tag": "v2.11.2",
+        "tag": "v2.12.2",
         "destinations": ["Visual Studio Code Marketplace"]
       }]
     },


### PR DESCRIPTION
Updates the version of Zowe Explorer to v2.12.2 which is the latest tag as of the 2.13.0 code freeze.