### PR TITLE
Update CLI component versions for 2.17.0 RC 2

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -224,14 +224,14 @@
       "componentGroup": "IBM&reg CICS&reg Plug-in for Zowe CLI",
       "entries": [{
         "repository": "cics-for-zowe-client",
-        "tag": "v5.0.5",
+        "tag": "v5.0.6",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
       "componentGroup": "IBM&reg Db2&reg Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-db2-plugin",
-        "tag": "v5.0.7",
+        "tag": "v5.0.8",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {


### PR DESCRIPTION
This PR updates the following package versions in manifest.json.template for `zowe-v2-lts`
| Updated Package | Old Version | New Version |
| --- | --- | --- |
| db2-for-zowe-cli | v5.0.7 | v5.0.8 |
| cics-for-zowe-cli | v5.0.5 | v5.0.6 |
