### PR TITLE
TSS: Detect zOSMF Root CA

### DIFF
--- a/bin/commands/certificate/keyring-jcl/connect/.parameters
+++ b/bin/commands/certificate/keyring-jcl/connect/.parameters
@@ -8,6 +8,6 @@ trust-cas||string|||||Labels of extra certificate authorities should be trusted,
 connect-user||string|required||||Certificate owner. Can be `SITE` or a user ID.
 connect-label||string|required||||Certificate label to connect.
 trust-zosmf||boolean|||||Whether to trust z/OSMF CA.
-zosmf-ca||string||_auto_|||Labels of z/OSMF root certificate authorities. Specify "_auto_" to let Zowe to detect automatically. This only works for RACF.
+zosmf-ca||string||_auto_|||Labels of z/OSMF root certificate authorities. Specify "_auto_" to let Zowe to detect automatically. This works for RACF and TSS.
 zosmf-user||string||IZUSVR|||z/OSMF user name. This is used to automatically detect z/OSMF root certificate authorities.
 ignore-security-failures||boolean|||||Whether to ignore security setup job failures.

--- a/bin/commands/certificate/keyring-jcl/connect/.parameters
+++ b/bin/commands/certificate/keyring-jcl/connect/.parameters
@@ -8,6 +8,6 @@ trust-cas||string|||||Labels of extra certificate authorities should be trusted,
 connect-user||string|required||||Certificate owner. Can be `SITE` or a user ID.
 connect-label||string|required||||Certificate label to connect.
 trust-zosmf||boolean|||||Whether to trust z/OSMF CA.
-zosmf-ca||string||_auto_|||Labels of z/OSMF root certificate authorities. Specify "_auto_" to let Zowe to detect automatically. This works for RACF and TSS.
+zosmf-ca||string||_auto_|||Labels of z/OSMF root certificate authorities. Specify `_auto_` to let Zowe to detect automatically. This works for RACF and TSS.
 zosmf-user||string||IZUSVR|||z/OSMF user name. This is used to automatically detect z/OSMF root certificate authorities.
 ignore-security-failures||boolean|||||Whether to ignore security setup job failures.

--- a/bin/commands/certificate/keyring-jcl/generate/.parameters
+++ b/bin/commands/certificate/keyring-jcl/generate/.parameters
@@ -16,6 +16,6 @@ country||string|||||Country of certificate and certificate authority.
 validity||string|||||Validity days of certificate.
 trust-cas||string|||||Labels of extra certificate authorities should be trusted, separated by comma (Maximum 2).
 trust-zosmf||boolean|||||Whether to trust z/OSMF CA.
-zosmf-ca||string||_auto_|||Labels of z/OSMF root certificate authorities. Specify "_auto_" to let Zowe to detect automatically. This only works for RACF.
+zosmf-ca||string||_auto_|||Labels of z/OSMF root certificate authorities. Specify "_auto_" to let Zowe to detect automatically. This works for RACF and TSS.
 zosmf-user||string||IZUSVR|||z/OSMF user name. This is used to automatically detect z/OSMF root certificate authorities.
 ignore-security-failures||boolean|||||Whether to ignore security setup job failures.

--- a/bin/commands/certificate/keyring-jcl/generate/.parameters
+++ b/bin/commands/certificate/keyring-jcl/generate/.parameters
@@ -16,6 +16,6 @@ country||string|||||Country of certificate and certificate authority.
 validity||string|||||Validity days of certificate.
 trust-cas||string|||||Labels of extra certificate authorities should be trusted, separated by comma (Maximum 2).
 trust-zosmf||boolean|||||Whether to trust z/OSMF CA.
-zosmf-ca||string||_auto_|||Labels of z/OSMF root certificate authorities. Specify "_auto_" to let Zowe to detect automatically. This works for RACF and TSS.
+zosmf-ca||string||_auto_|||Labels of z/OSMF root certificate authorities. Specify `_auto_` to let Zowe to detect automatically. This works for RACF and TSS.
 zosmf-user||string||IZUSVR|||z/OSMF user name. This is used to automatically detect z/OSMF root certificate authorities.
 ignore-security-failures||boolean|||||Whether to ignore security setup job failures.

--- a/bin/commands/certificate/keyring-jcl/import-ds/.parameters
+++ b/bin/commands/certificate/keyring-jcl/import-ds/.parameters
@@ -7,7 +7,7 @@ keyring-name||string|required||||Name of the keyring.
 alias|a|string|required|localhost|||Certificate alias name.
 trust-cas||string|||||Labels of extra certificate authorities should be trusted, separated by comma (Maximum 2).
 trust-zosmf||boolean|||||Whether to trust z/OSMF CA.
-zosmf-ca||string||_auto_|||Labels of z/OSMF root certificate authorities. Specify "_auto_" to let Zowe to detect automatically. This only works for RACF.
+zosmf-ca||string||_auto_|||Labels of z/OSMF root certificate authorities. Specify "_auto_" to let Zowe to detect automatically. This works for RACF and TSS.
 zosmf-user||string||IZUSVR|||z/OSMF user name. This is used to automatically detect z/OSMF root certificate authorities.
 import-ds-name||string|required||||Name of the data set holds certificate to import into keyring.
 import-ds-password||string|required||||Password of the data set holds certificate to import.

--- a/bin/commands/certificate/keyring-jcl/import-ds/.parameters
+++ b/bin/commands/certificate/keyring-jcl/import-ds/.parameters
@@ -7,7 +7,7 @@ keyring-name||string|required||||Name of the keyring.
 alias|a|string|required|localhost|||Certificate alias name.
 trust-cas||string|||||Labels of extra certificate authorities should be trusted, separated by comma (Maximum 2).
 trust-zosmf||boolean|||||Whether to trust z/OSMF CA.
-zosmf-ca||string||_auto_|||Labels of z/OSMF root certificate authorities. Specify "_auto_" to let Zowe to detect automatically. This works for RACF and TSS.
+zosmf-ca||string||_auto_|||Labels of z/OSMF root certificate authorities. Specify `_auto_` to let Zowe to detect automatically. This works for RACF and TSS.
 zosmf-user||string||IZUSVR|||z/OSMF user name. This is used to automatically detect z/OSMF root certificate authorities.
 import-ds-name||string|required||||Name of the data set holds certificate to import into keyring.
 import-ds-password||string|required||||Password of the data set holds certificate to import.


### PR DESCRIPTION
<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [x] DCO signoffs have been added to all commits, including this PR

#### PR type

- [x] Feature <!-- non-breaking change which adds functionality -->

#### Relevant issues

Partially fixes #3362 

#### Changes proposed in this PR
`detect_zosmf_root_ca` is currently working only for `RACF`.
I have added functionality for `TSS`.
`ACF2` will be (or not) added in different PR.

#### Does this PR introduce a breaking change?

- [x] No

#### Does this PR do something the person installing Zowe should know about?

You can install Zowe under `TSS` with option `--zosmf-ca _auto_`

#### Other information

ACF2 is not working under `tsocmd`, however there is utility `ACFUNIX` to get very same behavior. Needs to be discussed.

VERSION:2.15.0
CHANGELOG:TSS supported for detection of z/OSMF Root CA.

