### PR TITLE
setup dependabot.yml to group PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"
       all-security-minorpatch:
         applies-to: security-updates  
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      all-version-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      all-security-minorpatch:
+        applies-to: security-updates  
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
Sets dependabot to group updates when they're version updates or security updates which are on a minor/patch release boundary. This should help us keep PR count down. 

Version or security updates which occur on a major release boundary are still created as separate PRs, since they're more likely to introduce some kind of breakage to their respective project and would need to be debugged apart from other updates (sanity-test, install-test, actions, otherwise).

