### PR TITLE
Include 'zowe.job.suffix' to be compatible with prior configs

### DIFF
--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -861,8 +861,22 @@
           "properties": {
             "network": {
               "$ref": "#/$defs/networkSettings"
+            },
+            "job": {
+              "$ref": "#/$defs/componentJobSettings"
             }
           }
+        }
+      }
+    },
+    "componentJobSettings": {
+      "$anchor": "componentJobSettings",
+      "type": "object",
+      "description": "Component level overrides for job execution behavior",
+      "properties": {
+        "suffix": {
+          "type": "string",
+          "description": "Can be used by components to declare a jobname suffix to append to their job. This is not currently used by Zowe itself, it is up to components to use this value if desired. Zowe may use this value in the future."
         }
       }
     },


### PR DESCRIPTION
At previous advice, at least one extender was using 'zowe.job.suffix' within their component to let users customize their jobname.
As we just added 'zowe' section to components, there was a collision in schemas so after discussion it was found good to just have the zowe schema declare the existence of zowe.job.suffix. Right now we say zowe does nothing with it, and it is for extension use as needed.