### PR TITLE
update safkeyring schema to allow safkeyringjce://

### DIFF
--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -804,7 +804,7 @@
             "file": {
               "type": "string",
               "description": "Path of your z/OS keyring, including ring owner and ring name. Case sensitivity and spaces matter.",
-              "pattern": "^safkeyring:\/\/.*"
+              "pattern": "^safkeyring[a-z]*:\/\/.*"
             },
             "password": {
               "type": "string",
@@ -831,7 +831,7 @@
             "file": {
               "type": "string",
               "description": "Path of your z/OS keyring, including ring owner and ring name. Case sensitivity and spaces matter.",
-              "pattern": "^safkeyring:\/\/.*"
+              "pattern": "^safkeyring[a-z]*:\/\/.*"
             },
             "password": {
               "type": "string",


### PR DESCRIPTION
Address #3926 

Updates the zowe-yaml-schema.json to allow additional safkeyring types which are supported by Java 11+.  These include values like `safkeyringjcecca`, `safkeyringjcehybrid`, and `safkeyringjce`.

In the issue comment, Sean confirmed zss and app-server would tolerate the additional safkeyring types.