### PR TITLE
remove imperative (now in zowe-cli)

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -146,13 +146,6 @@
   },
   "sourceDependencies": [
     {
-      "componentGroup": "Imperative CLI Framework for Zowe",
-      "entries": [{
-        "repository": "imperative",
-        "tag": "zowe-v1-lts",
-        "destinations": ["Zowe CLI Package"]
-      }]
-    }, {
       "componentGroup": "Zowe API Mediation Layer",
       "entries": [{
         "repository": "api-layer",


### PR DESCRIPTION
Merging before builds complete to continue release process. Artifacts are unchanged and will not be re-built; this change impacts downstream automation.

Remove imperative from sourceDependencies - now included in the zowe-cli monorepo.