### PR TITLE
Node v20 Tests

### DIFF
--- a/.github/scripts/cicd_test/make_matrix.sh
+++ b/.github/scripts/cicd_test/make_matrix.sh
@@ -37,6 +37,10 @@ case $install_test_choice in
   test_force_system="zzow08"
   ;;
 
+"z/OS node v20")
+  test_file="$ZOS_NODE_V20_TESTFILE"
+  ;;
+
 "Non-strict Verify External Certificate")
   test_file="$NON_STRICT_VERIFY_EXTERNAL_CERTIFICATE_TESTFILE"
   ;;

--- a/.github/workflows/cicd-test-readme.md
+++ b/.github/workflows/cicd-test-readme.md
@@ -109,7 +109,7 @@ Background: CICD testing relies on a `zowe.pax` or `zowe-smpe.zip` (for SMPE ins
 When running CICD integration tests during RC stage, the following string will be parsed into the Github Actions matrix. As a result, a total of 21 independent jobs will be spawned.
 
 ```
-basic/install.ts(zzow06,zzow07,zzow08);basic/install-ptf.ts(zzow06,zzow07,zzow08);basic/install-ext.ts(zzow07);extended/keyring.ts(zzow06,zzow07,zzow08);extended/node-versions/node-v18.ts(zzow06,zzow07,zzow08);extended/certificates/nonstrict-verify-external-certificate.ts(zzow06)
+basic/install.ts(zzow06,zzow07,zzow08);basic/install-ptf.ts(zzow06,zzow07,zzow08);basic/install-ext.ts(zzow07);extended/keyring.ts(zzow06,zzow07,zzow08);extended/node-versions/node-v18.ts(zzow06,zzow07,zzow08);extended/node-versions/node-v20.ts(zzow06,zzow07,zzow08);extended/certificates/nonstrict-verify-external-certificate.ts(zzow06)
 ```
 
 Total elapsed time when running in parallel is approximately 3.5 hours on paper idealy if all parallel jobs are executing at the same time. In reality, from numerous tests performed, total elapsed time is around 4 hours.  
@@ -122,6 +122,7 @@ Selected test running elapsed time:
 | Convenience Pax | 53m |
 | SMPE PTF | 68m |
 | z/OS node v18 | 45m |
+| z/OS node v20 | 45m |
 | Keyring | 53m |
 | Non-strict Verify External Certificate | 51m |
 | Extensions | 67m

--- a/.github/workflows/cicd-test.yml
+++ b/.github/workflows/cicd-test.yml
@@ -25,6 +25,7 @@ on:
           - Extensions
           - Keyring
           - z/OS node v18
+          - z/OS node v20
           - Non-strict Verify External Certificate
           - Install PTF Twice
           - VSAM Caching Storage Method
@@ -74,6 +75,7 @@ env:
   EXTENSIONS_TESTFILE: basic/install-ext.ts
   KEYRING_TESTFILE: extended/keyring.ts
   ZOS_NODE_V18_TESTFILE: extended/node-versions/node-v18.ts
+  ZOS_NODE_V20_TESTFILE: extended/node-versions/node-v20.ts
   NON_STRICT_VERIFY_EXTERNAL_CERTIFICATE_TESTFILE: extended/certificates/nonstrict-verify-external-certificate.ts
   INSTALL_PTF_TWICE_TESTFILE: extended/install-ptf-two-times.ts
   VSAM_CACHING_STORAGE_METHOD_TESTFILE: extended/caching-storages/vsam-storage.ts
@@ -81,7 +83,7 @@ env:
   CONFIG_MANAGER_TESTFILE: extended/config-manager/enable-config-manager.ts
   GENERAL_API_DOCUMENTATION_TESTFILE: basic/install-api-gen.ts
   ZOWE_NIGHTLY_TESTS_FULL: basic/install.ts(all);basic/install-ptf.ts(all)
-  ZOWE_RELEASE_TESTS_FULL: basic/install.ts(all);basic/install-ptf.ts(all);basic/install-ext.ts(any);extended/keyring.ts(all);extended/node-versions/node-v18.ts(zzow08):extended/certificates/nonstrict-verify-external-certificate.ts(any);extended/caching-storages/infinispan-storage.ts(any);extended/config-manager/enable-config-manager.ts(any)
+  ZOWE_RELEASE_TESTS_FULL: basic/install.ts(all);basic/install-ptf.ts(all);basic/install-ext.ts(any);extended/keyring.ts(all);extended/node-versions/node-v18.ts(zzow08);extended/node-versions/node-v20.ts(any);extended/certificates/nonstrict-verify-external-certificate.ts(any);extended/caching-storages/infinispan-storage.ts(any);extended/config-manager/enable-config-manager.ts(any)
 
 jobs:
   display-dispatch-event-id:
@@ -290,6 +292,9 @@ jobs:
                 eta = 53
                 break;
               case 'z/OS node v18':
+                eta = 45
+                break;
+              case 'z/OS node v20':
                 eta = 45
                 break;
               case 'Infinispan Caching Storage Method':

--- a/tests/installation/src/__tests__/extended/node-versions/node-v20.ts
+++ b/tests/installation/src/__tests__/extended/node-versions/node-v20.ts
@@ -1,0 +1,44 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright IBM Corporation 2022
+ */
+
+import {
+  checkMandatoryEnvironmentVariables,
+  installAndVerifyConvenienceBuild,
+  showZoweRuntimeLogs,
+} from '../../../utils';
+import { TEST_TIMEOUT_CONVENIENCE_BUILD } from '../../../constants';
+
+const testServer = process.env.TEST_SERVER;
+const testSuiteName = 'Test convenience build installation with node.js v20';
+describe(testSuiteName, () => {
+  beforeAll(() => {
+    // validate variables
+    checkMandatoryEnvironmentVariables([
+      'ZOWE_BUILD_LOCAL',
+    ]);
+  });
+
+  test('install and verify', async () => {
+    await installAndVerifyConvenienceBuild(
+      testSuiteName,
+      testServer,
+      {
+        'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
+        'zowe_custom_for_test': 'true',
+        'zos_node_home': '/ZOWE/node/node-v20.11.0',
+        'zowe_lock_keystore': 'false',
+      }
+    );
+  }, TEST_TIMEOUT_CONVENIENCE_BUILD);
+
+  afterAll(async () => {
+    await showZoweRuntimeLogs(testServer);
+  })
+});


### PR DESCRIPTION
Adds node v20 to backend systems and creates new tests for Node v20. Adds Node v20 to the nightly/release test suite.

Node 20 passing test:
https://github.com/zowe/zowe-install-packaging/actions/runs/9007882831/job/24748714570
