### PR TITLE
Update CLI component versions for 3.0.0

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -205,35 +205,35 @@
       "componentGroup": "Zowe CLI",
       "entries": [{
         "repository": "zowe-cli",
-        "tag": "v7.29.1",
+        "tag": "v8.0.0",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
       "componentGroup": "IBM&reg CICS&reg Plug-in for Zowe CLI",
       "entries": [{
         "repository": "cics-for-zowe-client",
-        "tag": "v5.0.6",
+        "tag": "v6.0.0",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
       "componentGroup": "IBM&reg Db2&reg Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-db2-plugin",
-        "tag": "v5.0.9",
+        "tag": "v6.0.0",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
       "componentGroup": "IBM&reg MQ Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-mq-plugin",
-        "tag": "v3.0.1",
+        "tag": "v4.0.0",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {
       "componentGroup": "z/OS&reg FTP Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-ftp-plugin",
-        "tag": "v2.1.9",
+        "tag": "v3.0.0",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {


### PR DESCRIPTION
This PR updates the following package versions in manifest.json.template for `zowe-v3-lts`
| Updated Package | Old Version | New Version |
| --- | --- | --- |
| cli | v7.29.1 | v8.0.0 |
| cics-for-zowe-cli | v5.0.6 | v6.0.0 |
| db2-for-zowe-cli | v5.0.9 | v6.0.0 |
| mq-for-zowe-cli | v3.0.1 | v4.0.0 |
| zos-ftp-for-zowe-cli | v2.1.9 | v3.0.0 |
