### PR TITLE
Use correct parameters for node

### DIFF
--- a/bin/libs/zosmf.ts
+++ b/bin/libs/zosmf.ts
@@ -31,7 +31,7 @@ export function validateZosmfHostAndPort(zosmfHost: string, zosmfPort: number): 
     common.printError(`Warning: Could not validate if z/OS MF is available on 'https://${zosmfHost}:${zosmfPort}/zosmf/info'. NODE_HOME is not defined.`);
     zosmfCheckPassed=false;
   } else {
-    let execReturn = shell.execOutSync(`${std.getenv('NODE_HOME')}/bin/node`, `${std.getenv('ZWE_zowe_runtimeDirectory')}/bin/utils/curl.js`, `"https://${zosmfHost}:${zosmfPort}/zosmf/info"`, `-k`, `-H`, `"X-CSRF-ZOSMF-HEADER: true"`, `--response-type`, `status`);
+    const execReturn = shell.execOutSync(`${std.getenv('NODE_HOME')}/bin/node`, `${std.getenv('ZWE_zowe_runtimeDirectory')}/bin/utils/curl.js`, `https://${zosmfHost}:${zosmfPort}/zosmf/info`, `-k`, `-H`, `X-CSRF-ZOSMF-HEADER: true`, `--response-type`, `status`);
     if (execReturn.rc || !execReturn.out) {
       common.printError(`Warning: Could not validate if z/OS MF is available on 'https://${zosmfHost}:${zosmfPort}/zosmf/info'. No response code from z/OSMF server.`);
       zosmfCheckPassed=false


### PR DESCRIPTION
1. `validateZosmfHostAndPort` does not work due to extra quotes for address and header:

```
Error: unknown parameter "https://skynet:800/zosmf/info"
Header name must be a valid HTTP token [""X-CSRF-ZOSMF-HEADER"]
```
2. `let` -> `const`

## Questions
* Why the code is using env variables `ZOSMF_HOST` and `ZOSMF_PORT`?
* What's the purpose of [this](https://github.com/zowe/zowe-install-packaging/blob/1f9ad776820f62672d7b3e17d64ef8b9b0569332/bin/commands/internal/start/prepare/index.ts#L175-L181)?