### PR TITLE
default zss to 64 bit

### DIFF
--- a/example-zowe.yaml
+++ b/example-zowe.yaml
@@ -598,6 +598,7 @@ components:
     agent:
       jwt:
         fallback: true
+      64bit: true
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   jobs-api:


### PR DESCRIPTION
This is a breaking configuration change in v3 that defaults zss to start its 64 bit edition rather than prior 31 bit.
The code is not new. it has been in v2
This change is done to reduce memory pressure on 31 bit.
Zss plugins must match the server, so its recommended that extenders ship both 31 bit and 64 bit editions of a zss plugin to support both, but at least for v3 this config change means that those extenders that do not have 64 bit plugins yet will need users to revert the config back to "64bit: false" or else their plugins would not load.

More info here https://docs.zowe.org/stable/user-guide/mvd-configuration#zss-64-or-31-bit-modes