### PR TITLE
Update yaml diff generator

### DIFF
--- a/.github/workflows/diff-yaml
+++ b/.github/workflows/diff-yaml
@@ -1,4 +1,4 @@
-name: Generate schema diff
+name: Generate example yaml diff
 on:
   push:
     branches:
@@ -32,10 +32,10 @@ jobs:
       - name: '[Prep 4] Get from version'
         run: node -e "if ('${{ github.event.inputs.FROM_COMMIT }}'.length > 0) { console.log('FROM=${{ github.event.inputs.FROM_COMMIT }}') } else { let parts = '${{ env.TO }}'.split('.'); parts[1]--; console.log('FROM='+parts.join('.')); }" >> $GITHUB_ENV
       - name: '[Build] Make diff'
-        run: git diff ${{ env.FROM }} ${{ env.TO }} -- example-zowe.yaml > yaml.diff
+        run: git diff ${{ env.FROM }} ${{ env.TO }} -- example-zowe.yaml > example-yaml.diff
       - name: '[Upload]'
         uses: actions/upload-artifact@v3
         with:
-          name: schemas.diff
-          path: schemas.diff
+          name: example-yaml.diff
+          path: example-yaml.diff
           if-no-files-found: error


### PR DESCRIPTION
Accidentally, I had the yaml diff generator and schema diff generator share the same workflow name and output name, so really only the schema diff generator was running!
This will fix it by making them distinct.