### PR TITLE
Update defaults.yaml to example-zowe.yaml for schema checks

### DIFF
--- a/files/defaults.yaml
+++ b/files/defaults.yaml
@@ -88,7 +88,7 @@ zowe:
   configmgr:
     # STRICT=quit on any error, including missing schema
     # COMPONENT-COMPAT=if component missing schema, skip it with warning instead of quit
-    validation: "COMPONENT-COMPAT"
+    validation: "STRICT"
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   # runtime z/OS job name


### PR DESCRIPTION
https://github.com/zowe/zowe-install-packaging/blob/88c3aae45241dd2323a28c626b201312db2cd8c2/example-zowe.yaml#L298 contains an update to schema enforcement that was not in defaults.yaml
this PR syncs the two to have the same value.