### PR TITLE
Improve 121  and 122 messages to clarify choices

### DIFF
--- a/bin/libs/java.sh
+++ b/bin/libs/java.sh
@@ -83,7 +83,7 @@ require_java() {
   fi
 
   if [ -z "${JAVA_HOME}" ]; then
-    print_error_and_exit "Error ZWEL0122E: Cannot find java. Please define JAVA_HOME environment variable." "" 122
+    print_error_and_exit "Error ZWEL0122E: Cannot find java. Set the java.path value in the Zowe YAML, or include java in the PATH environment variable of any accounts that start or manage Zowe" "" 122
   fi
 
   ensure_java_is_on_path

--- a/bin/libs/java.ts
+++ b/bin/libs/java.ts
@@ -72,7 +72,7 @@ export function requireJava() {
     } 
   }
   if (!std.getenv('JAVA_HOME')) {
-    common.printErrorAndExit("Error ZWEL0122E: Cannot find java. Please define JAVA_HOME environment variable.", undefined, 122);
+    common.printErrorAndExit("Error ZWEL0122E: Cannot find java. Set the java.home value in the Zowe YAML, or include java in the PATH environment variable of any accounts that start or manage Zowe", undefined, 122);
   }
 
   ensureJavaIsOnPath();

--- a/bin/libs/node.sh
+++ b/bin/libs/node.sh
@@ -94,7 +94,7 @@ require_node() {
   fi
 
   if [ -z "${NODE_HOME}" ]; then
-    print_error_and_exit "Error ZWEL0121E: Cannot find node. Please define NODE_HOME environment variable." "" 121
+    print_error_and_exit "Error ZWEL0121E: Cannot find node. Set the node.path value in the Zowe YAML, or include node in the PATH environment variable of any accounts that start or manage Zowe" "" 121
   fi
 
   ensure_node_is_on_path

--- a/bin/libs/node.ts
+++ b/bin/libs/node.ts
@@ -78,7 +78,7 @@ export function requireNode() {
     }
   }
   if (!std.getenv('NODE_HOME')) {
-    common.printErrorAndExit("Error ZWEL0121E: Cannot find node. Please define NODE_HOME environment variable.", undefined, 121);
+    common.printErrorAndExit("Error ZWEL0121E: Cannot find node. Set the node.home value in the Zowe YAML, or include node in the PATH environment variable of any accounts that start or manage Zowe", undefined, 121);
   }
 
   ensureNodeIsOnPath();


### PR DESCRIPTION
Sometimes users have reported errors when doing zowe setup because they skipped a step in defining the location of java and node.
The error that can print out, ZWEL0122E and ZWEL0121E, is helpful but incomplete.
This PR just improves the message to make it easier to understand how to fix.