### PR TITLE
Update prereqs in AZWE003 FMID

### DIFF
--- a/smpe/bld/AZWE003.htm
+++ b/smpe/bld/AZWE003.htm
@@ -12,11 +12,11 @@
 <H2>  <H2>
 <H2>FMID AZWE003 </H2>
 <H3>for use with
-  <BR>z/OS 2.3.0 or later
+  <BR>z/OS 2.5.0 or later
   <BR>
   <BR> </H3>
 <H3> </H3>
-<H3>Document Date: March 2024 </H3>
+<H3>Document Date: October 2024 </H3>
 <H3> </H3>
 </CENTER>
 &nbsp;<BR>
@@ -321,7 +321,7 @@ product?
 </TH></TR><TR>
 <TD ALIGN="LEFT" VALIGN="TOP" WIDTH="1%">5650-ZOS
 </TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="33%">z/OS
-</TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="33%">2.3.0
+</TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="33%">2.5.0
 </TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="33%">N/A
 </TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="1%">No
 </TD></TR><TR>
@@ -395,19 +395,19 @@ See note
 <SUP><A HREF="#LIL2">1</A></SUP>
 </TD></TR><TR>
 <TD ALIGN="LEFT" VALIGN="TOP" WIDTH="1%">5655-DGH
-</TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="99%">IBM 64-bit SDK for z/OS Java Technology Edition 8.0.0
+</TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="99%">IBM Semeru Runtime Certified Edition for z/OS, Version 17
 </TD></TR><TR>
 <TD ALIGN="LEFT" VALIGN="TOP" WIDTH="1%">5650-ZOS
-</TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="99%">IBM z/OS Management Facility 2.3.0 or higher
+</TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="99%">IBM z/OS Management Facility 2.5.0 or higher
 </TD></TR><TR>
 <TD ALIGN="LEFT" VALIGN="TOP" WIDTH="1%">5650-ZOS
-</TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="99%">IBM z/OS 2.3.0 or higher
+</TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="99%">IBM z/OS 2.5.0 or higher
 </TD></TR><TR>
 <TD ALIGN="LEFT" VALIGN="TOP" COLSPAN="2" WIDTH="100%"><B>Note&#58; </B>
 The minimum product version is either what is listed in the table, or
 the currently minimum supported version, whichever is the most recent.
 <OL TYPE=1>
-<P><LI><A NAME="LIL2"></A>The pre-requistes for Node.js itself are not required, nor is
+<P><LI><A NAME="LIL2"></A>The pre-requisites for Node.js itself are not required, nor is
 any configuration of Node.js required. The only requirement is the
 presence of the Node.js executable code.
 </OL>
@@ -429,7 +429,7 @@ Minimum VRM/Service Level
 </TH><TH ALIGN="LEFT" VALIGN="BOTTOM" WIDTH="3%">Function
 </TH></TR><TR>
 <TD ALIGN="LEFT" VALIGN="TOP" WIDTH="1%">5650-ZOS
-</TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="96%">z/OS OpenSSH 2.3.0 or higher
+</TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="96%">z/OS OpenSSH 2.5.0 or higher
 </TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="3%">SSH connection
 </TD></TR><TR>
 <TD ALIGN="LEFT" VALIGN="TOP" COLSPAN="3" WIDTH="100%"><B>Note&#58; </B>

--- a/smpe/bld/AZWE003.htm
+++ b/smpe/bld/AZWE003.htm
@@ -389,7 +389,7 @@ to operate its basic functions.
 Minimum VRM/Service Level
 </TH></TR><TR>
 <TD ALIGN="LEFT" VALIGN="TOP" WIDTH="1%">5655-NOD
-</TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="99%">IBM SDK for Node.js - z/OS 14.0.0 or higher
+</TD><TD ALIGN="LEFT" VALIGN="TOP" WIDTH="99%">IBM SDK for Node.js - z/OS 18.0.0 or higher
 <BR>
 See note
 <SUP><A HREF="#LIL2">1</A></SUP>


### PR DESCRIPTION
We were missing updates to the FMID HTM file included in the SMP/e package.