### PR TITLE
Respect "import" option on pkcs12 certificate setup

### DIFF
--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -177,22 +177,22 @@
                           "description": "Keystore directory"
                         },
                         "name": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "description": "Certificate alias name. Note: please use all lower cases as alias.",
                           "default": "localhost"
                         },
                         "password": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "description": "Keystore password",
                           "default": "password"
                         },
                         "caAlias": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "description": "Alias name of self-signed certificate authority. Note: please use all lower cases as alias.",
                           "default": "local_ca"
                         },
                         "caPassword": {
-                          "type": "string",
+                          "type": [ "string", "null" ],
                           "description": "Password of keystore stored self-signed certificate authority.",
                           "default": "local_ca_password"
                         },


### PR DESCRIPTION
In the example zowe you'll see that scenario 2 of pkcs12 certificate setup has no mention of name, caAlias, password, caPassword.
https://github.com/zowe/zowe-install-packaging/blob/572cc81e41cc07bdda3b303633c410a124bd98f3/example-zowe.yaml#L148-L169

That's because those are used for scenario 1, but not scenario 2.
The fix to make nulls actually be identified as nulls has caught invalid schema again. These entries need to for now be ` "type": [ "string", "null" ],` in the schema.

A longer term solution would be to further use "oneOf" to identify the 5 scenarios of setup individually.