### PR TITLE
Updated help output for accuracy and yaml syntax

### DIFF
--- a/bin/commands/init/apfauth/.help
+++ b/bin/commands/init/apfauth/.help
@@ -4,7 +4,7 @@ NOTE: You require proper permission to run APF authorize command.
 
 These Zowe YAML configurations showing with sample values are used:
 
-```
+```yaml
 zowe:
   setup:
     dataset:

--- a/bin/commands/init/certificate/.help
+++ b/bin/commands/init/certificate/.help
@@ -7,7 +7,7 @@ be written back to your Zowe YAML configuration file:
 
 These Zowe YAML configurations showing with sample values are used:
 
-```
+```yaml
 zowe:
   setup:
     dataset:
@@ -148,12 +148,12 @@ zOSMF:
     Zowe the label of existing certificate.
 - If `zowe.verifyCertificates` is not `DISABLED`, and z/OSMF host (`zOSMF.host`)
   is provided, Zowe will try to trust z/OSMF certificate.
-  * If you are using `RACF` security manager, Zowe will try to automatically
-    detect the z/OSMF CA based on certificate owner specified by
+  * If you are using `RACF` or `TSS` security manager, Zowe will try to
+    automatically detect the z/OSMF CA based on certificate owner specified by
     `zowe.setup.certificate.keyring.zOSMF.user`. Default value of this field is
     `IZUSVR`. If the automatic detection failed, you will need to define
     `zowe.setup.certificate.keyring.zOSMF.ca` indicates what is the label of
     z/OSMF root certificate authority.
-  * If you are using `ACF2` or `TSS` (Top Secret) security manager,
+  * If you are using `ACF2` security manager,
     `zowe.setup.certificate.keyring.zOSMF.ca` is required to indicates what is
     the label of z/OSMF root certificate authority.

--- a/bin/commands/init/mvs/.help
+++ b/bin/commands/init/mvs/.help
@@ -2,7 +2,7 @@ This command will prepare Zowe custom data sets.
 
 These Zowe YAML configurations showing with sample values are used:
 
-```
+```yaml
 zowe:
   setup:
     dataset:

--- a/bin/commands/init/security/.help
+++ b/bin/commands/init/security/.help
@@ -4,7 +4,7 @@ NOTE: You require proper permission to run security configuration.
 
 These Zowe YAML configurations showing with sample values are used:
 
-```
+```yaml
 zowe:
   setup:
     dataset:

--- a/bin/commands/init/stc/.help
+++ b/bin/commands/init/stc/.help
@@ -5,7 +5,7 @@ NOTE: You require proper permission to write to target procedure library.
 
 These Zowe YAML configurations showing with sample values are used:
 
-```
+```yaml
 zowe:
   setup:
     dataset:

--- a/bin/commands/init/vsam/.help
+++ b/bin/commands/init/vsam/.help
@@ -1,9 +1,9 @@
-This command will run ZWECSVSM jcl to create VSAM data set for Zowe APIML
+This command will run ZWECSVSM JCL to create VSAM data set for Zowe APIML
 Caching Service.
 
 These Zowe YAML configurations showing with sample values are used:
 
-```
+```yaml
 zowe:
   setup:
     dataset:
@@ -21,9 +21,9 @@ components:
         name: IBMUSER.ZWE.CUST.CACHE2
 ```
 
-- `zowe.setup.dataset.prefix` shows where the `SZWESAMP` data set is installed,
-- `zowe.setup.dataset.jcllib` is the custom JCL library. Zowe will create customized
-  ZWESECUR JCL here before applying it.
+- `zowe.setup.dataset.prefix` shows where the `SZWESAMP` data set is installed.
+- `zowe.setup.dataset.jcllib` is the custom JCL library. Zowe server command may
+  generate sample JCLs and put into this data set.
 - `zowe.setup.vsam.mode` indicates whether the VSAM will utilize Record Level
   Sharing (RLS) services or not. Valid value is `RLS` or `NONRLS`.
 - `zowe.setup.vsam.volume` indicates the name of volume.

--- a/bin/commands/install/.help
+++ b/bin/commands/install/.help
@@ -6,7 +6,7 @@ already prepared during SMPE install.
 
 These Zowe YAML configurations showing with sample values are used:
 
-```
+```yaml
 zowe:
   setup:
     dataset:
@@ -19,3 +19,4 @@ Expected outputs:
   * `SZWEAUTH` contains few Zowe load modules (++PROGRAM).
   * `SZWESAMP` contains several sample configurations.
   * `SZWEEXEC` contains few utilities used by Zowe.
+  * `SZWELOAD` contains config manager for REXX.

--- a/bin/commands/start/.help
+++ b/bin/commands/start/.help
@@ -2,7 +2,7 @@ Start Zowe with main started task.
 
 These Zowe YAML configurations showing with sample values are used:
 
-```
+```yaml
 zowe:
   setup:
     security:

--- a/bin/commands/stop/.help
+++ b/bin/commands/stop/.help
@@ -2,7 +2,7 @@ Stop Zowe main job.
 
 These Zowe YAML configurations showing with sample values are used:
 
-```
+```yaml
 zowe:
   setup:
     security:


### PR DESCRIPTION
This PR contains updates to the zwe embedded `--help` documentation, such as typo fixes, missing information, and yaml syntax markdown hinting.