### PR TITLE
Automation fixes

### DIFF
--- a/.github/workflows/cicd-test.yml
+++ b/.github/workflows/cicd-test.yml
@@ -1,4 +1,11 @@
 name: Zowe CICD Integration Tests
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  statuses: write
+  
 on:   
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
We're seeing a handful of new build failures related to `GITHUB_TOKEN` permissions when trying to acquire locks to the Marist systems and posting status comments to pull requests. This PR will fix these issues.

Confirmed the additional `GITHUB_TOKEN` permissions fixed the locking issues in the CI/CD Integration Tests builds. No other instances of the `lock-resource` action are in use.