### PR TITLE
Clean up the code when checking z/OSMF [v2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
 
 ## `2.18.1`
-- Bugfix: Error message `ZWEL0141E` did not print user ID
+- Bugfix: Error message `ZWEL0141E` did not print user ID. [#3971](https://github.com/zowe/zowe-install-packaging/pull/3971)
 
 ## `2.17.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
 
+## `2.18.1`
+- Bugfix: Error message `ZWEL0141E` did not print user ID
+
 ## `2.17.0`
 
 ## New features and enhancements

--- a/bin/commands/internal/start/prepare/index.sh
+++ b/bin/commands/internal/start/prepare/index.sh
@@ -142,8 +142,11 @@ global_validate() {
     if [[ ${ZWE_ENABLED_COMPONENTS} == *"discovery"* || ${ZWE_ENABLED_COMPONENTS} == *"files-api"* || ${ZWE_ENABLED_COMPONENTS} == *"jobs-api"* ]]; then
       validate_this "validate_zosmf_host_and_port \"${ZOSMF_HOST}\" \"${ZOSMF_PORT}\" 2>&1" "zwe-internal-start-prepare,global_validate:${LINENO}"
     fi
-  elif [ "${ZWE_components_gateway_apiml_security_auth_provider}" = "zosmf" ]; then
-    validate_this "validate_zosmf_as_auth_provider \"${ZOSMF_HOST}\" \"${ZOSMF_PORT}\" \"${ZWE_components_gateway_apiml_security_auth_provider}\" 2>&1" "zwe-internal-start-prepare,global_validate:${LINENO}"
+    if [ "${ZWE_components_discovery_enabled}" = "false" -a "${ZWE_components_gateway_apiml_security_auth_provider}" = "zosmf" ]; then
+      let "ZWE_PRIVATE_ERRORS_FOUND=${ZWE_PRIVATE_OLD_ERRORS_FOUND}+1"
+      print_error "Using z/OSMF as 'components.gateway.apiml.security.auth.provider' is not possible: discovery is disabled."
+      print_formatted_info "ZWELS" "zwe-internal-start-prepare,global_validate:${LINENO}" "Zosmf validation failed"
+    fi
   fi
 
   check_runtime_validation_result "zwe-internal-start-prepare,global_validate:${LINENO}"

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -75,7 +75,7 @@ function prepareLogDirectory() {
   if (logDir) {
     os.mkdir(logDir, 0o750);
     if (!fs.isDirectoryWritable(logDir)) {
-      common.printFormattedError("ZWELS", "zwe-internal-start-prepare,prepare_log_directory", `ZWEL0141E: User $(get_user_id) does not have write permission on ${logDir}.`);
+      common.printFormattedError("ZWELS", "zwe-internal-start-prepare,prepare_log_directory", `ZWEL0141E: User ${user} does not have write permission on ${logDir}.`);
       std.exit(141);
     }
   }
@@ -172,12 +172,11 @@ function globalValidate(enabledComponents:string[]): void {
         privateErrors++;
         common.printFormattedError('ZWELS', "zwe-internal-start-prepare,global_validate", "Zosmf validation failed");
       }
-    } else if (std.getenv('ZWE_components_gateway_apiml_security_auth_provider') == "zosmf") {
-      let zosmfOk = zosmf.validateZosmfAsAuthProvider(zosmfHost, zosmfPort, 'zosmf');
-      if (!zosmfOk) {
-        privateErrors++;
-        common.printFormattedError('ZWELS', "zwe-internal-start-prepare,global_validate", "Zosmf validation failed");
-      }
+    }
+    if (!enabledComponents.includes('discovery') && std.getenv('ZWE_components_gateway_apiml_security_auth_provider') == "zosmf") {
+      privateErrors++;
+      common.printError("Using z/OSMF as 'components.gateway.apiml.security.auth.provider' is not possible: discovery is disabled.");
+      common.printFormattedError('ZWELS', "zwe-internal-start-prepare,global_validate", "Zosmf validation failed");
     }
   }
   

--- a/bin/libs/zosmf.sh
+++ b/bin/libs/zosmf.sh
@@ -49,16 +49,3 @@ validate_zosmf_host_and_port() {
     print_message "Successfully checked z/OS MF is available on 'https://${zosmf_host}:${zosmf_port}/zosmf/info'"
   fi
 }
-
-validate_zosmf_as_auth_provider() {
-  zosmf_host="${1}"
-  zosmf_port="${2}"
-  auth_provider="${3}"
-
-  if [ -n "${zosmf_host}" -a -n "${zosmf_port}" ]; then
-    if [ "${auth_provider}" = "zosmf" ]; then
-      print_error "z/OSMF is not configured. Using z/OSMF as authentication provider is not supported."
-      return 1
-    fi
-  fi
-}

--- a/bin/libs/zosmf.ts
+++ b/bin/libs/zosmf.ts
@@ -47,14 +47,3 @@ export function validateZosmfHostAndPort(zosmfHost: string, zosmfPort: number): 
   }
   return zosmfCheckPassed;
 }
-
-//TODO isnt this completely backwards?
-export function validateZosmfAsAuthProvider(zosmfHost: string, zosmfPort: number, authProvider: string): boolean {
-  if (zosmfHost && zosmfPort) {
-    if (authProvider == 'zosmf') {
-      common.printError("z/OSMF is not configured. Using z/OSMF as authentication provider is not supported.");
-      return true;
-    }
-  }
-  return false;
-}


### PR DESCRIPTION
<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [x] Bugfix

#### Relevant issues

Fixes #3932

#### Changes proposed in this PR
* Error message `ZWEL0141E` contains a text `$(get_user_id)` instead of real userID
* When checking z/OSMF connection, some conditions are checked twice
* This error message does not make sense `z/OSMF is not configured. Using z/OSMF as authentication provider is not supported.`
  * If zOSMF is configured
  * If default setting of authentication provider is used

#### Does this PR introduce a breaking change?
- [x] No

#### Testing
Always this setting:
```
zowe:
  environments:
    ZOSMF_HOST: example.com
    ZOSMF_PORT: 1234
```

With or without fix, if `discovery.enabled=true`: 
`Successfully checked z/OS MF is available on 'https://example.com:1234/zosmf/info'`

But when this is set:
```
components.discovery.enabled=false
components.gateway.apiml.security.auth.provider=zosmf
```

No fix, confusing error message is printed and the zowe continues:
`ERROR: z/OSMF is not configured. Using z/OSMF as authentication provider is not supported.  `

With fix, error with reason is printed and zowe is terminated:
```log
ERROR: Using z/OSMF as 'components.gateway.apiml.security.auth.provider' is not possible: discovery is disabled. 
ERROR: 2024-09-06 07:21:53 <ZWELS:67504334> martin ERROR (zwe-internal-start-prepare,global_validate) Zosmf validation failed 
```