### PR TITLE
category fix for TLS variable

### DIFF
--- a/workflows/files/ZWECONF.xml
+++ b/workflows/files/ZWECONF.xml
@@ -294,7 +294,7 @@ some use cases, like containerization, this port could be different.</descriptio
           TLS settings only apply when attls=false.
           Else you must use AT-TLS configuration for TLS customization.
         </description>
-        <category>certificates</category>
+        <category>network</category>
         <string valueMustBeChoice="true" multiLine="false">
             <!-- Put validation here -->
             <choice>TLSv1.1</choice>


### PR DESCRIPTION
The choice of TLS version tolerance was being presented in the wrong section of the PSWI configuration workflow. This aligns it with other similar fields.Signed-off-by: pz636264 <pavel.zlatnik@broadcom.com>