### PR TITLE
Changes to sed command to use pr 107 of launcher

### DIFF
--- a/bin/commands/init/stc/index.sh
+++ b/bin/commands/init/stc/index.sh
@@ -115,7 +115,7 @@ else
     print_message "Please manually verify if this path works for your environment, especially when you are working in Sysplex environment."
   fi
   result=$(cat "//'${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWESLSTC)'" | \
-          sed "s/^\/\/STEPLIB .*\$/\/\/STEPLIB  DD   DSNAME=${authLoadlib},DISP=SHR/" | \
+          sed "s/^\/\/STEPLIB .*\$/\/\/STEPLIB  DD   DSNAME=${authLoadlib},/" | \
           sed "s#^CONFIG=.*\$#CONFIG=$(convert_to_absolute_path ${ZWE_CLI_PARAMETER_CONFIG})#" \
           > "${tmpfile}")
   code=$?


### PR DESCRIPTION
PR https://github.com/zowe/launcher/pull/107 which is primarily for the JCL PR, can be merged prior to it as long as this PR is merged which makes the current work compatible with it.

The incompatibility fixed here is just that the DISP=SHR argument is on a different line, so the sed command needs adjustment to that.