### PR TITLE
fix orion sourceDep

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -287,7 +287,7 @@
       "componentGroup": "Zowe Desktop Eclipse Orion-based React Editor",
       "entries": [{
         "repository": "orion-editor-component",
-        "tag": "master",
+        "tag": "v2.x/master",
         "destinations": ["Zowe PAX"]
       }]
     }, {


### PR DESCRIPTION
The orion-editor-component sourceDependency `master` no longer exists, which is causing other automation to fail, including the nightly test trigger. `v2.x/master` looks like the appropriate replacement since the component is only receiving maintenance and dependency upgrades on that line.