### PR TITLE
Zwe doc should run on push to v2.x/master (release)

### DIFF
--- a/.github/workflows/zwe-doc-generation.yml
+++ b/.github/workflows/zwe-doc-generation.yml
@@ -4,7 +4,7 @@ on:
   # Will run this on push when v2 is out
   push:
     branches:
-      - v2.x/rc
+      - v2.x/master
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Zowe `zwe` doc generation currently runs on push to v2.x/rc, which results in unnecessary runs of the tool and an excess of PRs on the docs-site or build failures. v2.x/rc can receive multiple changes in a single release cycle. 

Instead, v2.x/master should be used for generating doc - there will be a single push per release to this branch, albeit it will come closer the live release time.