### PR TITLE
Validate appfw plugins schema during component install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Zowe Installer will be documented in this file.
 ## `2.17.0`
 
 ## New features and enhancements
+- Enhancement: `zwe components install` and `zwe components upgrade` now checks the schema validity of any application framework plugins present within a component, so that you will know better if a component is valid prior to running Zowe. [#3866](https://github.com/zowe/zowe-install-packaging/pull/3866) 
 - Enhancement: Added zowe.network.server.tls.attls and zowe.network.client.tls.attls as booleans for controlling global or per-component way to tell Zowe servers that they should operate in a mode compatible with an AT-TLS setup. [#3463](https://github.com/zowe/zowe-install-packaging/pull/3463)
 
 ## `2.16.0`

--- a/bin/commands/components/install/extract/index.ts
+++ b/bin/commands/components/install/extract/index.ts
@@ -155,7 +155,13 @@ export function execute(componentFile: string, autoEncoding?: string, upgrade?: 
   //   If invalid, the installation will exit with an error message.
   if (manifest.appfwPlugins) {
     manifest.appfwPlugins.forEach((appfwPlugin: {path: string})=> {
-      component.getPluginDefinition(pathoid.resolve(tmpDir, appfwPlugin.path));
+      let result = component.getPluginDefinition(pathoid.resolve(tmpDir, appfwPlugin.path), true);
+      //Normally, getPluginDefinition would quit upon failure. But we want to cleanup the tmpDir before that.
+      // So, we pass true to allow it to continue, check for null, and then remove the tmpdir and exit if so.
+      if (result === null) {
+        fs.rmrf(tmpDir);
+        std.exit(1);
+      }
     });
   }
   

--- a/bin/commands/components/install/extract/index.ts
+++ b/bin/commands/components/install/extract/index.ts
@@ -150,6 +150,14 @@ export function execute(componentFile: string, autoEncoding?: string, upgrade?: 
     common.printErrorAndExit(`Error ZWEL0167E: Cannot find component name from ${componentFile} package manifest`, undefined, 167);
   }
   common.printDebug(`- Component name found as ${componentName}`);
+
+  // If the component has appfw plugins, their validity should be checked against appfw plugin schema.
+  //   If invalid, the installation will exit with an error message.
+  if (manifest.appfwPlugins) {
+    manifest.appfwPlugins.forEach((appfwPlugin: {path: string})=> {
+      component.getPluginDefinition(pathoid.resolve(tmpDir, appfwPlugin.path));
+    });
+  }
   
   const destinationDir = pathoid.resolve(targetDir, componentName);
   const bkpDir = pathoid.resolve(targetDir, `${componentName}_zwebkp`);

--- a/bin/libs/component.ts
+++ b/bin/libs/component.ts
@@ -116,32 +116,33 @@ function showExceptions(e: any,depth: number): void {
 
 export function getPluginDefinition(pluginRootPath:string, continueOnFailure?: boolean) {
   const pluginDefinitionPath = `${pluginRootPath}/pluginDefinition.json`;
+  const configId = `appfwPlugin:${pluginRootPath}`;
 
   const printer = continueOnFailure ? common.printError : common.printErrorAndExit;
 
   if (fs.fileExists(pluginDefinitionPath)) {
     let status;
-    if ((status = CONFIG_MGR.addConfig(pluginRootPath))) {
+    if ((status = CONFIG_MGR.addConfig(configId))) {
       printer(`Could not add config for ${pluginRootPath}, status=${status}`);
       return null;
     }
     
-    if ((status = CONFIG_MGR.loadSchemas(pluginRootPath, PLUGIN_DEF_SCHEMAS))) {
+    if ((status = CONFIG_MGR.loadSchemas(configId, PLUGIN_DEF_SCHEMAS))) {
       printer(`Could not load schemas ${PLUGIN_DEF_SCHEMAS} for plugin ${pluginRootPath}, status=${status}`);
       return null;
     }
 
 
-    if ((status = CONFIG_MGR.setConfigPath(pluginRootPath, `FILE(${pluginDefinitionPath})`))) {
+    if ((status = CONFIG_MGR.setConfigPath(configId, `FILE(${pluginDefinitionPath})`))) {
       printer(`Could not set config path for ${pluginDefinitionPath}, status=${status}`);
       return null;
     }
-    if ((status = CONFIG_MGR.loadConfiguration(pluginRootPath))) {
+    if ((status = CONFIG_MGR.loadConfiguration(configId))) {
       printer(`Could not load config for ${pluginDefinitionPath}, status=${status}`);
       return null;
     }
 
-    let validation = CONFIG_MGR.validate(pluginRootPath);
+    let validation = CONFIG_MGR.validate(configId);
     if (validation.ok){
       if (validation.exceptionTree){
         common.printError(`Validation of ${pluginDefinitionPath} against schema ${PLUGIN_DEF_SCHEMA_ID} found invalid JSON Schema data`);
@@ -151,7 +152,7 @@ export function getPluginDefinition(pluginRootPath:string, continueOnFailure?: b
         }
         return null;
       } else {
-        return CONFIG_MGR.getConfigData(pluginRootPath);
+        return CONFIG_MGR.getConfigData(configId);
       }
     } else {
       printer(`Error occurred on validation of ${pluginDefinitionPath} against schema ${PLUGIN_DEF_SCHEMA_ID} `);


### PR DESCRIPTION
Resolves https://github.com/zowe/zowe-install-packaging/issues/3863 by simply checking for appfwPlugin entries in a component manifest and then running a loop of `getPluginDefinition()` during the install extract step (called during both install and upgrade) but not caring about the output - it either passes or quits in error if schema is invalid.

I put this in a spot of the code where the component directory is still a temp dir - not yet resolved so that if a failure occurs then the folder can be removed.