### PR TITLE
Use labels to adjust CI behavior

### DIFF
--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -92,7 +92,7 @@ jobs:
   
   regular-build:
 
-    if: ${{ github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.run_build == 'true' }}
+    if: ${{ github.event_name != 'issue_comment' }} || steps.pr-comment-check.outputs.run_build 
     runs-on: ubuntu-latest
     needs: check-permission
     steps: 
@@ -147,35 +147,33 @@ jobs:
               console.error('Cannot read manifest or manifest is invalid.');
             }
 
-      - name: '[Prep 6a] Process github.event.inputs'
+      - name: '[Prep 6a] Process labels for ci build (pull, push, comment)'
         id: process-labels
+        if: github.event_name != 'workflow_dispatch'
         run: |
           BUILD_WHAT="PAX"
-          
-          echo INPUTS_BUILD_PSWI=${{ github.event.inputs.BUILD_PSWI }} >> $GITHUB_ENV
-          if [[ "${{ github.event.inputs.BUILD_PSWI }}" == true ]]; then
-            echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
+            
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: PSWI') }}" == true ]]; then
             BUILD_WHAT=$BUILD_WHAT", SMPE, PSWI"
           else
-            echo INPUTS_BUILD_SMPE=${{ github.event.inputs.BUILD_SMPE }} >> $GITHUB_ENV
-            if [[ "${{ github.event.inputs.BUILD_SMPE }}" == true ]]; then
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: SMPE') }}" == true ]]; then
               BUILD_WHAT=$BUILD_WHAT", SMPE"
             fi
           fi
 
-          echo INPUTS_BUILD_KUBERNETES=${{ github.event.inputs.BUILD_KUBERNETES }} >> $GITHUB_ENV
-          if [[ "${{ github.event.inputs.BUILD_KUBERNETES }}" == true ]]; then
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: Kubernetes') }}" == true ]]; then
             BUILD_WHAT=$BUILD_WHAT", K8S"
           fi
 
-          echo INPUTS_KEEP_TEMP_PAX_FOLDER=${{ github.event.inputs.KEEP_TEMP_PAX_FOLDER }} >> $GITHUB_ENV
-          
+          echo INPUTS_KEEP_TEMP_PAX_FOLDER="${{ contains(github.event.pull_request.labels.*.name, 'Build: Debug-Remote') }}" >> $GITHUB_ENV
+
           echo BUILD_WHAT=$BUILD_WHAT >> $GITHUB_OUTPUT
 
-      - name: '[Prep 6b] Process github.event.inputs'
+      - name: '[Prep 6b] Process github.event.inputs for manually triggered build'
         id: process-inputs
+        if: github.event_name == 'workflow_dispatch'
         run: |
-          BUILD_WHAT="PAX"
+          BUILD_WHAT="${{ steps.process-labels.outputs.BUILD_WHAT_LABELS }}"
           
           echo INPUTS_BUILD_PSWI=${{ github.event.inputs.BUILD_PSWI }} >> $GITHUB_ENV
           if [[ "${{ github.event.inputs.BUILD_PSWI }}" == true ]]; then
@@ -394,8 +392,8 @@ jobs:
       "${{ (github.event_name == 'pull_request' 
                 && !contains(github.event.pull_request.labels.*.name, 'Build: None') 
                 && !contains(github.event.pull_request.labels.*.name, 'Test: None')) || 
-          (github.event_name == 'push' && contains(github.ref, 'staging')) ||
-          (needs.pr-comment-check.outputs.run_build == 'true') }}"
+          (github.event_name == 'push' && contains(github.ref, 'staging')) }} ||
+          steps.pr-comment-check.outputs.run_build"
          
     steps:
       - name: 'Determine branch name'
@@ -410,13 +408,13 @@ jobs:
         id: get-test-suite
         run: |
           TEST_SUITE="Convenience Pax"
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Basic') }}" ]]; then
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Basic') }}" == true ]]; then
             TEST_SUITE="Convenience Pax"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: SMPE') }}" ]]; then
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: SMPE') }}" == true ]]; then
             TEST_SUITE="SMPE PTF"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Extended') }}" ]]; then
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Extended') }}" == true ]]; then
             TEST_SUITE="Zowe Nightly Tests"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Everything') }}" ]]; then
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Everything') }}" == true ]]; then
             TEST_SUITE="Zowe Release Tests"
           else 
             echo "Unknown test label encountered; defaulting to Convenience Pax."

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -156,19 +156,19 @@ jobs:
         run: |
           BUILD_WHAT="PAX"
             
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: PSWI') }}" == true ]]; then
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: PSWI') }}" == "true" ]]; then
             BUILD_WHAT=$BUILD_WHAT", SMPE, PSWI"
           else
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: SMPE') }}" == true ]]; then
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: SMPE') }}" == "true" ]]; then
               BUILD_WHAT=$BUILD_WHAT", SMPE"
             fi
           fi
 
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: Kubernetes') }}" == true ]]; then
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: Kubernetes') }}" == "true" ]]; then
             BUILD_WHAT=$BUILD_WHAT", K8S"
           fi
 
-          echo INPUTS_KEEP_TEMP_PAX_FOLDER="${{ contains(github.event.pull_request.labels.*.name, 'Build: Debug-Remote') }}" >> $GITHUB_ENV
+          echo "INPUTS_KEEP_TEMP_PAX_FOLDER=${{ contains(github.event.pull_request.labels.*.name, 'Build: Debug-Remote') }}" >> $GITHUB_ENV
 
           echo BUILD_WHAT=$BUILD_WHAT >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -62,6 +62,7 @@ jobs:
           echo "wfdispatch ${{ github.event_name == 'workflow_dispatch' }}"
           echo "build:none ${{ contains(github.event.pull_request.labels, 'Build: None') }}"
           echo "build:none by *.name ${{ contains(github.event.pull_request.labels.*.name, 'Build: None') }}"
+          echo "! build:none by *.name ${{ !contains(github.event.pull_request.labels.*.name, 'Build: None') }}"
           echo "test:none ${{ contains(github.event.pull_request.labels, 'Test: None') }}"
           echo "build:kuber ${{ contains(github.event.pull_request.labels.*.name, 'Build: Kubernetes') }}"
 
@@ -101,8 +102,8 @@ jobs:
   regular-build:
 
     if: |
-      "(${{ github.event_name != 'issue_comment' }} || steps.pr-comment-check.outputs.run_build) && 
-       (${{ github.event_name == 'workflow_dispatch' }} || ${{ !contains(github.event.pull_request.labels, 'Build: None') }})"
+      "(${{ github.event_name != 'issue_comment' }} || steps.pr-comment-check.outputs.run_build == 'true') && 
+       (${{ github.event_name == 'workflow_dispatch' }} || ${{ !contains(github.event.pull_request.labels.*.name, 'Build: None') }})"
     runs-on: ubuntu-latest
     needs: check-permission
     steps: 

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -46,7 +46,7 @@ jobs:
 
   pr-comment-check:
 
-    name: 'PR Comment Trigger'
+    name: 'PR Comment Check'
     runs-on: ubuntu-latest
     outputs:
       issue_run_ci: ${{ steps.check-comment.outputs.issue_run_ci }}

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -92,7 +92,8 @@ jobs:
   
   regular-build:
 
-    if: ${{ github.event_name != 'issue_comment' }} || steps.pr-comment-check.outputs.run_build 
+    if: |
+      "(${{ github.event_name != 'issue_comment' }} || steps.pr-comment-check.outputs.run_build) && ${{ !contains(github.event.pull_request.labels.*.name, 'Build: None') }}"
     runs-on: ubuntu-latest
     needs: check-permission
     steps: 

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -60,7 +60,7 @@ jobs:
   pr-comment-check:
 
     name: 'PR Comment Trigger'
-    if: ${{ github.event.issue.pull_request && github.event_name == 'issue_comment' }}
+    if: ${{ github.event_name == 'issue_comment' }}
     runs-on: ubuntu-latest
     outputs:
       run_build: ${{ steps.check-comment.outputs.run_build }}

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -73,7 +73,6 @@ jobs:
   pr-comment-check:
 
     name: 'PR Comment Trigger'
-    if: (github.event_name == 'issue_comment')
     runs-on: ubuntu-latest
     outputs:
       run_build: ${{ steps.check-comment.outputs.run_build }}
@@ -105,10 +104,9 @@ jobs:
   regular-build:
 
     if: |
-      "(${{ github.event_name != 'issue_comment' }} || steps.pr-comment-check.outputs.run_build == 'true') && 
-       (${{ github.event_name == 'workflow_dispatch' }} || ${{ !contains(github.event.pull_request.labels.*.name, 'Build: None') }})"
+      "${{ (github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.run_build == 'true') && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}"
     runs-on: ubuntu-latest
-    needs: check-permission
+    needs: [pr-comment-check, check-permission]
     steps: 
       - name: '[Prep 1] Checkout'
         uses: actions/checkout@v4

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -69,11 +69,10 @@ jobs:
         id: check-comment
         run: |
           echo "run_build=false" >> $GITHUB_OUTPUT
-          if [[ ${{ github.event.issue.pull_request }} && ${{ github.event_name == 'issue_comment' }} && ${{ github.event.comment.body }} = '@zowe-robot ci' ]]; then
+          if [[ ${{ github.event.issue.pull_request }} && ${{ github.event_name == 'issue_comment' }} && ${{ github.event.comment.body }} = '/ci' ]]; then
             echo "run_build=true" >> $GITHUB_OUTPUT
           fi     
 
- 
   display-dispatch-event-id:
     if: github.event.inputs.RANDOM_DISPATCH_EVENT_ID != ''
     runs-on: ubuntu-latest
@@ -93,7 +92,8 @@ jobs:
   regular-build:
 
     if: |
-      "(${{ github.event_name != 'issue_comment' }} || steps.pr-comment-check.outputs.run_build) && ${{ !contains(github.event.pull_request.labels.*.name, 'Build: None') }}"
+      "(${{ github.event_name != 'issue_comment' }} || steps.pr-comment-check.outputs.run_build) && 
+       (${{ github.event_name == 'workflow_dispatch' }} || ${{ !contains(github.event.pull_request.labels, 'Build: None') }})"
     runs-on: ubuntu-latest
     needs: check-permission
     steps: 

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -56,6 +56,15 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
+      - name: 'dump other logic tests'
+        run: |
+          echo "issue_comment ${{ github.event_name == 'issue_comment' }}"
+          echo "wfdispatch ${{ github.event_name == 'workflow_dispatch' }}"
+          echo "build:none ${{ contains(github.event.pull_request.labels, 'Build: None') }}"
+          echo "build:none by *.name ${{ contains(github.event.pull_request.labels.*.name, 'Build: None') }}"
+          echo "test:none ${{ contains(github.event.pull_request.labels, 'Test: None') }}"
+          echo "build:kuber ${{ contains(github.event.pull_request.labels.*.name, 'Build: Kubernetes') }}"
+
 
   pr-comment-check:
 

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -65,6 +65,9 @@ jobs:
           echo "! build:none by *.name ${{ !contains(github.event.pull_request.labels.*.name, 'Build: None') }}"
           echo "test:none ${{ contains(github.event.pull_request.labels, 'Test: None') }}"
           echo "build:kuber ${{ contains(github.event.pull_request.labels.*.name, 'Build: Kubernetes') }}"
+          echo "(${{ github.event_name != 'issue_comment' }} || steps.pr-comment-check.outputs.run_build == 'true') && 
+                 (${{ github.event_name == 'workflow_dispatch' }} || ${{ !contains(github.event.pull_request.labels.*.name, 'Build: None') }})"
+          echo "${{ (github.event_name != 'issue_comment' || steps.pr-comment-check.outputs.run_build == 'true') && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}"
 
 
   pr-comment-check:

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -108,7 +108,7 @@ jobs:
 
     if: |
       "${{ (github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.run_build == 'true') 
-        && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}"
+        && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}" == 'true'
     runs-on: ubuntu-latest
     needs: [pr-comment-check, check-permission]
     steps: 
@@ -410,7 +410,7 @@ jobs:
       "${{  ( github.event_name == 'push' && contains(github.ref, 'staging') ) ||
             ( (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && 
               !contains(github.event.pull_request.labels.*.name, 'Build: None') && 
-              !contains(github.event.pull_request.labels.*.name, 'Test: None') ) }}"
+              !contains(github.event.pull_request.labels.*.name, 'Test: None') ) }}" == 'true'
          
     steps:
       - name: 'Determine branch name'

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -157,14 +157,18 @@ jobs:
           BUILD_WHAT="PAX"
             
           if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: PSWI') }}" == "true" ]]; then
+            echo INPUTS_BUILD_PSWI=true >> $GITHUB_ENV
+            echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
             BUILD_WHAT=$BUILD_WHAT", SMPE, PSWI"
           else
             if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: SMPE') }}" == "true" ]]; then
+              echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
               BUILD_WHAT=$BUILD_WHAT", SMPE"
             fi
           fi
 
           if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: Kubernetes') }}" == "true" ]]; then
+            echo INPUTS_BUILD_KUBERNETES=true >> $GITHUB_ENV
             BUILD_WHAT=$BUILD_WHAT", K8S"
           fi
 

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -418,7 +418,7 @@ jobs:
           elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Silly') }}" == true ]]; then
             TEST_SUITE="Zowe Release Tests"
           else 
-            echo "Unknown test label encountered; defaulting to Convenience Pax."
+            echo "Unknown test label encountered; defaulting to 'Test: Basic' and running Convenience Pax tests."
           fi
           echo "TEST_SUITE=$TEST_SUITE" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -108,7 +108,7 @@ jobs:
 
     if: |
       "${{ (github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.run_build == 'true') 
-        && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}" == 'true'
+        && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}" == true
     runs-on: ubuntu-latest
     needs: [pr-comment-check, check-permission]
     steps: 
@@ -410,7 +410,7 @@ jobs:
       "${{  ( github.event_name == 'push' && contains(github.ref, 'staging') ) ||
             ( (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && 
               !contains(github.event.pull_request.labels.*.name, 'Build: None') && 
-              !contains(github.event.pull_request.labels.*.name, 'Test: None') ) }}" == 'true'
+              !contains(github.event.pull_request.labels.*.name, 'Test: None') ) }}" == true
          
     steps:
       - name: 'Determine branch name'

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -65,10 +65,10 @@ jobs:
           echo "! build:none by *.name ${{ !contains(github.event.pull_request.labels.*.name, 'Build: None') }}"
           echo "test:none ${{ contains(github.event.pull_request.labels, 'Test: None') }}"
           echo "build:kuber ${{ contains(github.event.pull_request.labels.*.name, 'Build: Kubernetes') }}"
-          echo "(${{ github.event_name != 'issue_comment' }} || steps.pr-comment-check.outputs.run_build == 'true') && 
-                 (${{ github.event_name == 'workflow_dispatch' }} || ${{ !contains(github.event.pull_request.labels.*.name, 'Build: None') }})"
-          echo "${{ (github.event_name != 'issue_comment' || steps.pr-comment-check.outputs.run_build == 'true') && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}"
-
+          echo "Run Build Step:"
+          echo "${{ (github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.run_build == 'true') && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}"
+          echo "Run Test Step:"
+          echo  "${{  ( github.event_name == 'push' && contains(github.ref, 'staging') ) || ( (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && !contains(github.event.pull_request.labels.*.name, 'Build: None') && !contains(github.event.pull_request.labels.*.name, 'Test: None') ) }}"
 
   pr-comment-check:
 
@@ -104,7 +104,8 @@ jobs:
   regular-build:
 
     if: |
-      "${{ (github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.run_build == 'true') && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}"
+      "${{ (github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.run_build == 'true') 
+        && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}"
     runs-on: ubuntu-latest
     needs: [pr-comment-check, check-permission]
     steps: 
@@ -403,11 +404,10 @@ jobs:
     needs: regular-build
     runs-on: ubuntu-latest
     if: |
-      "${{ (github.event_name == 'pull_request' 
-                && !contains(github.event.pull_request.labels.*.name, 'Build: None') 
-                && !contains(github.event.pull_request.labels.*.name, 'Test: None')) || 
-          (github.event_name == 'push' && contains(github.ref, 'staging')) }} ||
-          steps.pr-comment-check.outputs.run_build"
+      "${{  ( github.event_name == 'push' && contains(github.ref, 'staging') ) ||
+            ( (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && 
+              !contains(github.event.pull_request.labels.*.name, 'Build: None') && 
+              !contains(github.event.pull_request.labels.*.name, 'Test: None') ) }}"
          
     steps:
       - name: 'Determine branch name'
@@ -422,13 +422,13 @@ jobs:
         id: get-test-suite
         run: |
           TEST_SUITE="Convenience Pax"
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Basic') }}" == true ]]; then
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Basic') }}" = "true" ]]; then
             TEST_SUITE="Convenience Pax"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: SMPE') }}" == true ]]; then
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: SMPE') }}" = "true" ]]; then
             TEST_SUITE="SMPE PTF"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Extended') }}" == true ]]; then
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Extended') }}" = "true" ]]; then
             TEST_SUITE="Zowe Nightly Tests"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Silly') }}" == true ]]; then
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Silly') }}" = "true" ]]; then
             TEST_SUITE="Zowe Release Tests"
           else 
             echo "Unknown test label encountered; defaulting to 'Test: Basic' and running Convenience Pax tests."

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -56,14 +56,14 @@ jobs:
     name: 'PR Comment Trigger'
     runs-on: ubuntu-latest
     outputs:
-      run_build: ${{ steps.check-comment.outputs.run_build }}
+      issue_run_ci: ${{ steps.check-comment.outputs.issue_run_ci }}
     steps:
       - name: Check for a comment triggering a build
         id: check-comment
         run: |
-          echo "run_build=false" >> $GITHUB_OUTPUT
+          echo "issue_run_ci=false" >> $GITHUB_OUTPUT
           if [[ ! -z "${{ github.event.issue.pull_request }}" && ${{ github.event_name == 'issue_comment' }} && "${{ github.event.comment.body }}" = '/ci' ]]; then
-            echo "run_build=true" >> $GITHUB_OUTPUT
+            echo "issue_run_ci=true" >> $GITHUB_OUTPUT
           fi     
 
   dump-test:
@@ -88,6 +88,22 @@ jobs:
           echo "Run Test Step:"
           echo  "${{  ( github.event_name == 'push' && contains(github.ref, 'staging') ) || ( (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && !contains(github.event.pull_request.labels.*.name, 'Build: None') && !contains(github.event.pull_request.labels.*.name, 'Test: None') ) }}"
 
+  set-run-conditions:
+    runs-on: ubuntu-latest
+    needs: pr-comment-check
+    outputs:
+      should-build: ${{ steps.check-build.outputs.run_build }}
+      should-test: ${{ steps.check-test.outputs.run_test}}
+    steps:
+      - id: check-build
+        name: 'export conditional used to determine if we should run a build'
+        run: |
+          echo "run_build=${{ (github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.issue_run_ci == 'true') && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}" >> $GITHUB_OUTPUT
+      - id: check-test
+        name: 'export conditional used to determine if we should run a build'
+        run: |
+          echo "run_test=${{  ( github.event_name == 'push' && contains(github.ref, 'staging') ) || ( (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && !contains(github.event.pull_request.labels.*.name, 'Build: None') && !contains(github.event.pull_request.labels.*.name, 'Test: None') ) }}" >> $GITHUB_OUTPUT
+
   display-dispatch-event-id:
     if: github.event.inputs.RANDOM_DISPATCH_EVENT_ID != ''
     runs-on: ubuntu-latest
@@ -103,14 +119,12 @@ jobs:
         uses: zowe-actions/shared-actions/permission-check@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}  
-  
+
   regular-build:
 
-    if: |
-      "${{ (github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.run_build == 'true') 
-        && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}" == true
+    if: ${{ needs.set-run-conditions.outputs.should-build == 'true' }}
     runs-on: ubuntu-latest
-    needs: [pr-comment-check, check-permission]
+    needs: [set-run-conditions, check-permission]
     steps: 
       - name: '[Prep 1] Checkout'
         uses: actions/checkout@v4
@@ -404,14 +418,10 @@ jobs:
   # default running Convenience Pax on any zzow server
   call-integration-test:
 
-    needs: regular-build
+    needs: [set-run-conditions, regular-build]
     runs-on: ubuntu-latest
-    if: |
-      "${{  ( github.event_name == 'push' && contains(github.ref, 'staging') ) ||
-            ( (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && 
-              !contains(github.event.pull_request.labels.*.name, 'Build: None') && 
-              !contains(github.event.pull_request.labels.*.name, 'Test: None') ) }}" == true
-         
+    if: ${{ needs.set-run-conditions.outputs.should-test == 'true' }}
+
     steps:
       - name: 'Determine branch name'
         run: |

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -415,7 +415,7 @@ jobs:
             TEST_SUITE="SMPE PTF"
           elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Extended') }}" == true ]]; then
             TEST_SUITE="Zowe Nightly Tests"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Everything') }}" == true ]]; then
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Silly') }}" == true ]]; then
             TEST_SUITE="Zowe Release Tests"
           else 
             echo "Unknown test label encountered; defaulting to Convenience Pax."

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -81,7 +81,7 @@ jobs:
         id: check-comment
         run: |
           echo "run_build=false" >> $GITHUB_OUTPUT
-          if [[ ${{ github.event.issue.pull_request }} && ${{ github.event_name == 'issue_comment' }} && ${{ github.event.comment.body }} = '/ci' ]]; then
+          if [[ ! -z "${{ github.event.issue.pull_request }}" && ${{ github.event_name == 'issue_comment' }} && "${{ github.event.comment.body }}" = '/ci' ]]; then
             echo "run_build=true" >> $GITHUB_OUTPUT
           fi     
 

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -49,8 +49,26 @@ env:
 
 jobs:
 
+ 
+
+  pr-comment-check:
+
+    name: 'PR Comment Trigger'
+    runs-on: ubuntu-latest
+    outputs:
+      run_build: ${{ steps.check-comment.outputs.run_build }}
+    steps:
+      - name: Check for a comment triggering a build
+        id: check-comment
+        run: |
+          echo "run_build=false" >> $GITHUB_OUTPUT
+          if [[ ! -z "${{ github.event.issue.pull_request }}" && ${{ github.event_name == 'issue_comment' }} && "${{ github.event.comment.body }}" = '/ci' ]]; then
+            echo "run_build=true" >> $GITHUB_OUTPUT
+          fi     
+
   dump-test:
     runs-on: ubuntu-latest
+    needs: pr-comment-check
     steps:
       - name: 'dump $github'
         run: echo "$GITHUB_CONTEXT"
@@ -69,21 +87,6 @@ jobs:
           echo "${{ (github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.run_build == 'true') && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}"
           echo "Run Test Step:"
           echo  "${{  ( github.event_name == 'push' && contains(github.ref, 'staging') ) || ( (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && !contains(github.event.pull_request.labels.*.name, 'Build: None') && !contains(github.event.pull_request.labels.*.name, 'Test: None') ) }}"
-
-  pr-comment-check:
-
-    name: 'PR Comment Trigger'
-    runs-on: ubuntu-latest
-    outputs:
-      run_build: ${{ steps.check-comment.outputs.run_build }}
-    steps:
-      - name: Check for a comment triggering a build
-        id: check-comment
-        run: |
-          echo "run_build=false" >> $GITHUB_OUTPUT
-          if [[ ! -z "${{ github.event.issue.pull_request }}" && ${{ github.event_name == 'issue_comment' }} && "${{ github.event.comment.body }}" = '/ci' ]]; then
-            echo "run_build=true" >> $GITHUB_OUTPUT
-          fi     
 
   display-dispatch-event-id:
     if: github.event.inputs.RANDOM_DISPATCH_EVENT_ID != ''

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -60,7 +60,7 @@ jobs:
   pr-comment-check:
 
     name: 'PR Comment Trigger'
-    if: ${{ github.event_name == 'issue_comment' }}
+    if: (github.event_name == 'issue_comment')
     runs-on: ubuntu-latest
     outputs:
       run_build: ${{ steps.check-comment.outputs.run_build }}
@@ -98,7 +98,9 @@ jobs:
     needs: check-permission
     steps: 
       - name: '[Prep 1] Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
   
       - name: '[Prep 2] Setup jFrog CLI'
         uses: jfrog/setup-jfrog-cli@v2

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -12,6 +12,8 @@ on:
       - v2.x/staging 
   pull_request:
     types: [opened, synchronize]
+  issue_comment:
+    types: [created, edited]
 
   workflow_dispatch:
     inputs:
@@ -40,7 +42,38 @@ on:
         required: false
         type: string
 
+env:
+  BUILD_LABEL: 'see-regular-build-prepare-6a'
+  TEST_LABEL: 'see-call-integration-test-prepare'
+  ISSUE_COMMENT_RUN_BUILD: false
+
 jobs:
+
+  dump-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'dump $github'
+        run: echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+
+  pr-comment-check:
+
+    name: 'PR Comment Trigger'
+    if: ${{ github.event.issue.pull_request && github.event_name == 'issue_comment' }}
+    runs-on: ubuntu-latest
+    outputs:
+      run_build: ${{ steps.check-comment.outputs.run_build }}
+    steps:
+      - name: Check for a comment triggering a build
+        id: check-comment
+        run: |
+          echo "run_build=false" >> $GITHUB_OUTPUT
+          if [[ ${{ github.event.issue.pull_request }} && ${{ github.event_name == 'issue_comment' }} && ${{ github.event.comment.body }} = '@zowe-robot ci' ]]; then
+            echo "run_build=true" >> $GITHUB_OUTPUT
+          fi     
+
+ 
   display-dispatch-event-id:
     if: github.event.inputs.RANDOM_DISPATCH_EVENT_ID != ''
     runs-on: ubuntu-latest
@@ -58,6 +91,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}  
   
   regular-build:
+
+    if: ${{ github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.run_build == 'true' }}
     runs-on: ubuntu-latest
     needs: check-permission
     steps: 
@@ -112,7 +147,32 @@ jobs:
               console.error('Cannot read manifest or manifest is invalid.');
             }
 
-      - name: '[Prep 6] Process github.event.inputs'
+      - name: '[Prep 6a] Process github.event.inputs'
+        id: process-labels
+        run: |
+          BUILD_WHAT="PAX"
+          
+          echo INPUTS_BUILD_PSWI=${{ github.event.inputs.BUILD_PSWI }} >> $GITHUB_ENV
+          if [[ "${{ github.event.inputs.BUILD_PSWI }}" == true ]]; then
+            echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
+            BUILD_WHAT=$BUILD_WHAT", SMPE, PSWI"
+          else
+            echo INPUTS_BUILD_SMPE=${{ github.event.inputs.BUILD_SMPE }} >> $GITHUB_ENV
+            if [[ "${{ github.event.inputs.BUILD_SMPE }}" == true ]]; then
+              BUILD_WHAT=$BUILD_WHAT", SMPE"
+            fi
+          fi
+
+          echo INPUTS_BUILD_KUBERNETES=${{ github.event.inputs.BUILD_KUBERNETES }} >> $GITHUB_ENV
+          if [[ "${{ github.event.inputs.BUILD_KUBERNETES }}" == true ]]; then
+            BUILD_WHAT=$BUILD_WHAT", K8S"
+          fi
+
+          echo INPUTS_KEEP_TEMP_PAX_FOLDER=${{ github.event.inputs.KEEP_TEMP_PAX_FOLDER }} >> $GITHUB_ENV
+          
+          echo BUILD_WHAT=$BUILD_WHAT >> $GITHUB_OUTPUT
+
+      - name: '[Prep 6b] Process github.event.inputs'
         id: process-inputs
         run: |
           BUILD_WHAT="PAX"
@@ -327,9 +387,16 @@ jobs:
   # only run auto integration tests when the workflow is triggered by pull request
   # default running Convenience Pax on any zzow server
   call-integration-test:
+
     needs: regular-build
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && contains(github.ref, 'staging'))
+    if: |
+      "${{ (github.event_name == 'pull_request' 
+                && !contains(github.event.pull_request.labels.*.name, 'Build: None') 
+                && !contains(github.event.pull_request.labels.*.name, 'Test: None')) || 
+          (github.event_name == 'push' && contains(github.ref, 'staging')) ||
+          (needs.pr-comment-check.outputs.run_build == 'true') }}"
+         
     steps:
       - name: 'Determine branch name'
         run: |
@@ -338,6 +405,23 @@ jobs:
           else
             echo "BRANCH_NAME=$(echo ${GITHUB_REF_NAME})" >> $GITHUB_ENV
           fi
+
+      - name: 'Determine test suite'
+        id: get-test-suite
+        run: |
+          TEST_SUITE="Convenience Pax"
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Basic') }}" ]]; then
+            TEST_SUITE="Convenience Pax"
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: SMPE') }}" ]]; then
+            TEST_SUITE="SMPE PTF"
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Extended') }}" ]]; then
+            TEST_SUITE="Zowe Nightly Tests"
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Everything') }}" ]]; then
+            TEST_SUITE="Zowe Release Tests"
+          else 
+            echo "Unknown test label encountered; defaulting to Convenience Pax."
+          fi
+          echo "TEST_SUITE=$TEST_SUITE" >> $GITHUB_OUTPUT
 
       - name: 'Call test workflow'
         uses: zowe-actions/shared-actions/workflow-remote-call-wait@main
@@ -349,7 +433,7 @@ jobs:
           workflow-filename: cicd-test.yml
           branch-name: ${{ env.BRANCH_NAME }}
           poll-frequency: 3
-          inputs-json-string: '{"custom-zowe-artifactory-pattern-or-build-number":"${{ github.run_number }}"}'
+          inputs-json-string: '{"custom-zowe-artifactory-pattern-or-build-number":"${{ github.run_number }}", "install-test": "${{ steps.get-test-suite.outputs.TEST_SUITE }}"}'
         # env:
         #   DEBUG: 'workflow-remote-call-wait'
       

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -42,14 +42,7 @@ on:
         required: false
         type: string
 
-env:
-  BUILD_LABEL: 'see-regular-build-prepare-6a'
-  TEST_LABEL: 'see-call-integration-test-prepare'
-  ISSUE_COMMENT_RUN_BUILD: false
-
 jobs:
-
- 
 
   pr-comment-check:
 

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -59,28 +59,6 @@ jobs:
             echo "issue_run_ci=true" >> $GITHUB_OUTPUT
           fi     
 
-  dump-test:
-    runs-on: ubuntu-latest
-    needs: pr-comment-check
-    steps:
-      - name: 'dump $github'
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-      - name: 'dump other logic tests'
-        run: |
-          echo "issue_comment ${{ github.event_name == 'issue_comment' }}"
-          echo "wfdispatch ${{ github.event_name == 'workflow_dispatch' }}"
-          echo "build:none ${{ contains(github.event.pull_request.labels, 'Build: None') }}"
-          echo "build:none by *.name ${{ contains(github.event.pull_request.labels.*.name, 'Build: None') }}"
-          echo "! build:none by *.name ${{ !contains(github.event.pull_request.labels.*.name, 'Build: None') }}"
-          echo "test:none ${{ contains(github.event.pull_request.labels, 'Test: None') }}"
-          echo "build:kuber ${{ contains(github.event.pull_request.labels.*.name, 'Build: Kubernetes') }}"
-          echo "Run Build Step:"
-          echo "${{ (github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.run_build == 'true') && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}"
-          echo "Run Test Step:"
-          echo  "${{  ( github.event_name == 'push' && contains(github.ref, 'staging') ) || ( (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && !contains(github.event.pull_request.labels.*.name, 'Build: None') && !contains(github.event.pull_request.labels.*.name, 'Test: None') ) }}"
-
   set-run-conditions:
     runs-on: ubuntu-latest
     needs: pr-comment-check
@@ -93,7 +71,7 @@ jobs:
         run: |
           echo "run_build=${{ (github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.issue_run_ci == 'true') && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}" >> $GITHUB_OUTPUT
       - id: check-test
-        name: 'export conditional used to determine if we should run a build'
+        name: 'export conditional used to determine if we should run a test suite'
         run: |
           echo "run_test=${{  ( github.event_name == 'push' && contains(github.ref, 'staging') ) || ( (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && !contains(github.event.pull_request.labels.*.name, 'Build: None') && !contains(github.event.pull_request.labels.*.name, 'Test: None') ) }}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Addresses #3123 

This PR updates existing build and packaging automation to modify their behavior based on labels add to the PR. The labels are only effective for builds triggered from pull requests (manually triggered builds will ignore all labels). This PR does not protect you from invalid combinations of build and test; i.e. Build: PAX and Test: SMP/e will fail.

 The following labels and features are added:

Build Labels:
* Build: None
* __Build: PAX__ (default)
* Build: SMPE
* Build: PSWI
* Build: Kubernetes
* Build: Debug-Remote

`Build: None` will supersede other build labels; the rest of the build labels act by composition. `Build: PSWI` auto-includes SMP/e, as SMP/e is required to build the PSWI. Using both `Build: SMPE` and `Build: PSWI` will create just the one PSWI. `Build: Debug-Remote` is a special label that can retain some server-side build information for additional debugging. Please check with the Systems squad before adding this label.

Test Labels:
* Test: None
* __Test: Basic__ (default)
* Test: SMPE
* Test: Extended
* Test: Silly (Release Tests; about 5 hours to complete)

Tests do _not_ work by composition, and instead will default to the smallest test suite by specified label. Test composition requires far more refactoring, so the work on that is deferred pending requirement from other squads. The decision to default to the least amount of testing is to avoid locking up our systems unnecessarily. 

Test triggers:

Adding and removing labels _will not trigger a build_, as this can kick off too many long-running builds in sequence. Instead, commenting on the pr with `/ci` will trigger the build. Editing the message in-place will also trigger a build. The expected developer workflow is to open a PR, decide if any non-default labels better apply to their PR, add them, and then trigger a build with `/ci`. 

