### PR TITLE
v3 Container Fixes

### DIFF
--- a/bin/commands/internal/start/prepare/index.sh
+++ b/bin/commands/internal/start/prepare/index.sh
@@ -145,7 +145,8 @@ global_validate() {
     if [[ ${ZWE_ENABLED_COMPONENTS} == *"discovery"* ]]; then
       validate_this "validate_zosmf_host_and_port \"${ZOSMF_HOST}\" \"${ZOSMF_PORT}\" 2>&1" "zwe-internal-start-prepare,global_validate:${LINENO}"
     else
-      if [ "${ZWE_components_gateway_apiml_security_auth_provider}" = "zosmf" ]; then
+      # check doesn't apply to container environments, caught with ZWE_POD_CLUSTERNAME
+      if [ "${ZWE_components_gateway_apiml_security_auth_provider}" = "zosmf" -a -z "${ZWE_POD_CLUSTERNAME}" ]; then 
         let "ZWE_PRIVATE_ERRORS_FOUND=${ZWE_PRIVATE_OLD_ERRORS_FOUND}+1"
         print_error "Using z/OSMF as 'components.gateway.apiml.security.auth.provider' is not possible: discovery is disabled."
         print_formatted_info "ZWELS" "zwe-internal-start-prepare,global_validate:${LINENO}" "Zosmf validation failed"

--- a/bin/commands/internal/start/prepare/index.sh
+++ b/bin/commands/internal/start/prepare/index.sh
@@ -145,8 +145,8 @@ global_validate() {
     if [[ ${ZWE_ENABLED_COMPONENTS} == *"discovery"* ]]; then
       validate_this "validate_zosmf_host_and_port \"${ZOSMF_HOST}\" \"${ZOSMF_PORT}\" 2>&1" "zwe-internal-start-prepare,global_validate:${LINENO}"
     else
-      # check doesn't apply to container environments, caught with ZWE_POD_CLUSTERNAME
-      if [ "${ZWE_components_gateway_apiml_security_auth_provider}" = "zosmf" -a -z "${ZWE_POD_CLUSTERNAME}" ]; then 
+      # check doesn't apply to container environments
+      if [ "${ZWE_components_gateway_apiml_security_auth_provider}" = "zosmf" -a "${ZWE_RUN_IN_CONTAINER}" != "true" ]; then 
         let "ZWE_PRIVATE_ERRORS_FOUND=${ZWE_PRIVATE_OLD_ERRORS_FOUND}+1"
         print_error "Using z/OSMF as 'components.gateway.apiml.security.auth.provider' is not possible: discovery is disabled."
         print_formatted_info "ZWELS" "zwe-internal-start-prepare,global_validate:${LINENO}" "Zosmf validation failed"

--- a/containers/kubernetes/samples/api-catalog-service.yaml
+++ b/containers/kubernetes/samples/api-catalog-service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: api-catalog
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/debug-pod.yaml
+++ b/containers/kubernetes/samples/debug-pod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: debug
     app.kubernetes.io/part-of: debug
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/debug-pod.yaml
+++ b/containers/kubernetes/samples/debug-pod.yaml
@@ -37,7 +37,7 @@ spec:
         claimName: zowe-workspace-pvc
   containers:
     - name: debug
-      image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:2.1.0-ubuntu.v2-x-staging
+      image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:3.0.0-ubuntu.v3-x-staging
       imagePullPolicy: Always
       resources:
         requests:

--- a/containers/kubernetes/samples/discovery-service-ci.yaml
+++ b/containers/kubernetes/samples/discovery-service-ci.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: discovery
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/discovery-service-lb.yaml
+++ b/containers/kubernetes/samples/discovery-service-lb.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: discovery
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/discovery-service-np.yaml
+++ b/containers/kubernetes/samples/discovery-service-np.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: discovery
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/gateway-service-ci.yaml
+++ b/containers/kubernetes/samples/gateway-service-ci.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: gateway
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/gateway-service-lb.yaml
+++ b/containers/kubernetes/samples/gateway-service-lb.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: gateway
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/gateway-service-np.yaml
+++ b/containers/kubernetes/samples/gateway-service-np.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: gateway
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/horizontal-pod-autoscaler/api-catalog-hpa.yaml
+++ b/containers/kubernetes/samples/horizontal-pod-autoscaler/api-catalog-hpa.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: hpa
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/horizontal-pod-autoscaler/app-server-hpa.yaml
+++ b/containers/kubernetes/samples/horizontal-pod-autoscaler/app-server-hpa.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: hpa
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/horizontal-pod-autoscaler/caching-hpa.yaml
+++ b/containers/kubernetes/samples/horizontal-pod-autoscaler/caching-hpa.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: hpa
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/horizontal-pod-autoscaler/discovery-hpa.yaml
+++ b/containers/kubernetes/samples/horizontal-pod-autoscaler/discovery-hpa.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: hpa
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/horizontal-pod-autoscaler/explorer-jes-hpa.yaml
+++ b/containers/kubernetes/samples/horizontal-pod-autoscaler/explorer-jes-hpa.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: hpa
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/horizontal-pod-autoscaler/explorer-mvs-hpa.yaml
+++ b/containers/kubernetes/samples/horizontal-pod-autoscaler/explorer-mvs-hpa.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: hpa
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/horizontal-pod-autoscaler/gateway-hpa.yaml
+++ b/containers/kubernetes/samples/horizontal-pod-autoscaler/gateway-hpa.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: hpa
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/horizontal-pod-autoscaler/zaas-hpa.yaml
+++ b/containers/kubernetes/samples/horizontal-pod-autoscaler/zaas-hpa.yaml
@@ -2,7 +2,7 @@
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: explorer-uss-hpa
+  name: zaas-hpa
   namespace: zowe
   labels:
     app.kubernetes.io/name: zowe
@@ -14,7 +14,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: explorer-uss
+    name: zaas
   minReplicas: 1
   maxReplicas: 3
   metrics:

--- a/containers/kubernetes/samples/network-policy/test-np-pod.yaml
+++ b/containers/kubernetes/samples/network-policy/test-np-pod.yaml
@@ -28,7 +28,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: debug
     app.kubernetes.io/part-of: debug
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/network-policy/zowe-np.yaml
+++ b/containers/kubernetes/samples/network-policy/zowe-np.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: k8s-network-policy
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/pod-disruption-budget/api-catalog-pdb.yaml
+++ b/containers/kubernetes/samples/pod-disruption-budget/api-catalog-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: pdb
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/pod-disruption-budget/caching-pdb.yaml
+++ b/containers/kubernetes/samples/pod-disruption-budget/caching-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: pdb
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/pod-disruption-budget/discovery-pdb.yaml
+++ b/containers/kubernetes/samples/pod-disruption-budget/discovery-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: pdb
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/pod-disruption-budget/explorer-jes-pdb.yaml
+++ b/containers/kubernetes/samples/pod-disruption-budget/explorer-jes-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: pdb
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/pod-disruption-budget/explorer-mvs-pdb.yaml
+++ b/containers/kubernetes/samples/pod-disruption-budget/explorer-mvs-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: pdb
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/pod-disruption-budget/explorer-uss-pdb.yaml
+++ b/containers/kubernetes/samples/pod-disruption-budget/explorer-uss-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: pdb
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/pod-disruption-budget/gateway-pdb.yaml
+++ b/containers/kubernetes/samples/pod-disruption-budget/gateway-pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: pdb
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/samples/pod-disruption-budget/zaas-pdb.yaml
+++ b/containers/kubernetes/samples/pod-disruption-budget/zaas-pdb.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: app-server-pdb
+  name: zaas-pdb
   namespace: zowe
   labels:
     app.kubernetes.io/name: zowe
@@ -16,4 +16,4 @@ spec:
     matchLabels:
       app.kubernetes.io/name: zowe
       app.kubernetes.io/instance: zowe
-      app.kubernetes.io/component: app-server
+      app.kubernetes.io/component: zaas

--- a/containers/kubernetes/samples/update-workspace-permission-pod.yaml
+++ b/containers/kubernetes/samples/update-workspace-permission-pod.yaml
@@ -22,7 +22,7 @@ spec:
         claimName: zowe-workspace-pvc
   containers:
     - name: update-workspace-permission
-      image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:2.1.0-ubuntu.v2-x-staging
+      image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:3.0.0-ubuntu.v3-x-staging
       imagePullPolicy: Always
       resources:
         requests:

--- a/containers/kubernetes/samples/update-workspace-permission-pod.yaml
+++ b/containers/kubernetes/samples/update-workspace-permission-pod.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: update-workspace-permission
     app.kubernetes.io/part-of: debug
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/vendors/bare-metal/discovery-ingress.yaml
+++ b/containers/kubernetes/samples/vendors/bare-metal/discovery-ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: discovery
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/vendors/bare-metal/gateway-ingress.yaml
+++ b/containers/kubernetes/samples/vendors/bare-metal/gateway-ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: gateway
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/vendors/ibmcloud/discovery-service-lb.yaml
+++ b/containers/kubernetes/samples/vendors/ibmcloud/discovery-service-lb.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: discovery
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/vendors/ibmcloud/gateway-service-lb.yaml
+++ b/containers/kubernetes/samples/vendors/ibmcloud/gateway-service-lb.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: gateway
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/vendors/openshift/discovery-route.yaml
+++ b/containers/kubernetes/samples/vendors/openshift/discovery-route.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: discovery
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/vendors/openshift/gateway-route.yaml
+++ b/containers/kubernetes/samples/vendors/openshift/gateway-route.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: gateway
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/samples/zaas-service.yaml
+++ b/containers/kubernetes/samples/zaas-service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: zaas
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/workloads/api-catalog-deployment.yaml
+++ b/containers/kubernetes/workloads/api-catalog-deployment.yaml
@@ -50,7 +50,7 @@ spec:
             claimName: zowe-workspace-pvc
       containers:
         - name: api-catalog
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/api-catalog-services:2.4.9-SNAPSHOT-ubuntu.v2-x-x
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/api-catalog-services:3.0.0-SNAPSHOT-ubuntu.v3-x-x
           imagePullPolicy: Always
           resources:
             requests:
@@ -115,7 +115,7 @@ spec:
               mountPath: "/home/zowe/instance/workspace"
       initContainers:
         - name: init-zowe
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:2.5.0-ubuntu.v2-x-staging
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:3.0.22-ubuntu.v3-x-staging
           imagePullPolicy: Always
           resources:
             requests:

--- a/containers/kubernetes/workloads/api-catalog-deployment.yaml
+++ b/containers/kubernetes/workloads/api-catalog-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: api-catalog
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/workloads/app-server-deployment.yaml
+++ b/containers/kubernetes/workloads/app-server-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: app-server
     app.kubernetes.io/part-of: app-server
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/workloads/app-server-deployment.yaml
+++ b/containers/kubernetes/workloads/app-server-deployment.yaml
@@ -50,7 +50,7 @@ spec:
             claimName: zowe-workspace-pvc
       containers:
         - name: app-server
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/app-server:2.5.0-ubuntu.v2-x-staging
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/app-server:3.0.0-ubuntu.v3-x-staging
           imagePullPolicy: Always
           resources:
             requests:
@@ -116,7 +116,7 @@ spec:
               mountPath: "/home/zowe/instance/workspace"
       initContainers:
         - name: init-zowe
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:2.5.0-ubuntu.v2-x-staging
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:3.0.0-ubuntu.v3-x-staging
           imagePullPolicy: Always
           resources:
             requests:

--- a/containers/kubernetes/workloads/caching-deployment.yaml
+++ b/containers/kubernetes/workloads/caching-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: caching
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/workloads/caching-deployment.yaml
+++ b/containers/kubernetes/workloads/caching-deployment.yaml
@@ -50,7 +50,7 @@ spec:
             claimName: zowe-workspace-pvc
       containers:
         - name: caching
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/caching-service:2.4.9-SNAPSHOT-ubuntu.v2-x-x
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/caching-service:3.0.22-SNAPSHOT-ubuntu.v3-x-x
           imagePullPolicy: Always
           resources:
             requests:
@@ -115,7 +115,7 @@ spec:
               mountPath: "/home/zowe/instance/workspace"
       initContainers:
         - name: init-zowe
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:2.5.0-ubuntu.v2-x-staging
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:3.0.0-ubuntu.v3-x-staging
           imagePullPolicy: Always
           resources:
             requests:

--- a/containers/kubernetes/workloads/cleanup-static-definitions-cronjob.yaml
+++ b/containers/kubernetes/workloads/cleanup-static-definitions-cronjob.yaml
@@ -48,7 +48,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: cleanup-static-definitions
-              image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:2.5.0-ubuntu.v2-x-staging
+              image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:3.0.0-ubuntu.v3-x-staging
               imagePullPolicy: Always
               resources:
                 requests:

--- a/containers/kubernetes/workloads/cleanup-static-definitions-cronjob.yaml
+++ b/containers/kubernetes/workloads/cleanup-static-definitions-cronjob.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: job-cleanup-static-definitions
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/workloads/discovery-statefulset.yaml
+++ b/containers/kubernetes/workloads/discovery-statefulset.yaml
@@ -53,7 +53,7 @@ spec:
             claimName: zowe-workspace-pvc
       containers:
         - name: discovery
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/discovery-service:2.4.9-SNAPSHOT-ubuntu.v2-x-x
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/discovery-service:3.0.22-SNAPSHOT-ubuntu.v3-x-x
           imagePullPolicy: Always
           resources:
             requests:
@@ -118,7 +118,7 @@ spec:
               mountPath: "/home/zowe/instance/workspace"
       initContainers:
         - name: init-zowe
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:2.5.0-ubuntu.v2-x-staging
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:3.0.0-ubuntu.v3-x-staging
           imagePullPolicy: Always
           resources:
             requests:

--- a/containers/kubernetes/workloads/discovery-statefulset.yaml
+++ b/containers/kubernetes/workloads/discovery-statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: discovery
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/workloads/explorer-ip-job.yaml
+++ b/containers/kubernetes/workloads/explorer-ip-job.yaml
@@ -45,7 +45,7 @@ spec:
             claimName: zowe-workspace-pvc
       containers:
         - name: explorer-ip
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/explorer-ip:3.0.0-ubuntu.v3-x-master
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/explorer-ip:3.0.1-ubuntu.v3-x-master
           imagePullPolicy: Always
           resources:
             requests:

--- a/containers/kubernetes/workloads/explorer-ip-job.yaml
+++ b/containers/kubernetes/workloads/explorer-ip-job.yaml
@@ -45,7 +45,7 @@ spec:
             claimName: zowe-workspace-pvc
       containers:
         - name: explorer-ip
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/explorer-ip:2.0.0-ubuntu.v2-x-master
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/explorer-ip:3.0.0-ubuntu.v3-x-master
           imagePullPolicy: Always
           resources:
             requests:
@@ -87,7 +87,7 @@ spec:
               mountPath: "/home/zowe/instance/workspace"
       initContainers:
         - name: init-zowe
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:2.5.0-ubuntu.v2-x-staging
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:3.0.0-ubuntu.v3-x-staging
           imagePullPolicy: Always
           resources:
             requests:

--- a/containers/kubernetes/workloads/explorer-ip-job.yaml
+++ b/containers/kubernetes/workloads/explorer-ip-job.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: job-explorer-ip
     app.kubernetes.io/managed-by: manual
 spec:

--- a/containers/kubernetes/workloads/explorer-jes-job.yaml
+++ b/containers/kubernetes/workloads/explorer-jes-job.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: explorer-jes
     app.kubernetes.io/part-of: explorer-ui
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/workloads/explorer-jes-job.yaml
+++ b/containers/kubernetes/workloads/explorer-jes-job.yaml
@@ -46,7 +46,7 @@ spec:
             claimName: zowe-workspace-pvc
       containers:
         - name: explorer-jes
-          image: zowe-docker-release.jfrog.io/ompzowe/explorer-jes:2.0.3-ubuntu
+          image: zowe-docker-release.jfrog.io/ompzowe/explorer-jes:3.0.0-ubuntu
           imagePullPolicy: Always
           resources:
             requests:
@@ -88,7 +88,7 @@ spec:
               mountPath: "/home/zowe/instance/workspace"
       initContainers:
         - name: init-zowe
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:2.5.0-ubuntu.v2-x-staging
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:3.0.0-ubuntu.v3-x-staging
           imagePullPolicy: Always
           resources:
             requests:

--- a/containers/kubernetes/workloads/explorer-mvs-job.yaml
+++ b/containers/kubernetes/workloads/explorer-mvs-job.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: explorer-mvs
     app.kubernetes.io/part-of: explorer-ui
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/workloads/explorer-mvs-job.yaml
+++ b/containers/kubernetes/workloads/explorer-mvs-job.yaml
@@ -46,7 +46,7 @@ spec:
             claimName: zowe-workspace-pvc
       containers:
         - name: explorer-mvs
-          image: zowe-docker-release.jfrog.io/ompzowe/explorer-mvs:2.0.3-ubuntu
+          image: zowe-docker-release.jfrog.io/ompzowe/explorer-mvs:3.0.0-ubuntu
           imagePullPolicy: Always
           resources:
             requests:
@@ -88,7 +88,7 @@ spec:
               mountPath: "/home/zowe/instance/workspace"
       initContainers:
         - name: init-zowe
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:2.5.0-ubuntu.v2-x-staging
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:3.0.0-ubuntu.v3-x-staging
           imagePullPolicy: Always
           resources:
             requests:

--- a/containers/kubernetes/workloads/explorer-uss-job.yaml
+++ b/containers/kubernetes/workloads/explorer-uss-job.yaml
@@ -46,7 +46,7 @@ spec:
             claimName: zowe-workspace-pvc
       containers:
         - name: explorer-uss
-          image: zowe-docker-release.jfrog.io/ompzowe/explorer-uss:2.0.3-ubuntu
+          image: zowe-docker-release.jfrog.io/ompzowe/explorer-uss:3.0.0-ubuntu
           imagePullPolicy: Always
           resources:
             requests:
@@ -88,7 +88,7 @@ spec:
               mountPath: "/home/zowe/instance/workspace"
       initContainers:
         - name: init-zowe
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:2.5.0-ubuntu.v2-x-staging
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:3.0.0-ubuntu.v3-x-staging
           imagePullPolicy: Always
           resources:
             requests:

--- a/containers/kubernetes/workloads/explorer-uss-job.yaml
+++ b/containers/kubernetes/workloads/explorer-uss-job.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: explorer-uss
     app.kubernetes.io/part-of: explorer-ui
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/workloads/gateway-deployment.yaml
+++ b/containers/kubernetes/workloads/gateway-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: gateway
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/workloads/gateway-deployment.yaml
+++ b/containers/kubernetes/workloads/gateway-deployment.yaml
@@ -50,7 +50,7 @@ spec:
             claimName: zowe-workspace-pvc
       containers:
         - name: gateway
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/gateway-service:2.4.9-SNAPSHOT-ubuntu.v2-x-x
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/gateway-service:3.0.22-SNAPSHOT-ubuntu.v3-x-x
           imagePullPolicy: Always
           resources:
             requests:
@@ -115,7 +115,7 @@ spec:
               mountPath: "/home/zowe/instance/workspace"
       initContainers:
         - name: init-zowe
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:2.5.0-ubuntu.v2-x-staging
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:3.0.0-ubuntu.v3-x-staging
           imagePullPolicy: Always
           resources:
             requests:

--- a/containers/kubernetes/workloads/zaas-deployment.yaml
+++ b/containers/kubernetes/workloads/zaas-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: zowe
     app.kubernetes.io/instance: zowe
-    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/version: "3.0.0"
     app.kubernetes.io/component: zaas
     app.kubernetes.io/part-of: apiml
     app.kubernetes.io/managed-by: manual

--- a/containers/kubernetes/workloads/zaas-deployment.yaml
+++ b/containers/kubernetes/workloads/zaas-deployment.yaml
@@ -50,7 +50,7 @@ spec:
             claimName: zowe-workspace-pvc
       containers:
         - name: zaas
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/zaas-service:2.4.9-SNAPSHOT-ubuntu.v2-x-x
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/zaas-service:3.0.22-SNAPSHOT-ubuntu.v3-x-x
           imagePullPolicy: Always
           resources:
             requests:
@@ -115,7 +115,7 @@ spec:
               mountPath: "/home/zowe/instance/workspace"
       initContainers:
         - name: init-zowe
-          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:2.5.0-ubuntu.v2-x-staging
+          image: zowe-docker-snapshot.jfrog.io/ompzowe/zowe-launch-scripts:3.0.0-ubuntu.v3-x-staging
           imagePullPolicy: Always
           resources:
             requests:

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -393,19 +393,19 @@
       "kind": "job",
       "registry": "zowe-docker-release.jfrog.io",
       "name": "ompzowe/explorer-ip",
-      "tag" : "3.0.0-ubuntu"
+      "tag" : "3.0.1-ubuntu"
     },
     "explorer-jes": {
       "kind": "job",
       "registry": "zowe-docker-release.jfrog.io",
       "name": "ompzowe/explorer-jes",
-      "tag" : "2.0.7-ubuntu"
+      "tag" : "3.0.0-ubuntu"
     },
     "explorer-mvs": {
       "kind": "job",
       "registry": "zowe-docker-release.jfrog.io",
       "name": "ompzowe/explorer-mvs",
-      "tag" : "2.0.10-ubuntu"
+      "tag" : "3.0.0-ubuntu"
     },
     "explorer-uss": {
       "kind": "job",


### PR DESCRIPTION
This PR fixes a few errors and inconsistencies in the v3 images.

- Adds horizontal pod autoscalers for ZAAS
- Fixes zwe start script for containers (was checking for discovery service locally which is not valid when running containers)
- Fixes image version defaults in some deployment and service definitions. This is always changed by release automation so it doesn't need to be maintained, but `3.0.0` on the v3 branch should be a little clearer than `2.1.0`.
- Updates explorer image versions in manifest

Verified all services can come up with this configuration - smoke test only.