### PR TITLE
update cicd-comment-trigger

### DIFF
--- a/.github/workflows/cicd-comment-trigger.yml
+++ b/.github/workflows/cicd-comment-trigger.yml
@@ -39,7 +39,8 @@ jobs:
           gh config set pager cat 
           PR_BRANCH=$(gh pr view ${{ github.event.issue.pull_request }} -R zowe/zowe-install-packaging --json headRefName  -q .headRefName)
           echo "pr_branch_name=$PR_BRANCH" >> $GITHUB_OUTPUT
-
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   trigger-ci:
     name: 'Trigger Build'


### PR DESCRIPTION
Fixes a missing token in the cicd-trigger, must be merged to v2.x/staging to be tested.