### PR TITLE
Update 2.x/master with 2.14.0 container fixes

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -12,9 +12,9 @@
   },
   "binaryDependencies": {
     "org.zowe.zlux.zlux-core": {
-      "version": "2.14.0-zlux-server-framework-PR-533",
+      "version": "2.15.0-zlux-app-server-PR-294",
       "repository": "libs-snapshot-local",
-      "artifact": "zlux-core-2.14.0-20240124.172356.pax"
+      "artifact": "zlux-core-2.15.0-20240201.143548.pax"
     },
     "org.zowe.zlux.sample-angular-app": {
       "version": "2.14.0-V2.X-RC",

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -12,9 +12,9 @@
   },
   "binaryDependencies": {
     "org.zowe.zlux.zlux-core": {
-      "version": "2.15.0-657-v2.x-staging-zlux-build",
+      "version": "2.14.0-RC",
       "repository": "libs-snapshot-local",
-      "artifact": "zlux-core-2.15.0-20240201.161145.pax"
+      "artifact": "zlux-core-2.14.0-20240202.143738.pax"
     },
     "org.zowe.zlux.sample-angular-app": {
       "version": "2.14.0-V2.X-RC",

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -14,7 +14,7 @@
     "org.zowe.zlux.zlux-core": {
       "version": "2.14.0-zlux-server-framework-PR-533",
       "repository": "libs-snapshot-local",
-      "artifact": "*.pax"
+      "artifact": "zlux-core-2.14.0-20240124.172356.pax"
     },
     "org.zowe.zlux.sample-angular-app": {
       "version": "2.14.0-V2.X-RC",

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -12,9 +12,9 @@
   },
   "binaryDependencies": {
     "org.zowe.zlux.zlux-core": {
-      "version": "2.14.0-RC",
+      "version": "2.14.0-zlux-server-framework-PR-533",
       "repository": "libs-snapshot-local",
-      "artifact": "zlux-core-2.14.0-20240119.184541.pax"
+      "artifact": "*.pax"
     },
     "org.zowe.zlux.sample-angular-app": {
       "version": "2.14.0-V2.X-RC",

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -12,9 +12,9 @@
   },
   "binaryDependencies": {
     "org.zowe.zlux.zlux-core": {
-      "version": "2.15.0-zlux-app-server-PR-294",
+      "version": "2.15.0-657-v2.x-staging-zlux-build",
       "repository": "libs-snapshot-local",
-      "artifact": "zlux-core-2.15.0-20240201.143548.pax"
+      "artifact": "zlux-core-2.15.0-20240201.161145.pax"
     },
     "org.zowe.zlux.sample-angular-app": {
       "version": "2.14.0-V2.X-RC",


### PR DESCRIPTION
Container fixes included; no re-build necessary. Containers were rebuilt and setup for distribution per https://github.com/zowe/zowe-install-packaging/issues/3285#issuecomment-1682396083 