### PR TITLE
Update ZE component versions for 2.14.0

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -372,7 +372,7 @@
       "componentGroup": "Zowe Visual Studio Code Extension",
       "entries": [{
         "repository": "vscode-extension-for-zowe",
-        "tag": "v2.12.2",
+        "tag": "v2.13.1",
         "destinations": ["Visual Studio Code Marketplace"]
       }]
     },


### PR DESCRIPTION
Updates the version of Zowe Explorer to v2.13.1 which is the latest tag as of the 2.14.0 code freeze.