### PR TITLE
Update CLI component versions again for 2.13.0

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -224,7 +224,7 @@
       "componentGroup": "Zowe CLI",
       "entries": [{
         "repository": "zowe-cli",
-        "tag": "v7.19.0",
+        "tag": "v7.20.1",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
@@ -238,7 +238,7 @@
       "componentGroup": "IBM&reg Db2&reg Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-db2-plugin",
-        "tag": "v5.0.4",
+        "tag": "v5.0.5",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
@@ -252,7 +252,7 @@
       "componentGroup": "z/OS&reg FTP Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-ftp-plugin",
-        "tag": "v2.1.5",
+        "tag": "v2.1.6",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {


### PR DESCRIPTION
This PR updates the following package versions in manifest.json.template for `zowe-v2-lts`
| Updated Package | Old Version | New Version |
| --- | --- | --- |
|db2-for-zowe-cli | v5.0.4 | v5.0.5|
|cli | v7.19.0 | v7.20.1|
|zos-ftp-for-zowe-cli | v2.1.5 | v2.1.6|
