### PR TITLE
Fix heappools64 setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to the Zowe Installer will be documented in this file.
 ## `2.16.0
 
 ## Minor enhancements/defect fixes
+- Enhancement: The command `zwe support` now includes CEE Runtime option output to better diagnose issues related to environment customization.
 - Bugfix: zowe.network.validatePortFree and zowe.network.vipaIp variables were moved from zowe.network to zowe.network.server in the schema but not in the code, causing inability to use them without the workaround of specifying them as environment variables ZWE_NETWORK_VALIDATE_PORT_FREE and ZWE_NETWORK_VIPA_IP instead. Now, the variables match the schema: zowe.network.server is used instead of zowe.network.
+- Bugfix: configmgr operations now run with HEAPPOOLS64 set to OFF to avoid abends caused when this parameter is not OFF.
 
 
 ## `2.15.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable changes to the Zowe Installer will be documented in this file.
 ## `2.16.0
 
 ## Minor enhancements/defect fixes
-- Enhancement: The command `zwe support` now includes CEE Runtime option output to better diagnose issues related to environment customization.
+- Enhancement: The command `zwe support` now includes CEE Runtime option output to better diagnose issues related to environment customization. (#3799)
 - Bugfix: zowe.network.validatePortFree and zowe.network.vipaIp variables were moved from zowe.network to zowe.network.server in the schema but not in the code, causing inability to use them without the workaround of specifying them as environment variables ZWE_NETWORK_VALIDATE_PORT_FREE and ZWE_NETWORK_VIPA_IP instead. Now, the variables match the schema: zowe.network.server is used instead of zowe.network.
-- Bugfix: configmgr operations now run with HEAPPOOLS64 set to OFF to avoid abends caused when this parameter is not OFF.
+- Bugfix: configmgr operations now run with HEAPPOOLS64 set to OFF to avoid abends caused when this parameter is not OFF. (#3799)
 
 
 ## `2.15.0`

--- a/bin/commands/components/disable/index.sh
+++ b/bin/commands/components/disable/index.sh
@@ -17,7 +17,7 @@ if [ "${USE_CONFIGMGR}" = "true" ]; then
     # user-facing command, use tmpdir to not mess up workspace permissions
     export ZWE_PRIVATE_TMP_MERGED_YAML_DIR=1
   fi
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/disable/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/disable/cli.js"
 else
 
 require_node

--- a/bin/commands/components/enable/index.sh
+++ b/bin/commands/components/enable/index.sh
@@ -17,7 +17,7 @@ if [ "${USE_CONFIGMGR}" = "true" ]; then
     # user-facing command, use tmpdir to not mess up workspace permissions
     export ZWE_PRIVATE_TMP_MERGED_YAML_DIR=1
   fi
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/enable/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/enable/cli.js"
 else
 
 require_node

--- a/bin/commands/components/handlerutils.ts
+++ b/bin/commands/components/handlerutils.ts
@@ -45,7 +45,7 @@ export class HandlerCaller {
     std.setenv('ZWE_CLI_REGISTRY_COMMAND', 'search');
     common.printMessage(`Calling handler '${this.handler}' to search for ${componentName}`);
 
-    const result = shell.execSync('sh', '-c', `_CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${std.getenv('ZWE_zowe_runtimeDirectory')}/bin/utils/configmgr -script "${this.handlerPath}"`);
+    const result = shell.execSync('sh', '-c', `_CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${std.getenv('ZWE_zowe_runtimeDirectory')}/bin/utils/configmgr -script "${this.handlerPath}"`);
     common.printMessage(`Handler search exited with rc=${result.rc}`);
     return result.rc;
   }
@@ -59,7 +59,7 @@ export class HandlerCaller {
     
     std.setenv('ZWE_CLI_REGISTRY_DRY_RUN', dryRun ? 'true' : 'false');
 
-    const result = shell.execOutSync('sh', '-c', `_CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${std.getenv('ZWE_zowe_runtimeDirectory')}/bin/utils/configmgr -script "${this.handlerPath}"`);
+    const result = shell.execOutSync('sh', '-c', `_CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${std.getenv('ZWE_zowe_runtimeDirectory')}/bin/utils/configmgr -script "${this.handlerPath}"`);
     common.printMessage(`Handler uninstall exited with rc=${result.rc}`);
 
     if (result.rc) {
@@ -95,7 +95,7 @@ export class HandlerCaller {
     std.setenv('ZWE_CLI_REGISTRY_DRY_RUN', dryRun ? 'true' : 'false');
 
 
-    const result = shell.execOutSync('sh', '-c', `_CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${std.getenv('ZWE_zowe_runtimeDirectory')}/bin/utils/configmgr -script "${this.handlerPath}"`);
+    const result = shell.execOutSync('sh', '-c', `_CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${std.getenv('ZWE_zowe_runtimeDirectory')}/bin/utils/configmgr -script "${this.handlerPath}"`);
     common.printMessage(`Handler ${action} exited with rc=${result.rc}`);
 
     if (result.rc) {

--- a/bin/commands/components/install/extract/index.sh
+++ b/bin/commands/components/install/extract/index.sh
@@ -13,7 +13,7 @@
 
 USE_CONFIGMGR=$(check_configmgr_enabled)
 if [ "${USE_CONFIGMGR}" = "true" ]; then
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/install/extract/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/install/extract/cli.js"
 else
 
 

--- a/bin/commands/components/install/index.sh
+++ b/bin/commands/components/install/index.sh
@@ -16,7 +16,7 @@ if [ "${USE_CONFIGMGR}" = "true" ]; then
   if [ -z "${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}" ]; then
     export ZWE_PRIVATE_TMP_MERGED_YAML_DIR=1
   fi
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/install/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/install/cli.js"
 else
 
 zwecli_inline_execute_command components install extract

--- a/bin/commands/components/install/process-hook/index.sh
+++ b/bin/commands/components/install/process-hook/index.sh
@@ -13,7 +13,7 @@
 
 USE_CONFIGMGR=$(check_configmgr_enabled)
 if [ "${USE_CONFIGMGR}" = "true" ]; then
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/install/process-hook/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/install/process-hook/cli.js"
 else
 
 

--- a/bin/commands/components/search/index.sh
+++ b/bin/commands/components/search/index.sh
@@ -17,7 +17,7 @@ if [ "${USE_CONFIGMGR}" = "true" ]; then
     # user-facing command, use tmpdir to not mess up workspace permissions
     export ZWE_PRIVATE_TMP_MERGED_YAML_DIR=1
   fi
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/search/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/search/cli.js"
 else
   print_error_and_exit "Error ZWEL0316E: Command requires zowe.useConfigmgr=true to use." "" 316
 fi

--- a/bin/commands/components/uninstall/index.sh
+++ b/bin/commands/components/uninstall/index.sh
@@ -17,7 +17,7 @@ if [ "${USE_CONFIGMGR}" = "true" ]; then
     # user-facing command, use tmpdir to not mess up workspace permissions
     export ZWE_PRIVATE_TMP_MERGED_YAML_DIR=1
   fi
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/uninstall/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/uninstall/cli.js"
 else
   print_error_and_exit "Error ZWEL0316E: Command requires zowe.useConfigmgr=true to use." "" 316
 fi

--- a/bin/commands/components/upgrade/index.sh
+++ b/bin/commands/components/upgrade/index.sh
@@ -17,7 +17,7 @@ if [ "${USE_CONFIGMGR}" = "true" ]; then
     # user-facing command, use tmpdir to not mess up workspace permissions
     export ZWE_PRIVATE_TMP_MERGED_YAML_DIR=1
   fi
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/upgrade/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/components/upgrade/cli.js"
 else
   print_error_and_exit "Error ZWEL0316E: Command requires zowe.useConfigmgr=true to use." "" 316
 fi

--- a/bin/commands/config/get/index.sh
+++ b/bin/commands/config/get/index.sh
@@ -17,7 +17,7 @@ if [ "${USE_CONFIGMGR}" = "true" ]; then
     # user-facing command, use tmpdir to not mess up workspace permissions
     export ZWE_PRIVATE_TMP_MERGED_YAML_DIR=1
   fi
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/config/get/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/config/get/cli.js"
 else
   echo "This command is only available when zowe.useConfigmgr=true"
 fi

--- a/bin/commands/config/validate/index.sh
+++ b/bin/commands/config/validate/index.sh
@@ -17,7 +17,7 @@ if [ "${USE_CONFIGMGR}" = "true" ]; then
     # user-facing command, use tmpdir to not mess up workspace permissions
     export ZWE_PRIVATE_TMP_MERGED_YAML_DIR=1
   fi
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/config/validate/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/config/validate/cli.js"
 else
   echo "This command is only available when zowe.useConfigmgr=true"
 fi

--- a/bin/commands/diagnose/index.sh
+++ b/bin/commands/diagnose/index.sh
@@ -13,7 +13,7 @@
 
 USE_CONFIGMGR=$(check_configmgr_enabled)
 if [ "${USE_CONFIGMGR}" = "true" ]; then
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/diagnose/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/diagnose/cli.js"
 else
 
   error_code="${ZWE_CLI_PARAMETER_ERROR_CODE}"

--- a/bin/commands/internal/config/get/index.sh
+++ b/bin/commands/internal/config/get/index.sh
@@ -13,7 +13,7 @@
 
 USE_CONFIGMGR=$(check_configmgr_enabled)
 if [ "${USE_CONFIGMGR}" = "true" ]; then
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/config/get/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/config/get/cli.js"
 else
 
 ###############################

--- a/bin/commands/internal/config/set/index.sh
+++ b/bin/commands/internal/config/set/index.sh
@@ -13,7 +13,7 @@
 
 USE_CONFIGMGR=$(check_configmgr_enabled)
 if [ "${USE_CONFIGMGR}" = "true" ]; then
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/config/set/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/config/set/cli.js"
 else
 
 ###############################

--- a/bin/commands/internal/container/init/index.sh
+++ b/bin/commands/internal/container/init/index.sh
@@ -13,7 +13,7 @@
 
 USE_CONFIGMGR=$(check_configmgr_enabled)
 if [ "${USE_CONFIGMGR}" = "true" ]; then
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/container/init/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/container/init/cli.js"
 else
 
 

--- a/bin/commands/internal/get-launch-components/index.sh
+++ b/bin/commands/internal/get-launch-components/index.sh
@@ -14,7 +14,7 @@
 
 USE_CONFIGMGR=$(check_configmgr_enabled)
 if [ "${USE_CONFIGMGR}" = "true" ]; then
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/get-launch-components/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/get-launch-components/cli.js"
 else
 
 

--- a/bin/commands/internal/start/component/index.sh
+++ b/bin/commands/internal/start/component/index.sh
@@ -13,7 +13,7 @@
 
 USE_CONFIGMGR=$(check_configmgr_enabled)
 if [ "${USE_CONFIGMGR}" = "true" ]; then
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/start/component/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/start/component/cli.js"
 else
 
 

--- a/bin/commands/internal/start/index.sh
+++ b/bin/commands/internal/start/index.sh
@@ -13,7 +13,7 @@
 
 USE_CONFIGMGR=$(check_configmgr_enabled)
 if [ "${USE_CONFIGMGR}" = "true" ]; then
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/start/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/start/cli.js"
 else
 
 

--- a/bin/commands/internal/start/prepare/index.sh
+++ b/bin/commands/internal/start/prepare/index.sh
@@ -17,7 +17,7 @@
 
 USE_CONFIGMGR=$(check_configmgr_enabled)
 if [ "${USE_CONFIGMGR}" = "true" ]; then
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/start/prepare/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/start/prepare/cli.js"
 else
 
 

--- a/bin/commands/start/index.sh
+++ b/bin/commands/start/index.sh
@@ -18,7 +18,7 @@ if [ "${USE_CONFIGMGR}" = "true" ]; then
     # user-facing command, use tmpdir to not mess up workspace permissions
     export ZWE_PRIVATE_TMP_MERGED_YAML_DIR=1
   fi
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/start/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/start/cli.js"
 else
 
 

--- a/bin/commands/stop/index.sh
+++ b/bin/commands/stop/index.sh
@@ -17,7 +17,7 @@ if [ "${USE_CONFIGMGR}" = "true" ]; then
     # user-facing command, use tmpdir to not mess up workspace permissions
     export ZWE_PRIVATE_TMP_MERGED_YAML_DIR=1
   fi
-  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/stop/cli.js"
+  _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/stop/cli.js"
 else
 
 

--- a/bin/commands/support/index.sh
+++ b/bin/commands/support/index.sh
@@ -47,6 +47,8 @@ print_level1_message "Collecting information about z/OS, Java, NodeJS and ESM"
 VERSION_FILE="${tmp_dir}/version_output"
 ZOS_VERSION=`operator_command "D IPLINFO" | grep -i release | xargs`
 print_message "- z/OS: ${ZOS_VERSION}"
+CEE_OPTIONS=`tsocmd "OMVS RUNOPTS('RPTOPTS(ON)')"`
+print_message "- CEE Runtime Options: ${CEE_OPTIONS}"
 JAVA_VERSION=`${JAVA_HOME}/bin/java -version 2>&1 | head -n 1`
 print_message "- Java: ${JAVA_VERSION}"
 NODE_VERSION=`${NODE_HOME}/bin/node --version`
@@ -57,6 +59,8 @@ echo "z/OS version: ${ZOS_VERSION}" > "${VERSION_FILE}"
 echo "Java version: ${JAVA_VERSION}" >> "${VERSION_FILE}"
 echo "NodeJS version: ${NODE_VERSION}" >> "${VERSION_FILE}"
 echo "External Security Manager: ${ESM}" >> "${VERSION_FILE}"
+echo "CEE Runtime Options: ${CEE_OPTIONS}" >> "${VERSION_FILE}"
+echo "Environment variables: ${ENVIRONMENT_VARIABLES}" >> "${VERSION_FILE}"
 print_message
 
 ###############################

--- a/bin/commands/support/index.sh
+++ b/bin/commands/support/index.sh
@@ -60,7 +60,6 @@ echo "Java version: ${JAVA_VERSION}" >> "${VERSION_FILE}"
 echo "NodeJS version: ${NODE_VERSION}" >> "${VERSION_FILE}"
 echo "External Security Manager: ${ESM}" >> "${VERSION_FILE}"
 echo "CEE Runtime Options: ${CEE_OPTIONS}" >> "${VERSION_FILE}"
-echo "Environment variables: ${ENVIRONMENT_VARIABLES}" >> "${VERSION_FILE}"
 print_message
 
 ###############################


### PR DESCRIPTION
HEAPPOOLS64, like HEAPPOOLS, has been identified as a parameter which when not set to OFF will cause issues with code that is built upon le.c or logging.c in zowe-common-c.
This importantly includes the launcher and configmgr, and seems to be a cause of the qjs opcode errors which results in msg ZWEL0029E in startup.

I am adding HEAPPOOLS64(OFF) everywhere HEAPPOOLS(OFF) was (configmgr invocations), but am also adding a new feature to print out all cee run options in the `zwe support` command so that people that are troubleshooting can more easily see what environmental differences people have