### PR TITLE
Fix nightly/release tests, fingerprint failure on zzow08

### DIFF
--- a/.github/workflows/cicd-test.yml
+++ b/.github/workflows/cicd-test.yml
@@ -80,8 +80,8 @@ env:
   INFINISPAN_CACHING_STORAGE_METHOD_TESTFILE: extended/caching-storages/infinispan-storage.ts
   CONFIG_MANAGER_TESTFILE: extended/config-manager/enable-config-manager.ts
   GENERAL_API_DOCUMENTATION_TESTFILE: basic/install-api-gen.ts
-  ZOWE_NIGHTLY_TESTS_FULL: basic/install.ts(all);basic/install-ptf.ts(all)
-  ZOWE_RELEASE_TESTS_FULL: basic/install.ts(all);basic/install-ptf.ts(all);basic/install-ext.ts(any);extended/keyring.ts(all);extended/node-versions/node-v18.ts(zzow08):extended/certificates/nonstrict-verify-external-certificate.ts(any);extended/caching-storages/infinispan-storage.ts(any);extended/config-manager/enable-config-manager.ts(any)
+  ZOWE_NIGHTLY_TESTS_FULL: basic/install.ts(all);basic/install-fmid.ts(all)
+  ZOWE_RELEASE_TESTS_FULL: basic/install.ts(all);basic/install-fmid.ts(all);basic/install-ext.ts(any);extended/keyring.ts(all);extended/node-versions/node-v18.ts(zzow08):extended/certificates/nonstrict-verify-external-certificate.ts(any);extended/caching-storages/infinispan-storage.ts(any);extended/config-manager/enable-config-manager.ts(any)
 
 jobs:
   display-dispatch-event-id:

--- a/playbooks/host_vars/marist-8.yml
+++ b/playbooks/host_vars/marist-8.yml
@@ -3,13 +3,6 @@ zowe_sanity_test_testcases: "./test/**/!(api-doc-gen).js"
 zowe_apiml_security_x509_enabled: true
 zowe_apiml_security_oidc_enabled: true
 
-work_dir_remote: /ZOWE/ansible
-zowe_root_dir: /ZOWE/runtime
-zowe_instance_dir: /ZOWE/instance
-zowe_extension_dir: /ZOWE/extensions
-zowe_keystore_dir: /ZOWE/keystore
-zowe_install_logs_dir: /ZOWE/logs
-
 zowe_smpe_volser: ZOWE03
 zowe_caching_vsam_volume: ZOWE03
 

--- a/tests/sanity/test/install/test-installed-files.js
+++ b/tests/sanity/test/install/test-installed-files.js
@@ -42,6 +42,7 @@ describe('verify installed files', function() {
 
   it('fingerprint should match', async function() {
     // IMPORT: After 'source' the profile, JAVA_HOME environment variable must exist
+    // note the --config <zowe_yaml_path> assumes the instance dir, which is set in ansible playbooks
     const fingerprintStdout = await sshHelper.executeCommandWithNoError(`touch ~/.profile && . ~/.profile && ${process.env.ZOWE_ROOT_DIR}/bin/zwe support verify-fingerprints --config /ZOWE/tmp/.zowe/zowe.yaml`);
     debug('fingerprint show result:', fingerprintStdout);
     addContext(this, {


### PR DESCRIPTION
This PR addresses failures seen in nightly builds and on zzow08.

Fingerpints:
* Tests are pointing to a hard-coded and incorrect `zowe.yaml` on zzow08. Normalized zzow08 configuration so the hard-coding is correct; the config didn't need to be different from 06/07.

Nightly/Release
* Changed these PTF test suites (applicable 3.1+) to FMID.