### PR TITLE
fix: update default service id for z/osmf in api layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 All notable changes to the Zowe Installer will be documented in this file.
+
+## `3.0.0`
+
+### Breaking Changes
+
+- `zowe.yaml` changed its default z/OSMF Service ID definition from `zosmf` to `ibmzosmf`, which may impact Zowe Clients. For more information on this change, please see the API Mediation Layer's 3.0.0 Breaking Changes.
+
 <!--Add the PR or issue number to the entry if available.-->
 ## `2.14.0`
 

--- a/example-zowe.yaml
+++ b/example-zowe.yaml
@@ -504,7 +504,7 @@ components:
           provider: zosmf
           zosmf:
             jwtAutoconfiguration: auto
-            serviceId: zosmf
+            serviceId: ibmzosmf
         authorization:
           endpoint:
             enabled: false


### PR DESCRIPTION
Updates the default z/OSMF service Id to `ibmzosmf` in v3

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 

- [ ] Other... Please describe:

#### Relevant issues

Related to https://github.com/zowe/api-layer/issues/3295

#### Changes proposed in this PR

- Set default to `ibmzosmf` in the exampe zowe.yaml for v3

#### Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

#### Does this PR do something the person installing Zowe should know about?

In existing installations moving to v3, they need to make sure to update the serviceId set for z/OSMF in the gateway configuration from default `zosmf` to `ibmzosmf`, the first one will no longer exist.

---
* Affected function: _general area of interest_ *

---
* Description: _1 line description_ *

---
* Part: _name of customizable file involved_  *

---
_multi-line description_

#### Is there a related doc issue or Pull Request? 
<!-- Link to a relevant documentation issue or Pull Request if any. -->

Doc issue/PR number: 

#### Other information

