### PR TITLE
feat: add icsf hardware keyring flag

### DIFF
--- a/example-zowe.yaml
+++ b/example-zowe.yaml
@@ -429,6 +429,7 @@ zowe:
       password: password
       # alias is the name of your key/cert. When using keyrings, get the Case Sensitive, Space Sensitive value in a TSO list ring.
       alias: localhost
+      icsfHwKey: false
     truststore:
       # truststore usually has same values as keystore (minus alias), but can be different if desired.
       type: PKCS12

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -682,6 +682,11 @@
             "alias": {
               "type": "string",
               "description": "Certificate alias name of defined in your PKCS#12 keystore"
+            },
+            "icsfHwKey": {
+              "type": "boolean",
+              "description": "Marks the keyring as ICSF hardware private key storage",
+              "default": false   
             }
           }
         },

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -768,6 +768,11 @@
             "alias": {
               "type": "string",
               "description": "Certificate label of z/OS keyring. Case sensitivity and spaces matter."
+            },
+            "icsfHwKey": {
+              "type": "boolean",
+              "description": "Marks the keyring as ICSF hardware private key storage",
+              "default": false   
             }
           }
         },


### PR DESCRIPTION
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [ ] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 

- [ ] Feature

#### Changes proposed in this PR

API-ML needs to know if a Zowe instance has a SAF Keyring with ICSF hardware key storage to avoid attempting reading the SAF keyring contents under some AT-TLS conditions:

If AT-TLS is enabled:

    With z/OSMF JWT provider: Ok not to read keyring (z/OSMF signs the JWT)
    With z/OSMF LTPA. Can't work with ICSF currently. Needs private key to sign JWT.
    With SAF provider. Can't work with ICSF currenty. Needs private key to sign JWT.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

#### Does this PR do something the person installing Zowe should know about?

In order to have an API Mediation Layer instance working with AT-TLS and an ICSF keyring, it's required to add a flag to the certificate section.
This PR does not handle the automation scenarios where the keyring is created by the Zowe installation.

---
* Affected function: _general area of interest_ *

---
* Description: _1 line description_ *

---
* Part: _name of customizable file involved_  *

---
_multi-line description_

#### Is there a related doc issue or Pull Request? 

Doc issue/PR number: 

#### Other information

