### PR TITLE
 Handle null to blank for configmgr update

### DIFF
--- a/bin/libs/config.ts
+++ b/bin/libs/config.ts
@@ -190,7 +190,8 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
         componentFileArray.push(`ZWE_configs_${key}=${envs['ZWE_components_'+componentAlpha+'_'+key]}`);
       }
     });
-    
+
+    componentFileArray = componentFileArray.map((row)=> { return row.endsWith('=null') ? row.substring(0, row.length-5)+'=' : row });
     const componentFileContent = componentFileArray.join('\n');
     rc = xplatform.storeFileUTF8(`${folderName}/.instance-${haInstance}.env`, xplatform.AUTO_DETECT, componentFileContent);
     if (rc) { 
@@ -200,6 +201,7 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
     }
   });
 
+  envFileArray = envFileArray.map((row)=> { return row.endsWith('=null') ? row.substring(0, row.length-5)+'=' : row });
   let envFileContent = envFileArray.join('\n');
   let rc = xplatform.storeFileUTF8(`${zwePrivateWorkspaceEnvDir}/.instance-${haInstance}.env`, xplatform.AUTO_DETECT, envFileContent);
   if (rc) {


### PR DESCRIPTION
A bugfix was recently merged to configmgr https://github.com/zowe/zowe-common-c/pull/442 where null lines in yaml like `foo: ` would previously be interpreted as `"foo": ""` in JSON for example, instead of `"foo": null`
This was not correct interpretation of yaml, so it was fixed, particularly to mode further away from our node code!
But, it caused a regression in our env code in that content that was previously `foo=` was now `foo=null` which wont work right for shell code.
So, now we change those nulls to blanks to keep the same behavior as prior while still handling YAML better than before.