### PR TITLE
Update base-jdk and base-node builds

### DIFF
--- a/containers/base-jdk/ubi/Dockerfile
+++ b/containers/base-jdk/ubi/Dockerfile
@@ -9,7 +9,7 @@
 # Copyright Contributors to the Zowe Project.
 #######################################################################
 
-FROM zowe-docker-release.jfrog.io/ompzowe/base:latest-ubi
+FROM zowe-docker-release.jfrog.io/ompzowe/base:2-ubi
 
 ##################################
 # labels

--- a/containers/base-jdk/ubuntu/Dockerfile
+++ b/containers/base-jdk/ubuntu/Dockerfile
@@ -9,7 +9,7 @@
 # Copyright Contributors to the Zowe Project.
 #######################################################################
 
-FROM zowe-docker-release.jfrog.io/ompzowe/base:latest-ubuntu
+FROM zowe-docker-release.jfrog.io/ompzowe/base:2-ubuntu
 
 ##################################
 # labels

--- a/containers/base-node/Dockerfile
+++ b/containers/base-node/Dockerfile
@@ -10,7 +10,7 @@
 #######################################################################
 
 # base image tag
-ARG ZOWE_BASE_IMAGE=latest-ubuntu
+ARG ZOWE_BASE_IMAGE=2-ubuntu
 
 FROM zowe-docker-release.jfrog.io/ompzowe/base:${ZOWE_BASE_IMAGE}
 

--- a/containers/zowe-launch-scripts/Dockerfile
+++ b/containers/zowe-launch-scripts/Dockerfile
@@ -10,7 +10,7 @@
 #######################################################################
 
 # base image tag
-ARG ZOWE_BASE_IMAGE=latest-ubuntu
+ARG ZOWE_BASE_IMAGE=2-ubuntu
 
 FROM zowe-docker-release.jfrog.io/ompzowe/base-node:${ZOWE_BASE_IMAGE}
 


### PR DESCRIPTION
Base-jdk and base-node container builds should pull from `<majorVersion>-<OS>` rather than `latest-<OS>`. The former still allows us flexibility in building against the latest base without opening us to an arbitrary `latest` that could be created by past or future major versions of `base`. 

Matches #3966 