### PR TITLE
Reduce shell count by one when configmgr used by using pipe directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Zowe Installer will be documented in this file.
 ## `2.16.0
 
 ## Minor enhancements/defect fixes
+- Enhancement: Reduced resource consumption by removal of one shell process per server that was used when starting each server.  (#3812)
 - Enhancement: The command `zwe support` now includes CEE Runtime option output to better diagnose issues related to environment customization. (#3799)
 - Bugfix: zowe.network.validatePortFree and zowe.network.vipaIp variables were moved from zowe.network to zowe.network.server in the schema but not in the code, causing inability to use them without the workaround of specifying them as environment variables ZWE_NETWORK_VALIDATE_PORT_FREE and ZWE_NETWORK_VIPA_IP instead. Now, the variables match the schema: zowe.network.server is used instead of zowe.network.
 - Bugfix: configmgr operations now run with HEAPPOOLS64 set to OFF to avoid abends caused when this parameter is not OFF. (#3799)

--- a/bin/commands/internal/start/component/index.ts
+++ b/bin/commands/internal/start/component/index.ts
@@ -104,7 +104,7 @@ export function execute(componentId: string, runInBackground: boolean=false) {
           }
           //TODO this will not work with unicode codepoints longer than a byte
           const buf = new ArrayBuffer(startScriptContents.length);
-          const view = new Uint8Array(startScriptContents.length);
+          const view = new Uint8Array(buf);
           const ebcdicString = stringlib.asciiToEbcdic(startScriptContents);
           for (let i = 0; i < startScriptContents.length; i++) {
             view[i] = ebcdicString.charCodeAt(i);

--- a/bin/commands/internal/start/component/index.ts
+++ b/bin/commands/internal/start/component/index.ts
@@ -98,7 +98,7 @@ export function execute(componentId: string, runInBackground: boolean=false) {
           const startScriptContents = `cd ${COMPONENT_DIR} ; . "${ZOWE_CONFIG.zowe.runtimeDirectory}/bin/libs/configmgr-index.sh" ; ${xplatform.loadFileUTF8(fullPath, xplatform.AUTO_DETECT)} ; wait;`;
           const pipeArray = os.pipe();
           if (!pipeArray) {
-            common.printFormattedError("ZWELS", "zwe-internal-start-component", `Error ZWEL064E: failed to run command os.pipe - Connot start component ${componentId}`);
+            common.printFormattedError("ZWELS", "zwe-internal-start-component", `Error ZWEL0064E: failed to run command os.pipe - Cannot start component ${componentId}`);
             return;
           }
           //TODO this will not work with unicode codepoints longer than a byte

--- a/bin/commands/internal/start/component/index.ts
+++ b/bin/commands/internal/start/component/index.ts
@@ -98,8 +98,7 @@ export function execute(componentId: string, runInBackground: boolean=false) {
           const startScriptContents = `cd ${COMPONENT_DIR} ; . "${ZOWE_CONFIG.zowe.runtimeDirectory}/bin/libs/configmgr-index.sh" ; ${xplatform.loadFileUTF8(fullPath, xplatform.AUTO_DETECT)} ; wait;`;
           const pipeArray = os.pipe();
           if (!pipeArray) {
-            //TODO error message
-            common.printFormattedError("ZWELS", "zwe-internal-start-component", `Error ZWEL???E: Could not create pipe.`);    
+            common.printFormattedError("ZWELS", "zwe-internal-start-component", `Error ZWEL064E: failed to run command os.pipe - Connot start component ${componentId}`);
             return;
           }
           //TODO this will not work with unicode codepoints longer than a byte


### PR DESCRIPTION
When inspecting for optimizations and reduction of shell usage for TMPDIR troubleshooting, I noticed that there's some unneeded use of shell wrappers for running each server.

In the code today, each time a start.sh of a server is run we spawn a shell to run that in, and then pipe its contents to ANOTHER shell so that we can put `wait` at the end.

We could have just spawned one shell with that pipe, instead of a shell-within-a-shell.
This looks to be largely from the old non-configmgr code, and configmgr can just further optimize.

The process tree goes from 7 processes in the case of zss:
![before](https://github.com/zowe/zowe-install-packaging/assets/30730276/e2d18d1f-c58c-4a3e-9cb1-2a1af053b740)

To 6:
![after](https://github.com/zowe/zowe-install-packaging/assets/30730276/4c3812b1-723a-4db4-bb18-6c7ecb410ec5)


An effort here can further reduce it to 5 https://github.com/zowe/launcher/issues/109
With both efforts combined, the tree of a given Zowe server would just be
* Launcher
    * configmgr
        * server's own start script 
            * server itself
            
But today it is

* Launcher
    * zwe
        * configmgr
            * shell wrapper being removed in this PR 
                * server's own start script 
                    * server itself

How to test this PR?
If the servers come up the same as they did before, success.
If a server is crashed (intentionally or unintentionally), launcher should have the same restart behavior as before.