### PR TITLE
NONRLS vsam mode if variable not initialized

### DIFF
--- a/workflows/files/ZWECONF.xml
+++ b/workflows/files/ZWECONF.xml
@@ -1848,7 +1848,11 @@ echo '    # VSAM configurations if you are using VSAM as Caching Service storage
 echo '    vsam:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '      # VSAM data set with Record-Level-Sharing enabled or not' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '      # Valid values could be: NONRLS or RLS.' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+#if (${instance-zowe_setup_vsam_mode})
 echo '      mode: $!{instance-zowe_setup_vsam_mode}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+#else
+echo '      mode: NONRLS' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+#end
 echo '      # Volume name if you are using VSAM in NONRLS mode' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '      volume: "$!{instance-zowe_setup_vsam_volume}"' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '      # Storage class name if you are using VSAM in RLS mode' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"


### PR DESCRIPTION
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
- [x ] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Relevant issues
-

#### Changes proposed in this PR

In case step caching_service_vsam_variables (Variables for Caching Service - VSAM mode) is skipped, variable zowe_setup_vsam_mode remained not initialized. Because of that, in configuration file remained empty value instead of default variable value (NONRLS). This fix adds velocity macro check, and if variable "Zowe setup VSAM mode" is skipped from setup, NONRLS value is injected as a mode.
- 

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


#### Does this PR do something the person installing Zowe should know about?

#### Is there a related doc issue or Pull Request? 
https://github.com/zowe/zowe-install-packaging/discussions/3930

#### Other information

