### PR TITLE
Fix PTF Test Errors in v1.x

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -261,6 +261,7 @@ $ ansible-playbook -l <server> show-logs.yml -v
 - **zowe_auto_create_user_group**: A boolean value to enable or disable creating Zowe user and group. Default value is `false`.
 - **zowe_configure_skip_zwesecur**: A boolean value to skip running `ZWESECUR` job when configure Zowe instance.
 - **zos_keystore_mode**: An optional string to configure Zowe instance to store certificates into Keyring instead of keystore. Valid values are `<empty>` (default value) or `KEYSTORE_MODE_KEYRING`.
+- **skip_configfmid**: A boolean value to skip automatically configuring Zowe after FMID installation. Default value is `false`.
 - **skip_start**: A boolean value to skip automatically starting Zowe after installation. Default value is `false`.
 - **zowe_uninstall_before_install**: If you want to uninstall Zowe before installing a new version. Default value is `true`.
 - **ZOWE_COMPONENTS_UPGRADE**: An optional boolean value to enable upgrading Zowe components to the latest version. If set to `true`,

--- a/playbooks/install-fmid.yml
+++ b/playbooks/install-fmid.yml
@@ -83,6 +83,7 @@
   # Configure Zowe
   - import_role:
       name: configfmid
+    when: not skip_configfmid|default(False)
 
   # ============================================================================
   # Start Zowe

--- a/tests/installation/src/utils.ts
+++ b/tests/installation/src/utils.ts
@@ -381,7 +381,9 @@ export async function installAndVerifySmpePtf(testcase: string, serverId: string
     'install-fmid.yml',
     serverId,
     {
-      'zowe_build_remote': ZOWE_FMID
+      'zowe_build_remote': ZOWE_FMID,
+      'skip_configfmid': 'true',
+      'skip_start': 'true'
     }
   );
 


### PR DESCRIPTION
v1.x/rc PTF tests are failing due to an unnecessary configuration steps in the playbook automation, which runs pre-patched base FMID scripts instead of the target install level (current PTF). This PR adds an option to disable configuration actions in the FMID playbook, and the PTF installation tests use that option.