### PR TITLE
allow custom properties in components.zowe

### DIFF
--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -857,7 +857,7 @@
         "zowe": {
           "type": "object",
           "description": "Component level overrides for top level Zowe network configuration.",
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "network": {
               "$ref": "#/$defs/networkSettings"


### PR DESCRIPTION
components.`componentname`.zowe is an area in the zowe.yaml which is meant for components to have whatever overrides they need, but which relate to zowe in some way.

in our schema, we detail certain values there we want to claim for our own purposes.
but everything else should be up to the extenders.
however, it seems the schema was not made in this way, we had the values set to "additionalProperties: false" and that conflicts with cases such as here https://github.com/zowe/zlux-app-server/pull/296