### PR TITLE
zOSMF  validate cleanup [WIP]

### DIFF
--- a/bin/commands/internal/start/prepare/index.sh
+++ b/bin/commands/internal/start/prepare/index.sh
@@ -145,8 +145,6 @@ global_validate() {
     if [[ ${ZWE_ENABLED_COMPONENTS} == *"discovery"* ]]; then
       validate_this "validate_zosmf_host_and_port \"${ZOSMF_HOST}\" \"${ZOSMF_PORT}\" 2>&1" "zwe-internal-start-prepare,global_validate:${LINENO}"
     fi
-  elif [ "${ZWE_components_zaas_apiml_security_auth_provider}" = "zosmf" ]; then
-    validate_this "validate_zosmf_as_auth_provider \"${ZOSMF_HOST}\" \"${ZOSMF_PORT}\" \"${ZWE_components_zaas_apiml_security_auth_provider}\" 2>&1" "zwe-internal-start-prepare,global_validate:${LINENO}"
   fi
 
   check_runtime_validation_result "zwe-internal-start-prepare,global_validate:${LINENO}"

--- a/bin/commands/internal/start/prepare/index.sh
+++ b/bin/commands/internal/start/prepare/index.sh
@@ -145,9 +145,8 @@ global_validate() {
     if [[ ${ZWE_ENABLED_COMPONENTS} == *"discovery"* ]]; then
       validate_this "validate_zosmf_host_and_port \"${ZOSMF_HOST}\" \"${ZOSMF_PORT}\" 2>&1" "zwe-internal-start-prepare,global_validate:${LINENO}"
     fi
-    elif [ "${ZWE_components_zaas_apiml_security_auth_provider}" = "zosmf" ]; then
-      validate_this "validate_zosmf_as_auth_provider \"${ZOSMF_HOST}\" \"${ZOSMF_PORT}\" \"${ZWE_components_zaas_apiml_security_auth_provider}\" 2>&1" "zwe-internal-start-prepare,global_validate:${LINENO}"
-    fi
+  elif [ "${ZWE_components_zaas_apiml_security_auth_provider}" = "zosmf" ]; then
+    validate_this "validate_zosmf_as_auth_provider \"${ZOSMF_HOST}\" \"${ZOSMF_PORT}\" \"${ZWE_components_zaas_apiml_security_auth_provider}\" 2>&1" "zwe-internal-start-prepare,global_validate:${LINENO}"
   fi
 
   check_runtime_validation_result "zwe-internal-start-prepare,global_validate:${LINENO}"

--- a/bin/commands/internal/start/prepare/index.sh
+++ b/bin/commands/internal/start/prepare/index.sh
@@ -145,6 +145,9 @@ global_validate() {
     if [[ ${ZWE_ENABLED_COMPONENTS} == *"discovery"* ]]; then
       validate_this "validate_zosmf_host_and_port \"${ZOSMF_HOST}\" \"${ZOSMF_PORT}\" 2>&1" "zwe-internal-start-prepare,global_validate:${LINENO}"
     fi
+    elif [ "${ZWE_components_zaas_apiml_security_auth_provider}" = "zosmf" ]; then
+      validate_this "validate_zosmf_as_auth_provider \"${ZOSMF_HOST}\" \"${ZOSMF_PORT}\" \"${ZWE_components_zaas_apiml_security_auth_provider}\" 2>&1" "zwe-internal-start-prepare,global_validate:${LINENO}"
+    fi
   fi
 
   check_runtime_validation_result "zwe-internal-start-prepare,global_validate:${LINENO}"

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -173,8 +173,12 @@ function globalValidate(enabledComponents:string[]): void {
         common.printFormattedError('ZWELS', "zwe-internal-start-prepare,globalValidate", "Zosmf validation failed");
       }
     }
+    else if (std.getenv('ZWE_components_zaas_apiml_security_auth_provider') == "zosmf") {
+      privateErrors++;
+      common.printFormattedError('ZWELS', "zwe-internal-start-prepare,globalValidate", "Zosmf validation failed");
+    }
   }
-
+  
   std.setenv('ZWE_PRIVATE_ERRORS_FOUND',''+privateErrors);
   varlib.checkRuntimeValidationResult("zwe-internal-start-prepare,globalValidate");
 

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -172,6 +172,7 @@ function globalValidate(enabledComponents:string[]): void {
         privateErrors++;
         common.printFormattedError('ZWELS', "zwe-internal-start-prepare,globalValidate", "Zosmf validation failed");
       }
+    }
   }
   
   std.setenv('ZWE_PRIVATE_ERRORS_FOUND',''+privateErrors);

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -3,9 +3,9 @@
   under the terms of the Eclipse Public License v2.0 which
   accompanies this distribution, and is available at
   https://www.eclipse.org/legal/epl-v20.html
- 
+
   SPDX-License-Identifier: EPL-2.0
- 
+
   Copyright Contributors to the Zowe Project.
 */
 
@@ -174,7 +174,7 @@ function globalValidate(enabledComponents:string[]): void {
       }
     }
   }
-  
+
   std.setenv('ZWE_PRIVATE_ERRORS_FOUND',''+privateErrors);
   varlib.checkRuntimeValidationResult("zwe-internal-start-prepare,globalValidate");
 
@@ -189,7 +189,7 @@ function validateComponents(enabledComponents:string[]): any {
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare,validateComponents", "process component validations ...");
 
   const componentEnvironments = {};
-  
+
   // reset error counter
   let privateErrors = 0;
   std.setenv('ZWE_PRIVATE_ERRORS_FOUND','0');
@@ -238,7 +238,7 @@ function validateComponents(enabledComponents:string[]): any {
       }
     }
   });
-  
+
   std.setenv('ZWE_PRIVATE_ERRORS_FOUND', ''+privateErrors);
   varlib.checkRuntimeValidationResult("zwe-internal-start-prepare,validateComponents");
 
@@ -253,8 +253,8 @@ function configureComponents(componentEnvironments?: any, enabledComponents?:str
 
   const zwePrivateWorkspaceEnvDir = std.getenv('ZWE_PRIVATE_WORKSPACE_ENV_DIR');
   const zweCliParameterHaInstance = std.getenv('ZWE_CLI_PARAMETER_HA_INSTANCE');
-  
-  
+
+
   enabledComponents.forEach((componentId: string)=> {
     common.printFormattedTrace("ZWELS", "zwe-internal-start-prepare,configureComponents", `- checking ${componentId}`);
     const componentDir = component.findComponentDirectory(componentId);
@@ -306,7 +306,7 @@ function configureComponents(componentEnvironments?: any, enabledComponents?:str
         common.printFormattedError("ZWELS", "zwe-internal-start-prepare,configureComponents", `${componentName} processComponentApimlStaticDefinitions failure`);
       }
       // - generic app framework plugin
-      success=component.processComponentAppfwPlugin(componentDir);      
+      success=component.processComponentAppfwPlugin(componentDir);
       if (success) {
         common.printFormattedDebug("ZWELS", "zwe-internal-start-prepare,configureComponents", `${componentName} processComponentAppfwPlugin success`);
       } else {
@@ -320,7 +320,7 @@ function configureComponents(componentEnvironments?: any, enabledComponents?:str
       } else {
         common.printFormattedError("ZWELS", "zwe-internal-start-prepare,configureComponents", `${componentName} processComponentZaasSharedLibs failure`);
       }
-                                    
+
       // - gateway shared lib
       success=component.processComponentGatewaySharedLibs(componentDir);
       if (success) {
@@ -356,13 +356,13 @@ function configureComponents(componentEnvironments?: any, enabledComponents?:str
           const result = shell.execOutSync('sh', '-c', `. ${runtimeDirectory}/bin/libs/configmgr-index.sh && cd ${componentDir} && . ${fullPath} ; export rc=$? ; export -p`);
 
           common.printFormattedDebug("ZWELS", "zwe-internal-start-prepare,configureComponents", `${componentName} configure ended with rc=${result.rc}`);
-          
+
           if (result.rc==0) {
             const exportContent = varlib.getEnvironmentExports(result.out);
             if (exportContent) {
               const rc = xplatform.storeFileUTF8(`${zwePrivateWorkspaceEnvDir}/${componentName}/.${zweCliParameterHaInstance}.env`, xplatform.AUTO_DETECT, exportContent);
               if (!rc) {
-                
+
               } else {
                 // set permission for the component environment snapshot
                 shell.execSync('chmod', `700`, `"${zwePrivateWorkspaceEnvDir}/${componentName}/.${zweCliParameterHaInstance}.env"`);
@@ -390,7 +390,7 @@ function configureComponents(componentEnvironments?: any, enabledComponents?:str
       }
     }
   });
-                            
+
   common.printFormattedDebug("ZWELS", "zwe-internal-start-prepare,configure_components", "component configurations are successful");
 }
 
@@ -456,7 +456,7 @@ export function execute() {
   config.sanitizeHaInstanceId();
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `starting Zowe instance ${std.getenv('ZWE_CLI_PARAMETER_HA_INSTANCE')} with ${cliParameterConfig} ...`);
 
-  // extra preparations for running in container 
+  // extra preparations for running in container
   // this is running in containers
   if (runInContainer == 'true') {
     prepareRunningInContainer();

--- a/bin/libs/zosmf.sh
+++ b/bin/libs/zosmf.sh
@@ -49,16 +49,3 @@ validate_zosmf_host_and_port() {
     print_message "Successfully checked z/OS MF is available on 'https://${zosmf_host}:${zosmf_port}/zosmf/info'"
   fi
 }
-
-validate_zosmf_as_auth_provider() {
-  zosmf_host="${1}"
-  zosmf_port="${2}"
-  auth_provider="${3}"
-
-  if [ -n "${zosmf_host}" -a -n "${zosmf_port}" ]; then
-    if [ "${auth_provider}" = "zosmf" ]; then
-      print_error "z/OSMF is not configured. Using z/OSMF as authentication provider is not supported."
-      return 1
-    fi
-  fi
-}

--- a/bin/libs/zosmf.sh
+++ b/bin/libs/zosmf.sh
@@ -17,12 +17,12 @@ validate_zosmf_host_and_port() {
   zosmf_host="${1}"
   zosmf_port="${2}"
 
-  if [ -z "${zosmf_host}" ]; then 
+  if [ -z "${zosmf_host}" ]; then
     print_error "z/OSMF host is not set."
     return 1
   fi
 
-  if [ -z "${zosmf_port}" ]; then 
+  if [ -z "${zosmf_port}" ]; then
     print_error "z/OSMF port is not set."
     return 1
   fi
@@ -47,5 +47,18 @@ validate_zosmf_host_and_port() {
 
   if [ "${zosmf_check_passed}" = "true" ]; then
     print_message "Successfully checked z/OS MF is available on 'https://${zosmf_host}:${zosmf_port}/zosmf/info'"
+  fi
+}
+
+validate_zosmf_as_auth_provider() {
+  zosmf_host="${1}"
+  zosmf_port="${2}"
+  auth_provider="${3}"
+
+  if [ -n "${zosmf_host}" -a -n "${zosmf_port}" ]; then
+    if [ "${auth_provider}" = "zosmf" ]; then
+      print_error "z/OSMF is not configured. Using z/OSMF as authentication provider is not supported."
+      return 1
+    fi
   fi
 }

--- a/bin/libs/zosmf.ts
+++ b/bin/libs/zosmf.ts
@@ -31,7 +31,7 @@ export function validateZosmfHostAndPort(zosmfHost: string, zosmfPort: number): 
     common.printError(`Warning: Could not validate if z/OS MF is available on 'https://${zosmfHost}:${zosmfPort}/zosmf/info'. NODE_HOME is not defined.`);
     zosmfCheckPassed=false;
   } else {
-    let execReturn = shell.execOutSync(`${std.getenv('NODE_HOME')}/bin/node`, `${std.getenv('ZWE_zowe_runtimeDirectory')}/bin/utils/curl.js`, `"https://${zosmfHost}:${zosmfPort}/zosmf/info"`, `-k`, `-H`, `"X-CSRF-ZOSMF-HEADER: true"`, `--response-type`, `status`);
+    const execReturn = shell.execOutSync(`${std.getenv('NODE_HOME')}/bin/node`, `${std.getenv('ZWE_zowe_runtimeDirectory')}/bin/utils/curl.js`, `https://${zosmfHost}:${zosmfPort}/zosmf/info`, `-k`, `-H`, `X-CSRF-ZOSMF-HEADER: true`, `--response-type`, `status`);
     if (execReturn.rc || !execReturn.out) {
       common.printError(`Warning: Could not validate if z/OS MF is available on 'https://${zosmfHost}:${zosmfPort}/zosmf/info'. No response code from z/OSMF server.`);
       zosmfCheckPassed=false
@@ -46,15 +46,4 @@ export function validateZosmfHostAndPort(zosmfHost: string, zosmfPort: number): 
     common.printMessage(`Successfully checked z/OS MF is available on 'https://${zosmfHost}:${zosmfPort}/zosmf/info'`)
   }
   return zosmfCheckPassed;
-}
-
-//TODO isnt this completely backwards?
-export function validateZosmfAsAuthProvider(zosmfHost: string, zosmfPort: number, authProvider: string): boolean {
-  if (zosmfHost && zosmfPort) {
-    if (authProvider == 'zosmf') {
-      common.printError("z/OSMF is not configured. Using z/OSMF as authentication provider is not supported.");
-      return true;
-    }
-  }
-  return false;
 }

--- a/bin/utils/curl.js
+++ b/bin/utils/curl.js
@@ -207,7 +207,7 @@ const req = HTTP.request(options, (res) => {
 
 // handling errors
 req.on('error', (e) => {
-  const msg = `Request failed (${e.code}): ${e.message}\n` +
+  const msg = `bin/utils/curl.js: Request failed (${e.code}): ${e.message}\n` +
     (verbose ? e.stack + '\n' : '');
   exitWithError(2, msg);
 });


### PR DESCRIPTION
Fixes https://github.com/zowe/zowe-install-packaging/issues/3932

* Function `bin/libs/zosmf.ts: validateZosmfAsAuthProvider` and the corresponding shell version is evaluating the default setting as an error:
```
ERROR: z/OSMF is not configured. Using z/OSMF as authentication provider is not supported. 
```

* JS version of ZWEL0141E was returning user id `"$(get_user_id)"` instead of real user id.
* Function names in messages changed to real names

## Tests

When `ZOSMF_HOST` and `ZOSMF_PORT` are defined:
### With valid values:
```
2024-08-22 07:43:12 <ZWELS:50725631> martin INFO (zwe-internal-start-prepare,globalValidate) process global validations ... 
Successfully checked z/OS MF is available on 'https://skynet:800/zosmf/info'    
```
### With invalid values:
```
bin/utils/curl.js: Request failed (ENOTFOUND): getaddrinfo ENOTFOUND skinet

couple of "zwe-internal-start-prepare" messages

ERROR: Warning: Could not validate if z/OS MF is available on 'https://skinet:801/zosmf/info'. No response code from z/OSMF server.
ERROR: 2024-08-22 07:45:03 <ZWELS:33949307> martin ERROR (zwe-internal-start-prepare,globalValidate) Zosmf validation failed
```
Note: The change in `curl.js` makes the log little bit better to read, it is more obvious, that the `"Request failed"` and `ERROR` are related and coming from the same check.