### PR TITLE
Runtime option fix and minor changes

### DIFF
--- a/bin/commands/support/.help
+++ b/bin/commands/support/.help
@@ -7,6 +7,7 @@ This command will collect these information:
   * Java version
   * Node.js version
   * External Security Manager
+  * CEE Runtime Options
 - Zowe configurations
   * Zowe manifest.json
   * Zowe configuration file

--- a/bin/commands/support/index.sh
+++ b/bin/commands/support/index.sh
@@ -11,6 +11,13 @@
 # Copyright Contributors to the Zowe Project.
 #######################################################################
 
+print_message_file() {
+  msg="${1}"
+  out_file="${2}"
+  print_message "- ${msg}"
+  echo "${msg}" >> "${out_file}"
+}
+
 print_level0_message "Collect information for Zowe support"
 
 ###############################
@@ -43,23 +50,23 @@ print_debug "Temporary directory created: ${tmp_dir}"
 print_message
 
 ###############################
-print_level1_message "Collecting information about z/OS, Java, NodeJS and ESM"
-VERSION_FILE="${tmp_dir}/version_output"
+print_level1_message "Collecting various environment information"
+ENVIRONMENT_FILE="${tmp_dir}/environment_output"
+echo "[Environment information]" > "${ENVIRONMENT_FILE}"
 ZOS_VERSION=`operator_command "D IPLINFO" | grep -i release | xargs`
-print_message "- z/OS: ${ZOS_VERSION}"
-CEE_OPTIONS=`tsocmd "OMVS RUNOPTS('RPTOPTS(ON)')"`
-print_message "- CEE Runtime Options: ${CEE_OPTIONS}"
+if [ -z "${ZOS_VERSION}" ]; then
+  ZOS_VERSION=`sysvar SYSOSLVL`
+fi
 JAVA_VERSION=`${JAVA_HOME}/bin/java -version 2>&1 | head -n 1`
-print_message "- Java: ${JAVA_VERSION}"
 NODE_VERSION=`${NODE_HOME}/bin/node --version`
-print_message "- NodeJS: ${NODE_VERSION}"
 ESM=`"${ZWE_zowe_runtimeDirectory}/bin/utils/getesm"`
-print_message "- External Security Manager: ${ESM}"
-echo "z/OS version: ${ZOS_VERSION}" > "${VERSION_FILE}"
-echo "Java version: ${JAVA_VERSION}" >> "${VERSION_FILE}"
-echo "NodeJS version: ${NODE_VERSION}" >> "${VERSION_FILE}"
-echo "External Security Manager: ${ESM}" >> "${VERSION_FILE}"
-echo "CEE Runtime Options: ${CEE_OPTIONS}" >> "${VERSION_FILE}"
+CEE_OPTIONS=`tsocmd "OMVS RUNOPTS('RPTOPTS(ON)')" 2>&1`
+
+print_message_file "z/OS version: ${ZOS_VERSION}" "${ENVIRONMENT_FILE}"
+print_message_file "Java version: ${JAVA_VERSION}" "${ENVIRONMENT_FILE}"
+print_message_file "NodeJS version: ${NODE_VERSION}" "${ENVIRONMENT_FILE}"
+print_message_file "External Security Manager: ${ESM}" "${ENVIRONMENT_FILE}"
+print_message_file "CEE Runtime Options: ${CEE_OPTIONS}" "${ENVIRONMENT_FILE}"
 print_message
 
 ###############################


### PR DESCRIPTION
1) The output of `CEE_OPTIONS=tsocmd "OMVS RUNOPTS('RPTOPTS(ON)')"` was not saved to due to error. The content of `version_output` was (missing the important part):
```
z/OS version: RELEASE z/OS 03.01.00 LICENSE = z/OS
Java version: java version "1.8.0_123"
NodeJS version: v18.24.0
External Security Manager: TSS
CEE Runtime Options: FSUM2051I The OMVS command failed because the display screen size is not supported.+
FSUM2052I The screen size must be at least 12 by 40 but less than 10000 bytes total.  The actual primary screen size is 255 by 255 (
65025 bytes).  The alternate screen size is 255 by 255 (65025 bytes).
```
2) `version_output` renamed to `environment_output`
3) Small change in help
4) If no SDSF, get the z/OS version from `&SYSOSLVL`
5) `print_message_file` to simplify the code

With fix, the output is like (some values might be altered):
```
[Environment information]
z/OS version: RELEASE z/OS 03.03.00 LICENSE = z/OS
Java version: java version "1.9.0_123"
NodeJS version: v22.00.01
External Security Manager: 007
CEE Runtime Options: OMVS RUNOPTS('RPTOPTS(ON)')
FSUM2051I The OMVS command failed because the display screen size is not supported.+
FSUM2052I The screen size must be at least 12 by 40 but less than 10000 bytes total.  The actual primary screen size is 255 by 255 (
65025 bytes).  The alternate screen size is 255 by 255 (65025 bytes).
LAST WHERE SET                 OPTION
-------------------------------------------------------------------------------
PARMLIB(CEEPRM00)              SKYNET(OFF)
PARMLIB(CEEPRM00)              T800(DEACTIVATED)
Programmer default             PIZZA,HAMBURGER,BEER
Default setting                BE_NICE_TO_EACH_OTHER
...
```