### PR TITLE
Add internal output command to generates configmgr merged yaml anytime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ manifest.json
 artifactory-download-spec.json
 
 # zowe jobs output
-output/
+./output/
 
 # release temporary folder
 .release/

--- a/bin/commands/internal/config/output/.examples
+++ b/bin/commands/internal/config/output/.examples
@@ -1,0 +1,1 @@
+zwe internal config output -c /path/to/zowe.yaml

--- a/bin/commands/internal/config/output/.help
+++ b/bin/commands/internal/config/output/.help
@@ -1,0 +1,1 @@
+Outputs the merged YAML used at Zowe runtime into zowe.workspaceDirectory/.env/.zowe-merged.yaml

--- a/bin/commands/internal/config/output/cli.ts
+++ b/bin/commands/internal/config/output/cli.ts
@@ -1,0 +1,13 @@
+/*
+  This program and the accompanying materials are made available
+  under the terms of the Eclipse Public License v2.0 which
+  accompanies this distribution, and is available at
+  https://www.eclipse.org/legal/epl-v20.html
+ 
+  SPDX-License-Identifier: EPL-2.0
+ 
+  Copyright Contributors to the Zowe Project.
+*/
+import * as std from 'cm_std';
+import * as index from './index';
+index.execute();

--- a/bin/commands/internal/config/output/index.sh
+++ b/bin/commands/internal/config/output/index.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+#######################################################################
+# This program and the accompanying materials are made available
+# under the terms of the Eclipse Public License v2.0 which
+# accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+#######################################################################
+
+_CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF),HEAPPOOLS64(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/internal/config/output/cli.js"

--- a/bin/commands/internal/config/output/index.ts
+++ b/bin/commands/internal/config/output/index.ts
@@ -1,0 +1,18 @@
+/*
+  This program and the accompanying materials are made available
+  under the terms of the Eclipse Public License v2.0 which
+  accompanies this distribution, and is available at
+  https://www.eclipse.org/legal/epl-v20.html
+ 
+  SPDX-License-Identifier: EPL-2.0
+ 
+  Copyright Contributors to the Zowe Project.
+*/
+
+import * as common from '../../../../libs/common';
+import * as config from '../../../../libs/config';
+
+export function execute() {
+  common.requireZoweYaml();
+  const ZOWE_CONFIG=config.getZoweConfig();
+}


### PR DESCRIPTION
When configmgr zwe code starts, it resolves all templates and merges all yaml files and parmlibs into one merged yaml file that is put in the .env folder for use by zowe and zowe servers.

This is useful to allow code that doesnt understand configmgr concepts to take advantage of the config results.

This command is intended to be run by any code within the STC that wishes to make use of the merged yaml file indirectly.

All this code does is run the configmgr startup procedure and nothing more. So, it is not new code, just a new way to invoke the existing code.

Example

`zwe internal generate -c FILE(/path/to/zowe.yaml):FILE(/path/to/default.yaml)`

Result

`workspace/.env/zowe-merged.yaml` is created, as a merger of those two files.