### PR TITLE
Remove unused convert script

### DIFF
--- a/bin/libs/config.sh
+++ b/bin/libs/config.sh
@@ -14,26 +14,6 @@
 # @internal 
 
 ###############################
-# Convert instance.env to zowe.yaml file
-convert_instance_env_to_yaml() {
-  instance_env="${1}"
-  zowe_yaml="${2}"
-
-  # we need node for following commands
-  ensure_node_is_on_path 1>/dev/null 2>&1
-
-  if [ -z "${zowe_yaml}" ]; then
-    node "${ROOT_DIR}/bin/utils/config-converter/src/cli.js" env yaml "${instance_env}"
-  else
-    node "${ROOT_DIR}/bin/utils/config-converter/src/cli.js" env yaml "${instance_env}" -o "${zowe_yaml}"
-
-    ensure_file_encoding "${zowe_yaml}" "zowe:" "IBM-1047"
-
-    chmod 640 "${zowe_yaml}"
-  fi
-}
-
-###############################
 # Check encoding of a file and convert to IBM-1047 if needed.
 #
 # Note: usually this is required if the file is supposed to be shell script,


### PR DESCRIPTION
While working on PR 3718, this block of code was spotted as dead.
It was used prior to v2.16.0, but in that release it was replaced with some QJS code that did the same thing.
I have not found any references to this function in the current codebase and testing of PR 3718 has revealed it to be unused.