### PR TITLE
Update CHANGELOG.md for breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ All notable changes to the Zowe Installer will be documented in this file.
 
 ### Breaking Changes
 
-- `zowe.yaml` changed its default z/OSMF Service ID definition from `zosmf` to `ibmzosmf`, which may impact Zowe Clients. For more information on this change, please see the API Mediation Layer's 3.0.0 Breaking Changes.
+-	The Zowe YAML now requires the `zaas` component for the API Mediation Layer to work. See example-zowe.yaml for new component values.
+-	The Zowe YAML attribute `components.gateway.apiml.security.auth.zosmf.serviceId` for the “gateway” component has changed from “zosmf” to “ibmzosmf”. This may impact Zowe Clients. See example-zowe.yaml for new component values. For more information on this change, please see the API Mediation Layer's 3.0.0 Breaking Changes.
+-	The Zowe YAML parameter `components.gateway.apiml.security.auth.zosmf.jwtAutoconfiguration` for the “gateway” component has changed. The value “auto” is no longer allowed, and you must choose either the default of “jwt” or “ltpa” depending on if your z/OSMF is set up for JWT use as recommended See example-zowe.yaml for new component values. For more information on this change, please see the API Mediation Layer's 3.0.0 Breaking Changes.
+
 
 ### New features and enhancements
 - Enhancement: Added explanation to possible error message when checking z/OSMF setting. [#3956](https://github.com/zowe/zowe-install-packaging/pull/3956)


### PR DESCRIPTION
The v3 changelog omits breaking changes that users may encounter when moving from v2 to v3.
I have added missing items to the best of my knowledge.