### PR TITLE
Update ZE component versions for 2.17.0

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -372,7 +372,7 @@
       "componentGroup": "Zowe Visual Studio Code Extension",
       "entries": [{
         "repository": "zowe-explorer-vscode",
-        "tag": "v2.15.4",
+        "tag": "v2.16.3",
         "destinations": ["Visual Studio Code Marketplace"]
       }]
     },


### PR DESCRIPTION
Updates the version of Zowe Explorer to v2.16.3 which is the latest tag as of the 2.17.0 code freeze.