### PR TITLE
Regression fix on network vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
+
+## `2.16.0
+
+## Minor enhancements/defect fixes
+- Bugfix: zowe.network.validatePortFree and zowe.network.vipaIp variables were moved from zowe.network to zowe.network.server in the schema but not in the code, causing inability to use them without the workaround of specifying them as environment variables ZWE_NETWORK_VALIDATE_PORT_FREE and ZWE_NETWORK_VIPA_IP instead. Now, the variables match the schema: zowe.network.server is used instead of zowe.network.
+
+
 ## `2.15.0`
 
 ## New features and enhancements

--- a/bin/libs/network.sh
+++ b/bin/libs/network.sh
@@ -87,7 +87,7 @@ get_netstat() {
 is_port_available() {
   port="${1}"
 
-  if [ "${ZWE_zowe_network_validatePortFree:-$ZWE_zowe_environments_ZWE_NETWORK_VALIDATE_PORT_FREE}" = "false" ]; then
+  if [ "${ZWE_zowe_network_server_validatePortFree:-$ZWE_zowe_environments_ZWE_NETWORK_VALIDATE_PORT_FREE}" = "false" ]; then
     print_message "Port validation skipped due to zowe.network.validatePortFree=false"
     return 0
   fi
@@ -102,7 +102,7 @@ is_port_available() {
 
   case $(uname) in
     "OS/390")
-      vipa_ip=${ZWE_zowe_network_vipaIp:-$ZWE_zowe_environments_ZWE_NETWORK_VIPA_IP}
+      vipa_ip=${ZWE_zowe_network_server_vipaIp:-$ZWE_zowe_environments_ZWE_NETWORK_VIPA_IP}
       if [ -n "${vipa_ip}" ]; then
         result=$(${netstat} -B ${vipa_ip}+${port} -c SERVER 2>&1)
       else    

--- a/bin/libs/network.ts
+++ b/bin/libs/network.ts
@@ -45,7 +45,7 @@ export function getNetstat(): string|undefined {
 export function isPortAvailable(port: number): boolean {
   const netstat=getNetstat();
 
-  const skipValidate = (std.getenv('ZWE_zowe_network_validatePortFree') ? std.getenv('ZWE_zowe_network_validatePortFree') : std.getenv('ZWE_zowe_environments_ZWE_NETWORK_VALIDATE_PORT_FREE')) == 'false';
+  const skipValidate = (std.getenv('ZWE_zowe_network_server_validatePortFree') ? std.getenv('ZWE_zowe_network_server_validatePortFree') : std.getenv('ZWE_zowe_environments_ZWE_NETWORK_VALIDATE_PORT_FREE')) == 'false';
   if (skipValidate) {
     common.printMessage("Port validation skipped due to zowe.network.validatePortFree=false");
     return true;
@@ -61,9 +61,9 @@ export function isPortAvailable(port: number): boolean {
   let lines;
   switch (os.platform) {
     case 'zos':
-    const vipaIp = std.getenv('ZWE_zowe_network_vipaIp') ? std.getenv('ZWE_zowe_network_vipaIp') : std.getenv('ZWE_zowe_environments_ZWE_NETWORK_VIPA_IP');
+    const vipaIp = std.getenv('ZWE_zowe_network_server_vipaIp') ? std.getenv('ZWE_zowe_network_server_vipaIp') : std.getenv('ZWE_zowe_environments_ZWE_NETWORK_VIPA_IP');
     if (vipaIp !== undefined) {
-      retVal=shell.execOutSync('sh', '-c', `${netstat} -B ${std.getenv('ZWE_zowe_network_vipaIp')}+${port} -c SERVER 2>&1`);
+      retVal=shell.execOutSync('sh', '-c', `${netstat} -B ${vipaIp}+${port} -c SERVER 2>&1`);
     } else {
       retVal=shell.execOutSync('sh', '-c', `${netstat} -c SERVER -P ${port} 2>&1`);
     }


### PR DESCRIPTION
Bugfix: zowe.network.validatePortFree and zowe.network.vipaIp variables were moved from zowe.network to zowe.network.server in the schema but not in the code, causing inability to use them without the workaround of specifying them as environment variables ZWE_NETWORK_VALIDATE_PORT_FREE and ZWE_NETWORK_VIPA_IP instead. Now, the variables match the schema: zowe.network.server is used instead of zowe.network.