### PR TITLE
chore: update defaults for apiml v3

### DIFF
--- a/files/defaults.yaml
+++ b/files/defaults.yaml
@@ -157,7 +157,7 @@ components:
         authorization:
           endpoint:
             enabled: false
-          provider: ""
+          provider: "native"
         x509:
           enabled: false
 

--- a/files/defaults.yaml
+++ b/files/defaults.yaml
@@ -160,17 +160,10 @@ components:
           provider: ""
         x509:
           enabled: false
-    server:
-      internal:
-      # gateway supports internal connector
-        enabled: false
-        port: 7550
-        ssl:
-          enabled: false
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   zaas:
-    enabled: false
+    enabled: true
     port: 7558
     debug: false
 

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -336,7 +336,7 @@
       "componentGroup": "Zowe Visual Studio Code Extension",
       "entries": [{
         "repository": "zowe-explorer-vscode",
-        "tag": "next",
+        "tag": "main",
         "destinations": ["Visual Studio Code Marketplace"]
       }]
     },


### PR DESCRIPTION
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type

- [x] Bugfix

#### Changes proposed in this PR
- Set `zaas` component as enabled by default in defaults.yaml. This component is required for API ML to work.
- Remove unsupported internal connector settings in v3.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

