### PR TITLE
debug pr labels from ci trigger

### DIFF
--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -95,6 +95,8 @@ jobs:
         # run_build explanation: workflow_dispatch can be manual, '/ci' comment trigger, or nightly. 
         #   If this is a workflow_disaptch and not a '/ci' trigger, always run, ignoring PR labels. Otherwise, always check the label.
         run: |
+          echo ${{ steps.get-labels.outputs.result }}
+          echo ${{ fromJson(steps.get-labels.outputs.result) }}
           echo "run_build=${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.ORIGIN_ISSUE_TRIGGER == 'false') || !contains(fromJson(steps.get-labels.outputs.result), 'Build: None') }}" >> $GITHUB_OUTPUT
       - id: check-test
         name: 'export conditional used to determine if we should run a test suite'

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -77,7 +77,7 @@ jobs:
               return JSON.stringify(${{ toJson(github.event.pull_request.labels) }})
             }  
             else if ('${{ github.event.inputs.ORIGIN_ISSUE_TRIGGER}}' == 'true') {
-              github.rest.pulls.list({
+              const res = await github.rest.pulls.list({
                 state: 'open',
                 head: 'zowe:${{ github.ref_name }}',
                 owner: 'zowe',
@@ -86,6 +86,7 @@ jobs:
                 const pr = resp.data.find((item) => item.head.ref == '${{ github.ref_name }}')
                 return JSON.stringify(pr.labels)
               })
+              return res;
             } else {
               return '[]'
             }

--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -96,8 +96,6 @@ jobs:
         # run_build explanation: workflow_dispatch can be manual, '/ci' comment trigger, or nightly. 
         #   If this is a workflow_disaptch and not a '/ci' trigger, always run, ignoring PR labels. Otherwise, always check the label.
         run: |
-          echo ${{ steps.get-labels.outputs.result }}
-          echo ${{ fromJson(steps.get-labels.outputs.result) }}
           echo "run_build=${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.ORIGIN_ISSUE_TRIGGER == 'false') || !contains(fromJson(steps.get-labels.outputs.result), 'Build: None') }}" >> $GITHUB_OUTPUT
       - id: check-test
         name: 'export conditional used to determine if we should run a test suite'


### PR DESCRIPTION
There's an issue acquiring pr labels when triggered by `/ci`.

Fixed - didn't handle an async fn return value properly