### PR TITLE
Test - launcher without zwe

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -124,7 +124,9 @@
       "artifact": "configmgr-2.16.0-2024051014.pax"
     },
     "org.zowe.launcher": {
-      "version": "2.16.0"
+      "version": "^2.15.0-PR-115",
+      "artifact": "*.pax",
+      "repository": "libs-snapshot-local"
     },
     "org.zowe.keyring-utilities": {
       "version": "1.0.4",


### PR DESCRIPTION
Test build which uses launcher proof of concept where it calls configmgr binary directly to shorten startup time.