### PR TITLE
Fix PSWI build trigger

### DIFF
--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -31,12 +31,12 @@ on:
         default: false
         type: boolean
       PSWI_SMPE_ARTIFACTORY_PATH:
-        description: 'Set both this and AZWE_ARTIFACTORY_PATH. This is the Artifactory path to find an already-built Zowe SMPE package, instead of building from scratch'
+        description: 'Optional. Artifactory path to a pre-built SMP/e artifact.'
         required: false
         default: ''
         type: string
       PSWI_SMPE_AZWE_ARTIFACTORY_PATH:
-        description: 'Set both this and SMPE_ARTIFACTORY_PATH. This is the Artifactory path to find a pre-built AZWE FMID, instead of building from scratch'
+        description: 'Optional. Artifactory path to a pre-built pre-built AZWE FMID.'
         required: false
         default: ''
         type: string

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -51,6 +51,15 @@ on:
         type: string
 
 jobs:
+
+  dump-context:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+
   display-dispatch-event-id:
     if: github.event.inputs.RANDOM_DISPATCH_EVENT_ID != ''
     runs-on: ubuntu-latest

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -236,7 +236,7 @@ jobs:
 
       - name: '[PAX/SMPE Pax 2] Packaging'
         timeout-minutes: 60
-        if: env.INPUTS_BUILD_PSWI != 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH != '')
+        if: env.INPUTS_BUILD_PSWI != 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH == '')
         uses: zowe-actions/shared-actions/make-pax@main
         with: 
           pax-name: zowe
@@ -251,7 +251,7 @@ jobs:
             KEEP_TEMP_FOLDER=${{ steps.pax-prep.outputs.KEEP_TEMP_FOLDER }}
 
       - name: '[SMPE Pax 3] Post-make pax'
-        if: env.INPUTS_BUILD_SMPE == 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH != '')
+        if: env.INPUTS_BUILD_SMPE == 'true' || (env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH == '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH == '')
         run: |
           cd .pax
           chmod +x rename-back.sh


### PR DESCRIPTION
Corrects build logic so PSWI/SMPE selected with empty artifactory references will build everything from scratch.