### PR TITLE
Updates to `/ci` behavior

### DIFF
--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -290,7 +290,7 @@ jobs:
         id: pax-prep
         run: |
           if [ "${{ env.INPUTS_BUILD_SMPE }}" == "true" ] || [ "${{ env.INPUTS_BUILD_PSWI }}" == "true" ] ; then
-            if [[ "${{ github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH }}" == ""]]; then
+            if [[ "${{ github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH }}" == "" ]]; then
               echo EXTRA_FILES=zowe-smpe.zip,fmid.zip,pd.htm,smpe-promote.tar,smpe-build-logs.pax.Z,rename-back.sh >> $GITHUB_OUTPUT
               echo BUILD_SMPE=yes >> $GITHUB_OUTPUT
             else

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: false
         type: boolean
+      PSWI_SMPE_ARTIFACTORY_PATH:
+        description: 'Artifactory path to find an already-built Zowe SMPE package, instead of building from scratch'
+        required: false
+        default: ''
+        type: string
       KEEP_TEMP_PAX_FOLDER:
         description: 'do we need to keep temp pax folder?'
         required: false
@@ -198,8 +203,13 @@ jobs:
           
           echo INPUTS_BUILD_PSWI=${{ github.event.inputs.BUILD_PSWI }} >> $GITHUB_ENV
           if [[ "${{ github.event.inputs.BUILD_PSWI }}" == true ]]; then
-            echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
-            BUILD_WHAT=$BUILD_WHAT", SMPE, PSWI"
+            if [[ "${{ github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH }}" == ""]]; then
+              echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
+              BUILD_WHAT=$BUILD_WHAT", SMPE, PSWI"
+            else
+              echo INPUTS_BUILD_SMPE=false >> $GITHUB_ENV
+              BUILD_WHAT="PSWI"
+            fi
           else
             echo INPUTS_BUILD_SMPE=${{ github.event.inputs.BUILD_SMPE }} >> $GITHUB_ENV
             if [[ "${{ github.event.inputs.BUILD_SMPE }}" == true ]]; then
@@ -280,8 +290,13 @@ jobs:
         id: pax-prep
         run: |
           if [ "${{ env.INPUTS_BUILD_SMPE }}" == "true" ] || [ "${{ env.INPUTS_BUILD_PSWI }}" == "true" ] ; then
-            echo EXTRA_FILES=zowe-smpe.zip,fmid.zip,pd.htm,smpe-promote.tar,smpe-build-logs.pax.Z,rename-back.sh >> $GITHUB_OUTPUT
-            echo BUILD_SMPE=yes >> $GITHUB_OUTPUT
+            if [[ "${{ github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH }}" == ""]]; then
+              echo EXTRA_FILES=zowe-smpe.zip,fmid.zip,pd.htm,smpe-promote.tar,smpe-build-logs.pax.Z,rename-back.sh >> $GITHUB_OUTPUT
+              echo BUILD_SMPE=yes >> $GITHUB_OUTPUT
+            else
+              echo EXTRA_FILES= >> $GITHUB_OUTPUT
+              echo BUILD_SMPE= >> $GITHUB_OUTPUT
+            fi
           else
             echo EXTRA_FILES= >> $GITHUB_OUTPUT
             echo BUILD_SMPE= >> $GITHUB_OUTPUT
@@ -295,6 +310,7 @@ jobs:
 
       - name: '[PAX/SMPE Pax 2] Packaging'
         timeout-minutes: 60
+        if: env.INPUTS_BUILD_PSWI != 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '')
         uses: zowe-actions/shared-actions/make-pax@main
         with: 
           pax-name: zowe
@@ -309,7 +325,7 @@ jobs:
             KEEP_TEMP_FOLDER=${{ steps.pax-prep.outputs.KEEP_TEMP_FOLDER }}
 
       - name: '[SMPE Pax 3] Post-make pax'
-        if: env.INPUTS_BUILD_SMPE == 'true' || env.INPUTS_BUILD_PSWI == 'true'
+        if: env.INPUTS_BUILD_SMPE == 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '')
         run: |
           cd .pax
           chmod +x rename-back.sh
@@ -324,6 +340,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lock-resource-name: zowe-psi-build-zzow07-lock
           lock-avg-retry-interval: 60
+
+      - name: '[PSWI 0] PSWI pre-build check for existing smpe'
+        if: env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH != ''
+        run: |
+          jfrog rt dl libs-release-local/org/zowe/2.0.0/zowe-smpe-*.zip --flat=true .pax/AZWE002.zip
+          jfrog rt dl ${{github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH}}/zowe-smpe-*.zip --flat=true .pax/zowe-smpe.zip
+
 
       - name: '[SMPE Pax 4] Build PSWI'
         if: env.INPUTS_BUILD_PSWI == 'true'

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -101,6 +101,8 @@ jobs:
         run: |
           echo ${{ steps.check-build.outputs.run_build == 'true' }}
           echo ${{ steps.check-build.outputs.run_build == 'false' }}
+          echo ${{ steps.get-labels.outputs.result }}
+          echo ${{ fromJson(steps.get-labels.outputs.result) }}
           echo ${{ contains(fromJson(steps.get-labels.outputs.result), 'Test: None') }}
           echo "run_test=${{ (steps.check-build.outputs.run_build == 'true' && !contains(fromJson(steps.get-labels.outputs.result), 'Test: None')) }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -73,7 +73,10 @@ jobs:
       - id: check-test
         name: 'export conditional used to determine if we should run a test suite'
         run: |
-          echo "run_test=${{  steps.check-build.outputs.run_build == 'true' && !contains(github.event.pull_request.labels.*.name, 'Test: None') }}" >> $GITHUB_OUTPUT
+          echo ${{ steps.check-build.outputs.run_build == 'true' }}
+          echo ${{ !contains(github.event.pull_request.labels.*.name, 'Test: None') }}
+          echo ${{ contains(github.event.pull_request.labels.*.name, 'Test: None') != 'true' }}
+          echo "run_test=${{  steps.check-build.outputs.run_build == 'true' && contains(github.event.pull_request.labels.*.name, 'Test: None') != 'true' }}" >> $GITHUB_OUTPUT
 
   display-dispatch-event-id:
     if: github.event.inputs.RANDOM_DISPATCH_EVENT_ID != ''

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -31,12 +31,12 @@ on:
         default: false
         type: boolean
       PSWI_SMPE_ARTIFACTORY_PATH:
-        description: 'Set both this and AZWE_ARTIFACTORY_PATH. This is the Artifactory path to find an already-built Zowe SMPE package, instead of building from scratch'
+        description: 'Optional. Artifactory path to a pre-built SMP/e artifact.'
         required: false
         default: ''
         type: string
       PSWI_SMPE_AZWE_ARTIFACTORY_PATH:
-        description: 'Set both this and SMPE_ARTIFACTORY_PATH. This is the Artifactory path to find a pre-built AZWE FMID, instead of building from scratch'
+        description: 'Optional. Artifactory path to a pre-built pre-built AZWE FMID.'
         required: false
         default: ''
         type: string
@@ -315,7 +315,7 @@ jobs:
 
       - name: '[PAX/SMPE Pax 2] Packaging'
         timeout-minutes: 60
-        if: env.INPUTS_BUILD_PSWI != 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH != '')
+        if: env.INPUTS_BUILD_PSWI != 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH == '')
         uses: zowe-actions/shared-actions/make-pax@main
         with: 
           pax-name: zowe
@@ -330,7 +330,7 @@ jobs:
             KEEP_TEMP_FOLDER=${{ steps.pax-prep.outputs.KEEP_TEMP_FOLDER }}
 
       - name: '[SMPE Pax 3] Post-make pax'
-        if: env.INPUTS_BUILD_SMPE == 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH != '')
+        if: env.INPUTS_BUILD_SMPE == 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH == '')
         run: |
           cd .pax
           chmod +x rename-back.sh

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -99,11 +99,6 @@ jobs:
       - id: check-test
         name: 'export conditional used to determine if we should run a test suite'
         run: |
-          echo ${{ steps.check-build.outputs.run_build == 'true' }}
-          echo ${{ steps.check-build.outputs.run_build == 'false' }}
-          echo ${{ steps.get-labels.outputs.result }}
-          echo ${{ fromJson(steps.get-labels.outputs.result) }}
-          echo ${{ contains(fromJson(steps.get-labels.outputs.result), 'Test: None') }}
           echo "run_test=${{ (steps.check-build.outputs.run_build == 'true' && !contains(fromJson(steps.get-labels.outputs.result), 'Test: None')) }}" >> $GITHUB_OUTPUT
 
   display-dispatch-event-id:

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -77,7 +77,8 @@ jobs:
           echo ${{ !contains(github.event.pull_request.labels.*.name, 'Test: None') }}
           echo ${{ contains(github.event.pull_request.labels.*.name, 'Test: None') == 'true' }}
           echo ${{  steps.check-build.outputs.run_build == 'true' && contains(github.event.pull_request.labels.*.name, 'Test: None') != 'true' }}
-          echo "run_test=${{  steps.check-build.outputs.run_build == 'true' && contains(github.event.pull_request.labels.*.name, 'Test: None') != 'true' }}" >> $GITHUB_OUTPUT
+          echo ${{ (steps.check-build.outputs.run_build == 'true' && !contains(github.event.pull_request.labels.*.name, 'Test: None')) }}
+          echo "run_test=${{ (steps.check-build.outputs.run_build == 'true' && !contains(github.event.pull_request.labels.*.name, 'Test: None')) }}" >> $GITHUB_OUTPUT
 
   display-dispatch-event-id:
     if: github.event.inputs.RANDOM_DISPATCH_EVENT_ID != ''

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -73,11 +73,6 @@ jobs:
       - id: check-test
         name: 'export conditional used to determine if we should run a test suite'
         run: |
-          echo ${{ steps.check-build.outputs.run_build == 'true' }}
-          echo ${{ !contains(github.event.pull_request.labels.*.name, 'Test: None') }}
-          echo ${{ contains(github.event.pull_request.labels.*.name, 'Test: None') == 'true' }}
-          echo ${{  steps.check-build.outputs.run_build == 'true' && contains(github.event.pull_request.labels.*.name, 'Test: None') != 'true' }}
-          echo ${{ (steps.check-build.outputs.run_build == 'true' && !contains(github.event.pull_request.labels.*.name, 'Test: None')) }}
           echo "run_test=${{ (steps.check-build.outputs.run_build == 'true' && !contains(github.event.pull_request.labels.*.name, 'Test: None')) }}" >> $GITHUB_OUTPUT
 
   display-dispatch-event-id:

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -76,6 +76,7 @@ jobs:
           echo ${{ steps.check-build.outputs.run_build == 'true' }}
           echo ${{ !contains(github.event.pull_request.labels.*.name, 'Test: None') }}
           echo ${{ contains(github.event.pull_request.labels.*.name, 'Test: None') != 'true' }}
+          echo ${{  steps.check-build.outputs.run_build == 'true' && contains(github.event.pull_request.labels.*.name, 'Test: None') != 'true' }}
           echo "run_test=${{  steps.check-build.outputs.run_build == 'true' && contains(github.event.pull_request.labels.*.name, 'Test: None') != 'true' }}" >> $GITHUB_OUTPUT
 
   display-dispatch-event-id:

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -12,8 +12,6 @@ on:
       - v2.x/staging 
   pull_request:
     types: [opened, synchronize]
-  issue_comment:
-    types: [created, edited]
 
   workflow_dispatch:
     inputs:
@@ -32,6 +30,16 @@ on:
         required: false
         default: false
         type: boolean
+      PSWI_SMPE_ARTIFACTORY_PATH:
+        description: 'Optional. Artifactory path to a pre-built SMP/e artifact.'
+        required: false
+        default: ''
+        type: string
+      PSWI_SMPE_AZWE_ARTIFACTORY_PATH:
+        description: 'Optional. Artifactory path to a pre-built pre-built AZWE FMID.'
+        required: false
+        default: ''
+        type: string
       KEEP_TEMP_PAX_FOLDER:
         description: 'do we need to keep temp pax folder?'
         required: false
@@ -44,36 +52,13 @@ on:
 
 jobs:
 
-  pr-comment-check:
-
-    name: 'PR Comment Check'
+  dump-context:
     runs-on: ubuntu-latest
-    outputs:
-      issue_run_ci: ${{ steps.check-comment.outputs.issue_run_ci }}
     steps:
-      - name: Check for a comment triggering a build
-        id: check-comment
-        run: |
-          echo "issue_run_ci=false" >> $GITHUB_OUTPUT
-          if [[ ! -z "${{ github.event.issue.pull_request }}" && ${{ github.event_name == 'issue_comment' }} && "${{ github.event.comment.body }}" = '/ci' ]]; then
-            echo "issue_run_ci=true" >> $GITHUB_OUTPUT
-          fi     
-
-  set-run-conditions:
-    runs-on: ubuntu-latest
-    needs: pr-comment-check
-    outputs:
-      should-build: ${{ steps.check-build.outputs.run_build }}
-      should-test: ${{ steps.check-test.outputs.run_test}}
-    steps:
-      - id: check-build
-        name: 'export conditional used to determine if we should run a build'
-        run: |
-          echo "run_build=${{ (github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.issue_run_ci == 'true') && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}" >> $GITHUB_OUTPUT
-      - id: check-test
-        name: 'export conditional used to determine if we should run a test suite'
-        run: |
-          echo "run_test=${{ (steps.check-build.outputs.run_build == 'true' && !contains(github.event.pull_request.labels.*.name, 'Test: None')) }}" >> $GITHUB_OUTPUT
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
 
   display-dispatch-event-id:
     if: github.event.inputs.RANDOM_DISPATCH_EVENT_ID != ''
@@ -90,17 +75,13 @@ jobs:
         uses: zowe-actions/shared-actions/permission-check@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}  
-
+  
   regular-build:
-
-    if: ${{ needs.set-run-conditions.outputs.should-build == 'true' }}
     runs-on: ubuntu-latest
-    needs: [set-run-conditions, check-permission]
+    needs: check-permission
     steps: 
       - name: '[Prep 1] Checkout'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
+        uses: actions/checkout@v2
   
       - name: '[Prep 2] Setup jFrog CLI'
         uses: jfrog/setup-jfrog-cli@v2
@@ -150,42 +131,20 @@ jobs:
               console.error('Cannot read manifest or manifest is invalid.');
             }
 
-      - name: '[Prep 6a] Process labels for ci build (pull, push, comment)'
-        id: process-labels
-        if: github.event_name != 'workflow_dispatch'
+      - name: '[Prep 6] Process github.event.inputs'
+        id: process-inputs
         run: |
           BUILD_WHAT="PAX"
-            
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: PSWI') }}" == "true" ]]; then
-            echo INPUTS_BUILD_PSWI=true >> $GITHUB_ENV
-            echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
-            BUILD_WHAT=$BUILD_WHAT", SMPE, PSWI"
-          else
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: SMPE') }}" == "true" ]]; then
-              echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
-              BUILD_WHAT=$BUILD_WHAT", SMPE"
-            fi
-          fi
-
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: Kubernetes') }}" == "true" ]]; then
-            echo INPUTS_BUILD_KUBERNETES=true >> $GITHUB_ENV
-            BUILD_WHAT=$BUILD_WHAT", K8S"
-          fi
-
-          echo "INPUTS_KEEP_TEMP_PAX_FOLDER=${{ contains(github.event.pull_request.labels.*.name, 'Build: Debug-Remote') }}" >> $GITHUB_ENV
-
-          echo BUILD_WHAT=$BUILD_WHAT >> $GITHUB_OUTPUT
-
-      - name: '[Prep 6b] Process github.event.inputs for manually triggered build'
-        id: process-inputs
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          BUILD_WHAT="${{ steps.process-labels.outputs.BUILD_WHAT_LABELS }}"
           
           echo INPUTS_BUILD_PSWI=${{ github.event.inputs.BUILD_PSWI }} >> $GITHUB_ENV
           if [[ "${{ github.event.inputs.BUILD_PSWI }}" == true ]]; then
-            echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
-            BUILD_WHAT=$BUILD_WHAT", SMPE, PSWI"
+            if [[ "${{ github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH }}" == "" ]]; then
+              echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
+              BUILD_WHAT=$BUILD_WHAT", SMPE, PSWI"
+            else
+              echo INPUTS_BUILD_SMPE=false >> $GITHUB_ENV
+              BUILD_WHAT="PSWI"
+            fi
           else
             echo INPUTS_BUILD_SMPE=${{ github.event.inputs.BUILD_SMPE }} >> $GITHUB_ENV
             if [[ "${{ github.event.inputs.BUILD_SMPE }}" == true ]]; then
@@ -266,8 +225,13 @@ jobs:
         id: pax-prep
         run: |
           if [ "${{ env.INPUTS_BUILD_SMPE }}" == "true" ] || [ "${{ env.INPUTS_BUILD_PSWI }}" == "true" ] ; then
-            echo EXTRA_FILES=zowe-smpe.zip,fmid.zip,pd.htm,smpe-promote.tar,smpe-build-logs.pax.Z,rename-back.sh >> $GITHUB_OUTPUT
-            echo BUILD_SMPE=yes >> $GITHUB_OUTPUT
+            if [[ "${{ github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH }}" == "" || "${{github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH}}" == "" ]]; then
+              echo EXTRA_FILES=zowe-smpe.zip,fmid.zip,pd.htm,smpe-promote.tar,smpe-build-logs.pax.Z,rename-back.sh >> $GITHUB_OUTPUT
+              echo BUILD_SMPE=yes >> $GITHUB_OUTPUT
+            else
+              echo EXTRA_FILES= >> $GITHUB_OUTPUT
+              echo BUILD_SMPE= >> $GITHUB_OUTPUT
+            fi
           else
             echo EXTRA_FILES= >> $GITHUB_OUTPUT
             echo BUILD_SMPE= >> $GITHUB_OUTPUT
@@ -281,6 +245,7 @@ jobs:
 
       - name: '[PAX/SMPE Pax 2] Packaging'
         timeout-minutes: 60
+        if: env.INPUTS_BUILD_PSWI != 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH == '')
         uses: zowe-actions/shared-actions/make-pax@main
         with: 
           pax-name: zowe
@@ -295,7 +260,7 @@ jobs:
             KEEP_TEMP_FOLDER=${{ steps.pax-prep.outputs.KEEP_TEMP_FOLDER }}
 
       - name: '[SMPE Pax 3] Post-make pax'
-        if: env.INPUTS_BUILD_SMPE == 'true' || env.INPUTS_BUILD_PSWI == 'true'
+        if: env.INPUTS_BUILD_SMPE == 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH == '')
         run: |
           cd .pax
           chmod +x rename-back.sh
@@ -310,6 +275,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lock-resource-name: zowe-psi-build-zzow07-lock
           lock-avg-retry-interval: 60
+
+      - name: '[PSWI 0] PSWI pre-build check for existing smpe'
+        if: env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH != '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH != ''
+        run: |
+          jfrog rt dl ${{github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH}}/AZWE002*.zip --flat=true .pax/AZWE002.zip
+          jfrog rt dl ${{github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH}}/zowe-smpe-*.zip --flat=true .pax/zowe-smpe.zip
+
 
       - name: '[SMPE Pax 4] Build PSWI'
         if: env.INPUTS_BUILD_PSWI == 'true'
@@ -392,11 +364,9 @@ jobs:
   # only run auto integration tests when the workflow is triggered by pull request
   # default running Convenience Pax on any zzow server
   call-integration-test:
-
-    needs: [set-run-conditions, regular-build]
+    needs: regular-build
     runs-on: ubuntu-latest
-    if: ${{ needs.set-run-conditions.outputs.should-test == 'true' }}
-
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && contains(github.ref, 'staging'))
     steps:
       - name: 'Determine branch name'
         run: |
@@ -405,23 +375,6 @@ jobs:
           else
             echo "BRANCH_NAME=$(echo ${GITHUB_REF_NAME})" >> $GITHUB_ENV
           fi
-
-      - name: 'Determine test suite'
-        id: get-test-suite
-        run: |
-          TEST_SUITE="Convenience Pax"
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Basic') }}" = "true" ]]; then
-            TEST_SUITE="Convenience Pax"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: SMPE') }}" = "true" ]]; then
-            TEST_SUITE="SMPE PTF"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Extended') }}" = "true" ]]; then
-            TEST_SUITE="Zowe Nightly Tests"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Silly') }}" = "true" ]]; then
-            TEST_SUITE="Zowe Release Tests"
-          else 
-            echo "Unknown test label encountered; defaulting to 'Test: Basic' and running Convenience Pax tests."
-          fi
-          echo "TEST_SUITE=$TEST_SUITE" >> $GITHUB_OUTPUT
 
       - name: 'Call test workflow'
         uses: zowe-actions/shared-actions/workflow-remote-call-wait@main
@@ -433,7 +386,7 @@ jobs:
           workflow-filename: cicd-test.yml
           branch-name: ${{ env.BRANCH_NAME }}
           poll-frequency: 3
-          inputs-json-string: '{"custom-zowe-artifactory-pattern-or-build-number":"${{ github.run_number }}", "install-test": "${{ steps.get-test-suite.outputs.TEST_SUITE }}"}'
+          inputs-json-string: '{"custom-zowe-artifactory-pattern-or-build-number":"${{ github.run_number }}"}'
         # env:
         #   DEBUG: 'workflow-remote-call-wait'
       

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -203,7 +203,7 @@ jobs:
           
           echo INPUTS_BUILD_PSWI=${{ github.event.inputs.BUILD_PSWI }} >> $GITHUB_ENV
           if [[ "${{ github.event.inputs.BUILD_PSWI }}" == true ]]; then
-            if [[ "${{ github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH }}" == ""]]; then
+            if [[ "${{ github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH }}" == "" ]]; then
               echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
               BUILD_WHAT=$BUILD_WHAT", SMPE, PSWI"
             else

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -73,7 +73,7 @@ jobs:
       - id: check-test
         name: 'export conditional used to determine if we should run a test suite'
         run: |
-          echo "run_test=${{  ( github.event_name == 'push' && contains(github.ref, 'staging') ) || ( (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && !contains(github.event.pull_request.labels.*.name, 'Build: None') && !contains(github.event.pull_request.labels.*.name, 'Test: None') ) }}" >> $GITHUB_OUTPUT
+          echo "run_test=${{  steps.check-build.outputs.run_build == 'true' && !contains(github.event.pull_request.labels.*.name, 'Test: None') }}" >> $GITHUB_OUTPUT
 
   display-dispatch-event-id:
     if: github.event.inputs.RANDOM_DISPATCH_EVENT_ID != ''

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -31,7 +31,12 @@ on:
         default: false
         type: boolean
       PSWI_SMPE_ARTIFACTORY_PATH:
-        description: 'Artifactory path to find an already-built Zowe SMPE package, instead of building from scratch'
+        description: 'Set both this and AZWE_ARTIFACTORY_PATH. This is the Artifactory path to find an already-built Zowe SMPE package, instead of building from scratch'
+        required: false
+        default: ''
+        type: string
+      PSWI_SMPE_AZWE_ARTIFACTORY_PATH:
+        description: 'Set both this and SMPE_ARTIFACTORY_PATH. This is the Artifactory path to find a pre-built AZWE FMID, instead of building from scratch'
         required: false
         default: ''
         type: string
@@ -290,7 +295,7 @@ jobs:
         id: pax-prep
         run: |
           if [ "${{ env.INPUTS_BUILD_SMPE }}" == "true" ] || [ "${{ env.INPUTS_BUILD_PSWI }}" == "true" ] ; then
-            if [[ "${{ github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH }}" == "" ]]; then
+            if [[ "${{ github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH }}" == "" || "${{github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH}}" == "" ]]; then
               echo EXTRA_FILES=zowe-smpe.zip,fmid.zip,pd.htm,smpe-promote.tar,smpe-build-logs.pax.Z,rename-back.sh >> $GITHUB_OUTPUT
               echo BUILD_SMPE=yes >> $GITHUB_OUTPUT
             else
@@ -310,7 +315,7 @@ jobs:
 
       - name: '[PAX/SMPE Pax 2] Packaging'
         timeout-minutes: 60
-        if: env.INPUTS_BUILD_PSWI != 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '')
+        if: env.INPUTS_BUILD_PSWI != 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH != '')
         uses: zowe-actions/shared-actions/make-pax@main
         with: 
           pax-name: zowe
@@ -325,7 +330,7 @@ jobs:
             KEEP_TEMP_FOLDER=${{ steps.pax-prep.outputs.KEEP_TEMP_FOLDER }}
 
       - name: '[SMPE Pax 3] Post-make pax'
-        if: env.INPUTS_BUILD_SMPE == 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '')
+        if: env.INPUTS_BUILD_SMPE == 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH != '')
         run: |
           cd .pax
           chmod +x rename-back.sh
@@ -342,9 +347,9 @@ jobs:
           lock-avg-retry-interval: 60
 
       - name: '[PSWI 0] PSWI pre-build check for existing smpe'
-        if: env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH != ''
+        if: env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH != '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH != ''
         run: |
-          jfrog rt dl libs-release-local/org/zowe/2.0.0/zowe-smpe-*.zip --flat=true .pax/AZWE002.zip
+          jfrog rt dl ${{github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH}}/AZWE002*.zip --flat=true .pax/AZWE002.zip
           jfrog rt dl ${{github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH}}/zowe-smpe-*.zip --flat=true .pax/zowe-smpe.zip
 
 

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -74,7 +74,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             if ('${{ github.event_name}}' == 'pull_request') {
-              return ${{ toJson(github.event.pull_request.labels) }}
+              return JSON.stringify(${{ toJson(github.event.pull_request.labels) }})
             }  
             else if ('${{ github.event.inputs.ORIGIN_ISSUE_TRIGGER}}' == 'true') {
               github.rest.pulls.list({
@@ -99,6 +99,9 @@ jobs:
       - id: check-test
         name: 'export conditional used to determine if we should run a test suite'
         run: |
+          echo ${{ steps.check-build.outputs.run_build == 'true' }}
+          echo ${{ steps.check-build.outputs.run_build == 'false' }}
+          echo ${{ contains(fromJson(steps.get-labels.outputs.result), 'Test: None') }}
           echo "run_test=${{ (steps.check-build.outputs.run_build == 'true' && !contains(fromJson(steps.get-labels.outputs.result), 'Test: None')) }}" >> $GITHUB_OUTPUT
 
   display-dispatch-event-id:

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -12,8 +12,6 @@ on:
       - v2.x/staging 
   pull_request:
     types: [opened, synchronize]
-  issue_comment:
-    types: [created, edited]
 
   workflow_dispatch:
     inputs:
@@ -41,39 +39,57 @@ on:
         description: 'random dispatch event id'
         required: false
         type: string
+      ORIGIN_ISSUE_TRIGGER:
+        description: 'is being triggered from PR issue comment'
+        default: false
+        required: false
+        type: boolean
+
+env:
+  PR_LABELS:
 
 jobs:
 
-  pr-comment-check:
-
-    name: 'PR Comment Check'
-    runs-on: ubuntu-latest
-    outputs:
-      issue_run_ci: ${{ steps.check-comment.outputs.issue_run_ci }}
-    steps:
-      - name: Check for a comment triggering a build
-        id: check-comment
-        run: |
-          echo "issue_run_ci=false" >> $GITHUB_OUTPUT
-          if [[ ! -z "${{ github.event.issue.pull_request }}" && ${{ github.event_name == 'issue_comment' }} && "${{ github.event.comment.body }}" = '/ci' ]]; then
-            echo "issue_run_ci=true" >> $GITHUB_OUTPUT
-          fi     
-
   set-run-conditions:
     runs-on: ubuntu-latest
-    needs: pr-comment-check
     outputs:
+      pr-labels: ${{ steps.get-labels.outputs.result }}
       should-build: ${{ steps.check-build.outputs.run_build }}
       should-test: ${{ steps.check-test.outputs.run_test}}
     steps:
+      - name: 'Get labels'
+        id: get-labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            if ('${{ github.event_name}}' == 'pull_request') {
+              return ${{ toJson(github.event.pull_request.labels) }}
+            }  
+            else if ('${{ github.event.inputs.ORIGIN_ISSUE_TRIGGER}}' == 'true') {
+              github.rest.pulls.list({
+                state: 'open',
+                head: 'zowe:${{ env.GITHUB_HEAD_REF }}',
+                owner: 'zowe',
+                repo: 'zowe-install-packaging'
+              }).then((resp) => {
+                const pr = resp.data.find((item) => item.head.ref == 'user/markackert/ci-label-behavior-updates')
+                return JSON.stringify(pr.labels)
+              })
+            } else {
+              return '[]'
+            }
+  
       - id: check-build
         name: 'export conditional used to determine if we should run a build'
+        # run_build explanation: workflow_dispatch can be manual, '/ci' comment trigger, or nightly. 
+        #   If this is a workflow_disaptch and not a '/ci' trigger, always run, ignoring PR labels. Otherwise, always check the label.
         run: |
-          echo "run_build=${{ (github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.issue_run_ci == 'true') && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}" >> $GITHUB_OUTPUT
+          echo "run_build=${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.ORIGIN_ISSUE_TRIGGER == 'false') || !contains(fromJson(steps.get-labels.outputs.result), 'Build: None') }}" >> $GITHUB_OUTPUT
       - id: check-test
         name: 'export conditional used to determine if we should run a test suite'
         run: |
-          echo "run_test=${{ (steps.check-build.outputs.run_build == 'true' && !contains(github.event.pull_request.labels.*.name, 'Test: None')) }}" >> $GITHUB_OUTPUT
+          echo "run_test=${{ (steps.check-build.outputs.run_build == 'true' && !contains(fromJson(steps.get-labels.outputs.result), 'Test: None')) }}" >> $GITHUB_OUTPUT
 
   display-dispatch-event-id:
     if: github.event.inputs.RANDOM_DISPATCH_EVENT_ID != ''
@@ -99,9 +115,7 @@ jobs:
     steps: 
       - name: '[Prep 1] Checkout'
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
-  
+
       - name: '[Prep 2] Setup jFrog CLI'
         uses: jfrog/setup-jfrog-cli@v2
         env:
@@ -156,23 +170,23 @@ jobs:
         run: |
           BUILD_WHAT="PAX"
             
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: PSWI') }}" == "true" ]]; then
+          if [[ "${{ contains(fromJson(needs.set-run-conditions.outputs.pr-labels), 'Build: PSWI') }}" == "true" ]]; then
             echo INPUTS_BUILD_PSWI=true >> $GITHUB_ENV
             echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
             BUILD_WHAT=$BUILD_WHAT", SMPE, PSWI"
           else
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: SMPE') }}" == "true" ]]; then
+            if [[ "${{ contains(fromJson(needs.set-run-conditions.outputs.pr-labels), 'Build: SMPE') }}" == "true" ]]; then
               echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
               BUILD_WHAT=$BUILD_WHAT", SMPE"
             fi
           fi
 
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: Kubernetes') }}" == "true" ]]; then
+          if [[ "${{ contains(fromJson(needs.set-run-conditions.outputs.pr-labels), 'Build: Kubernetes') }}" == "true" ]]; then
             echo INPUTS_BUILD_KUBERNETES=true >> $GITHUB_ENV
             BUILD_WHAT=$BUILD_WHAT", K8S"
           fi
 
-          echo "INPUTS_KEEP_TEMP_PAX_FOLDER=${{ contains(github.event.pull_request.labels.*.name, 'Build: Debug-Remote') }}" >> $GITHUB_ENV
+          echo "INPUTS_KEEP_TEMP_PAX_FOLDER=${{ contains(fromJson(needs.set-run-conditions.outputs.pr-labels), 'Build: Debug-Remote') }}" >> $GITHUB_ENV
 
           echo BUILD_WHAT=$BUILD_WHAT >> $GITHUB_OUTPUT
 
@@ -410,13 +424,13 @@ jobs:
         id: get-test-suite
         run: |
           TEST_SUITE="Convenience Pax"
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Basic') }}" = "true" ]]; then
+          if [[ "${{ contains(fromJson(needs.set-run-conditions.outputs.pr-labels), 'Test: Basic') }}" = "true" ]]; then
             TEST_SUITE="Convenience Pax"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: SMPE') }}" = "true" ]]; then
+          elif [[ "${{ contains(fromJson(needs.set-run-conditions.outputs.pr-labels), 'Test: SMPE') }}" = "true" ]]; then
             TEST_SUITE="SMPE PTF"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Extended') }}" = "true" ]]; then
+          elif [[ "${{ contains(fromJson(needs.set-run-conditions.outputs.pr-labels), 'Test: Extended') }}" = "true" ]]; then
             TEST_SUITE="Zowe Nightly Tests"
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Silly') }}" = "true" ]]; then
+          elif [[ "${{ contains(fromJson(needs.set-run-conditions.outputs.pr-labels), 'Test: Silly') }}" = "true" ]]; then
             TEST_SUITE="Zowe Release Tests"
           else 
             echo "Unknown test label encountered; defaulting to 'Test: Basic' and running Convenience Pax tests."

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -12,6 +12,8 @@ on:
       - v2.x/staging 
   pull_request:
     types: [opened, synchronize]
+  issue_comment:
+    types: [created, edited]
 
   workflow_dispatch:
     inputs:
@@ -30,16 +32,6 @@ on:
         required: false
         default: false
         type: boolean
-      PSWI_SMPE_ARTIFACTORY_PATH:
-        description: 'Optional. Artifactory path to a pre-built SMP/e artifact.'
-        required: false
-        default: ''
-        type: string
-      PSWI_SMPE_AZWE_ARTIFACTORY_PATH:
-        description: 'Optional. Artifactory path to a pre-built pre-built AZWE FMID.'
-        required: false
-        default: ''
-        type: string
       KEEP_TEMP_PAX_FOLDER:
         description: 'do we need to keep temp pax folder?'
         required: false
@@ -52,13 +44,36 @@ on:
 
 jobs:
 
-  dump-context:
+  pr-comment-check:
+
+    name: 'PR Comment Check'
     runs-on: ubuntu-latest
+    outputs:
+      issue_run_ci: ${{ steps.check-comment.outputs.issue_run_ci }}
     steps:
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
+      - name: Check for a comment triggering a build
+        id: check-comment
+        run: |
+          echo "issue_run_ci=false" >> $GITHUB_OUTPUT
+          if [[ ! -z "${{ github.event.issue.pull_request }}" && ${{ github.event_name == 'issue_comment' }} && "${{ github.event.comment.body }}" = '/ci' ]]; then
+            echo "issue_run_ci=true" >> $GITHUB_OUTPUT
+          fi     
+
+  set-run-conditions:
+    runs-on: ubuntu-latest
+    needs: pr-comment-check
+    outputs:
+      should-build: ${{ steps.check-build.outputs.run_build }}
+      should-test: ${{ steps.check-test.outputs.run_test}}
+    steps:
+      - id: check-build
+        name: 'export conditional used to determine if we should run a build'
+        run: |
+          echo "run_build=${{ (github.event_name != 'issue_comment' || needs.pr-comment-check.outputs.issue_run_ci == 'true') && (github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'Build: None')) }}" >> $GITHUB_OUTPUT
+      - id: check-test
+        name: 'export conditional used to determine if we should run a test suite'
+        run: |
+          echo "run_test=${{ (steps.check-build.outputs.run_build == 'true' && !contains(github.event.pull_request.labels.*.name, 'Test: None')) }}" >> $GITHUB_OUTPUT
 
   display-dispatch-event-id:
     if: github.event.inputs.RANDOM_DISPATCH_EVENT_ID != ''
@@ -75,13 +90,17 @@ jobs:
         uses: zowe-actions/shared-actions/permission-check@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}  
-  
+
   regular-build:
+
+    if: ${{ needs.set-run-conditions.outputs.should-build == 'true' }}
     runs-on: ubuntu-latest
-    needs: check-permission
+    needs: [set-run-conditions, check-permission]
     steps: 
       - name: '[Prep 1] Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
   
       - name: '[Prep 2] Setup jFrog CLI'
         uses: jfrog/setup-jfrog-cli@v2
@@ -131,20 +150,42 @@ jobs:
               console.error('Cannot read manifest or manifest is invalid.');
             }
 
-      - name: '[Prep 6] Process github.event.inputs'
-        id: process-inputs
+      - name: '[Prep 6a] Process labels for ci build (pull, push, comment)'
+        id: process-labels
+        if: github.event_name != 'workflow_dispatch'
         run: |
           BUILD_WHAT="PAX"
+            
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: PSWI') }}" == "true" ]]; then
+            echo INPUTS_BUILD_PSWI=true >> $GITHUB_ENV
+            echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
+            BUILD_WHAT=$BUILD_WHAT", SMPE, PSWI"
+          else
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: SMPE') }}" == "true" ]]; then
+              echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
+              BUILD_WHAT=$BUILD_WHAT", SMPE"
+            fi
+          fi
+
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Build: Kubernetes') }}" == "true" ]]; then
+            echo INPUTS_BUILD_KUBERNETES=true >> $GITHUB_ENV
+            BUILD_WHAT=$BUILD_WHAT", K8S"
+          fi
+
+          echo "INPUTS_KEEP_TEMP_PAX_FOLDER=${{ contains(github.event.pull_request.labels.*.name, 'Build: Debug-Remote') }}" >> $GITHUB_ENV
+
+          echo BUILD_WHAT=$BUILD_WHAT >> $GITHUB_OUTPUT
+
+      - name: '[Prep 6b] Process github.event.inputs for manually triggered build'
+        id: process-inputs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          BUILD_WHAT="${{ steps.process-labels.outputs.BUILD_WHAT_LABELS }}"
           
           echo INPUTS_BUILD_PSWI=${{ github.event.inputs.BUILD_PSWI }} >> $GITHUB_ENV
           if [[ "${{ github.event.inputs.BUILD_PSWI }}" == true ]]; then
-            if [[ "${{ github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH }}" == "" ]]; then
-              echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
-              BUILD_WHAT=$BUILD_WHAT", SMPE, PSWI"
-            else
-              echo INPUTS_BUILD_SMPE=false >> $GITHUB_ENV
-              BUILD_WHAT="PSWI"
-            fi
+            echo INPUTS_BUILD_SMPE=true >> $GITHUB_ENV
+            BUILD_WHAT=$BUILD_WHAT", SMPE, PSWI"
           else
             echo INPUTS_BUILD_SMPE=${{ github.event.inputs.BUILD_SMPE }} >> $GITHUB_ENV
             if [[ "${{ github.event.inputs.BUILD_SMPE }}" == true ]]; then
@@ -225,13 +266,8 @@ jobs:
         id: pax-prep
         run: |
           if [ "${{ env.INPUTS_BUILD_SMPE }}" == "true" ] || [ "${{ env.INPUTS_BUILD_PSWI }}" == "true" ] ; then
-            if [[ "${{ github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH }}" == "" || "${{github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH}}" == "" ]]; then
-              echo EXTRA_FILES=zowe-smpe.zip,fmid.zip,pd.htm,smpe-promote.tar,smpe-build-logs.pax.Z,rename-back.sh >> $GITHUB_OUTPUT
-              echo BUILD_SMPE=yes >> $GITHUB_OUTPUT
-            else
-              echo EXTRA_FILES= >> $GITHUB_OUTPUT
-              echo BUILD_SMPE= >> $GITHUB_OUTPUT
-            fi
+            echo EXTRA_FILES=zowe-smpe.zip,fmid.zip,pd.htm,smpe-promote.tar,smpe-build-logs.pax.Z,rename-back.sh >> $GITHUB_OUTPUT
+            echo BUILD_SMPE=yes >> $GITHUB_OUTPUT
           else
             echo EXTRA_FILES= >> $GITHUB_OUTPUT
             echo BUILD_SMPE= >> $GITHUB_OUTPUT
@@ -245,7 +281,6 @@ jobs:
 
       - name: '[PAX/SMPE Pax 2] Packaging'
         timeout-minutes: 60
-        if: env.INPUTS_BUILD_PSWI != 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH == '')
         uses: zowe-actions/shared-actions/make-pax@main
         with: 
           pax-name: zowe
@@ -260,7 +295,7 @@ jobs:
             KEEP_TEMP_FOLDER=${{ steps.pax-prep.outputs.KEEP_TEMP_FOLDER }}
 
       - name: '[SMPE Pax 3] Post-make pax'
-        if: env.INPUTS_BUILD_SMPE == 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH == '')
+        if: env.INPUTS_BUILD_SMPE == 'true' || env.INPUTS_BUILD_PSWI == 'true'
         run: |
           cd .pax
           chmod +x rename-back.sh
@@ -275,13 +310,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lock-resource-name: zowe-psi-build-zzow07-lock
           lock-avg-retry-interval: 60
-
-      - name: '[PSWI 0] PSWI pre-build check for existing smpe'
-        if: env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH != '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH != ''
-        run: |
-          jfrog rt dl ${{github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH}}/AZWE002*.zip --flat=true .pax/AZWE002.zip
-          jfrog rt dl ${{github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH}}/zowe-smpe-*.zip --flat=true .pax/zowe-smpe.zip
-
 
       - name: '[SMPE Pax 4] Build PSWI'
         if: env.INPUTS_BUILD_PSWI == 'true'
@@ -364,9 +392,11 @@ jobs:
   # only run auto integration tests when the workflow is triggered by pull request
   # default running Convenience Pax on any zzow server
   call-integration-test:
-    needs: regular-build
+
+    needs: [set-run-conditions, regular-build]
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && contains(github.ref, 'staging'))
+    if: ${{ needs.set-run-conditions.outputs.should-test == 'true' }}
+
     steps:
       - name: 'Determine branch name'
         run: |
@@ -375,6 +405,23 @@ jobs:
           else
             echo "BRANCH_NAME=$(echo ${GITHUB_REF_NAME})" >> $GITHUB_ENV
           fi
+
+      - name: 'Determine test suite'
+        id: get-test-suite
+        run: |
+          TEST_SUITE="Convenience Pax"
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Basic') }}" = "true" ]]; then
+            TEST_SUITE="Convenience Pax"
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: SMPE') }}" = "true" ]]; then
+            TEST_SUITE="SMPE PTF"
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Extended') }}" = "true" ]]; then
+            TEST_SUITE="Zowe Nightly Tests"
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'Test: Silly') }}" = "true" ]]; then
+            TEST_SUITE="Zowe Release Tests"
+          else 
+            echo "Unknown test label encountered; defaulting to 'Test: Basic' and running Convenience Pax tests."
+          fi
+          echo "TEST_SUITE=$TEST_SUITE" >> $GITHUB_OUTPUT
 
       - name: 'Call test workflow'
         uses: zowe-actions/shared-actions/workflow-remote-call-wait@main
@@ -386,7 +433,7 @@ jobs:
           workflow-filename: cicd-test.yml
           branch-name: ${{ env.BRANCH_NAME }}
           poll-frequency: 3
-          inputs-json-string: '{"custom-zowe-artifactory-pattern-or-build-number":"${{ github.run_number }}"}'
+          inputs-json-string: '{"custom-zowe-artifactory-pattern-or-build-number":"${{ github.run_number }}", "install-test": "${{ steps.get-test-suite.outputs.TEST_SUITE }}"}'
         # env:
         #   DEBUG: 'workflow-remote-call-wait'
       

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           echo ${{ steps.check-build.outputs.run_build == 'true' }}
           echo ${{ !contains(github.event.pull_request.labels.*.name, 'Test: None') }}
-          echo ${{ contains(github.event.pull_request.labels.*.name, 'Test: None') != 'true' }}
+          echo ${{ contains(github.event.pull_request.labels.*.name, 'Test: None') == 'true' }}
           echo ${{  steps.check-build.outputs.run_build == 'true' && contains(github.event.pull_request.labels.*.name, 'Test: None') != 'true' }}
           echo "run_test=${{  steps.check-build.outputs.run_build == 'true' && contains(github.event.pull_request.labels.*.name, 'Test: None') != 'true' }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/cicd-comment-trigger.yml
+++ b/.github/workflows/cicd-comment-trigger.yml
@@ -13,14 +13,6 @@ on:
 
 jobs:
 
-  dump-env:
-    name: 'Debug Env'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dump env
-        run: |
-          echo ${{ fromJson(github) }}
-
   pr-comment-check:
 
     name: 'PR Comment Check'

--- a/.github/workflows/cicd-comment-trigger.yml
+++ b/.github/workflows/cicd-comment-trigger.yml
@@ -1,0 +1,69 @@
+# Triggers when comments are made on issues/PRs, runs when '/ci' is added to a pull request.
+name: Zowe CICD Issue Trigger
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: write
+
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+
+  dump-env:
+    name: 'Debug Env'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump env
+        run: |
+          echo ${{ fromJson(github) }}
+
+  pr-comment-check:
+
+    name: 'PR Comment Check'
+    runs-on: ubuntu-latest
+    outputs:
+      issue_run_ci: ${{ steps.check-comment.outputs.issue_run_ci }}
+    steps:
+      - name: Check for a comment triggering a build
+        id: check-comment
+        run: |
+          echo "issue_run_ci=false" >> $GITHUB_OUTPUT
+          if [[ ! -z "${{ github.event.issue.pull_request }}" && ${{ github.event_name == 'issue_comment' }} && "${{ github.event.comment.body }}" = '/ci' ]]; then
+            echo "issue_run_ci=true" >> $GITHUB_OUTPUT
+          fi     
+
+  get-pr-branch:
+    name: 'Get PR Branch'
+    runs-on: ubuntu-latest
+    outputs:
+      pr_branch_name: 
+    steps:
+      - name: Find PR Branch Name
+        run: | 
+          gh config set pager cat 
+          PR_BRANCH=$(gh pr view ${{ github.event.issue.pull_request }} -R zowe/zowe-install-packaging --json headRefName  -q .headRefName)
+          echo "pr_branch_name=$PR_BRANCH" >> $GITHUB_OUTPUT
+
+
+  trigger-ci:
+    name: 'Trigger Build'
+    runs-on: ubuntu-latest
+    needs: [pr-comment-check, get-pr-branch]
+    if: ${{ needs.pr-comment-check.outputs.issue_run_ci == 'true' }}
+    steps:
+      - name: 'Trigger Build workflow'
+        uses: zowe-actions/shared-actions/workflow-remote-call-wait@main    
+        with:
+          github-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
+          owner: zowe
+          repo: zowe-install-packaging
+          workflow-filename: build-packaging.yml
+          branch-name: ${{ needs.get-pr-branch.outputs.pr_branch_name }}
+          poll-frequency: 3
+          inputs-json-string: '{"ORIGIN_ISSUE_TRIGGER":"true", "KEEP_TEMP_PAX_FOLDER":"false"}'
+        env:
+          DEBUG: zowe-actions:shared-actions:workflow-remote-call-wait

--- a/bin/libs/config.ts
+++ b/bin/libs/config.ts
@@ -190,7 +190,8 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
         componentFileArray.push(`ZWE_configs_${key}=${envs['ZWE_components_'+componentAlpha+'_'+key]}`);
       }
     });
-    
+
+    componentFileArray = componentFileArray.map((row)=> { return row.endsWith('=null') ? row.substring(0, row.length-5)+'=' : row });
     const componentFileContent = componentFileArray.join('\n');
     rc = xplatform.storeFileUTF8(`${folderName}/.instance-${haInstance}.env`, xplatform.AUTO_DETECT, componentFileContent);
     if (rc) { 
@@ -200,6 +201,7 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
     }
   });
 
+  envFileArray = envFileArray.map((row)=> { return row.endsWith('=null') ? row.substring(0, row.length-5)+'=' : row });
   let envFileContent = envFileArray.join('\n');
   let rc = xplatform.storeFileUTF8(`${zwePrivateWorkspaceEnvDir}/.instance-${haInstance}.env`, xplatform.AUTO_DETECT, envFileContent);
   if (rc) {


### PR DESCRIPTION
This PR tests and iterates on previously contributed `/ci` comment behavior, as it couldn't be tested prior to merge into a default branch.

After testing, this PR makes the following changes:
- Splits out the `/ci` comment trigger into a new workflow file. This is necessary (a) to avoid running a lot of empty `Zowe Build and Packaging` runs, which creates a lot of noise for an important workflow, and (b) to fix issues with triggering workflows from the default branch - the `issue_comment` trigger always hits against the default branch, so the build triggered would use the default branch as well. This split allows the comment-trigger workflow to determine the proper headRef using the issue number (a.k.a PR number) , and then calls Build and Packaging with that ref.
- Updates `build-packaging.yml` to support this new workflow_dispatch call pattern so everything runs like you'd expect (post a status comment to PR thread, use proper ref for build, respect labels, etc.).
- Updates PSWI builds to allow for PSWI builds using existing PAX files. This was cherry-picked from changes that went into `v2.x/rc` as part of a PSWI catch up release; this option is disabled by default and should only be triggered manually by the systems squad in rare cases.
