### PR TITLE
Validate zOSMF clean up [WIP]

### DIFF
--- a/bin/commands/internal/start/prepare/index.sh
+++ b/bin/commands/internal/start/prepare/index.sh
@@ -142,8 +142,6 @@ global_validate() {
     if [[ ${ZWE_ENABLED_COMPONENTS} == *"discovery"* || ${ZWE_ENABLED_COMPONENTS} == *"files-api"* || ${ZWE_ENABLED_COMPONENTS} == *"jobs-api"* ]]; then
       validate_this "validate_zosmf_host_and_port \"${ZOSMF_HOST}\" \"${ZOSMF_PORT}\" 2>&1" "zwe-internal-start-prepare,global_validate:${LINENO}"
     fi
-  elif [ "${ZWE_components_gateway_apiml_security_auth_provider}" = "zosmf" ]; then
-    validate_this "validate_zosmf_as_auth_provider \"${ZOSMF_HOST}\" \"${ZOSMF_PORT}\" \"${ZWE_components_gateway_apiml_security_auth_provider}\" 2>&1" "zwe-internal-start-prepare,global_validate:${LINENO}"
   fi
 
   check_runtime_validation_result "zwe-internal-start-prepare,global_validate:${LINENO}"

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -172,12 +172,6 @@ function globalValidate(enabledComponents:string[]): void {
         privateErrors++;
         common.printFormattedError('ZWELS', "zwe-internal-start-prepare,global_validate", "Zosmf validation failed");
       }
-    } else if (std.getenv('ZWE_components_gateway_apiml_security_auth_provider') == "zosmf") {
-      let zosmfOk = zosmf.validateZosmfAsAuthProvider(zosmfHost, zosmfPort, 'zosmf');
-      if (!zosmfOk) {
-        privateErrors++;
-        common.printFormattedError('ZWELS', "zwe-internal-start-prepare,global_validate", "Zosmf validation failed");
-      }
     }
   }
   

--- a/bin/libs/zosmf.sh
+++ b/bin/libs/zosmf.sh
@@ -49,16 +49,3 @@ validate_zosmf_host_and_port() {
     print_message "Successfully checked z/OS MF is available on 'https://${zosmf_host}:${zosmf_port}/zosmf/info'"
   fi
 }
-
-validate_zosmf_as_auth_provider() {
-  zosmf_host="${1}"
-  zosmf_port="${2}"
-  auth_provider="${3}"
-
-  if [ -n "${zosmf_host}" -a -n "${zosmf_port}" ]; then
-    if [ "${auth_provider}" = "zosmf" ]; then
-      print_error "z/OSMF is not configured. Using z/OSMF as authentication provider is not supported."
-      return 1
-    fi
-  fi
-}

--- a/bin/libs/zosmf.ts
+++ b/bin/libs/zosmf.ts
@@ -47,14 +47,3 @@ export function validateZosmfHostAndPort(zosmfHost: string, zosmfPort: number): 
   }
   return zosmfCheckPassed;
 }
-
-//TODO isnt this completely backwards?
-export function validateZosmfAsAuthProvider(zosmfHost: string, zosmfPort: number, authProvider: string): boolean {
-  if (zosmfHost && zosmfPort) {
-    if (authProvider == 'zosmf') {
-      common.printError("z/OSMF is not configured. Using z/OSMF as authentication provider is not supported.");
-      return true;
-    }
-  }
-  return false;
-}


### PR DESCRIPTION
Fixes https://github.com/zowe/zowe-install-packaging/issues/3932

Function `bin/libs/zosmf.ts: validateZosmfAsAuthProvider` and the corresponding shell version is evaluating the default setting as an error:
```
ERROR: z/OSMF is not configured. Using z/OSMF as authentication provider is not supported. 
```
## Tests
When `ZOSMF_HOST` and `ZOSMF_PORT` are defined:
### With valid values:
```
Successfully checked z/OS MF is available on 'https://skynet:800/zosmf/info'
```
### With invalid values:
```
ERROR: Warning: Could not validate if z/OS MF is available on 'https://skinet:800/zosmf/'. No response code from z/OSMF server.  
ERROR: 2024-08-16 08:09:10 <ZWELS:800> ZWESVUSR ERROR (zwe-internal-start-prepare,global_validate) Zosmf validation failed
```
