### PR TITLE
Fix help text for command

### DIFF
--- a/bin/commands/certificate/pkcs12/lock/.parameters
+++ b/bin/commands/certificate/pkcs12/lock/.parameters
@@ -1,4 +1,4 @@
 keystore-dir|d|string|required||||Keystore directory.
 user||string|required||||Owner of the keystore directory.
 group||string|required||||Group of the keystore directory.
-group-permission||string|||||Group permission. Can be <empty> for no permission, or `read`, `write`.
+group-permission||string|||||Group permission. Can be `<empty>` for no permission, or `read`, `write`.


### PR DESCRIPTION
add backtick to <empty> in the certificate/pkcs12/lock command help text.

The missing backtick was causing errors in the automated doc generation as part of release processing. The error was manually fixed in docs-site for the 2.15.0 release cycle.