### PR TITLE
Small schema update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe Installer will be documented in this file.
 
 ## `3.0.1`
 - Enhancement: new javascript funtion `getStatvfs()` to obtain information about the file sysytem [#3994](https://github.com/zowe/zowe-install-packaging/pull/3994)
-- Enhancement: schema validation update for `zowe.job.name` and `zowe.job.prefix` [#40nn](https://github.com/zowe/zowe-install-packaging/pull/40nn)
+- Enhancement: schema validation update for `zowe.job.name` and `zowe.job.prefix` [#4060](https://github.com/zowe/zowe-install-packaging/pull/4060)
 
 ## `3.0.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zowe Installer will be documented in this file.
 
 ## `3.0.1`
 - Enhancement: new javascript funtion `getStatvfs()` to obtain information about the file sysytem [#3994](https://github.com/zowe/zowe-install-packaging/pull/3994)
+- Enhancement: schema validation update for `zowe.job.name` and `zowe.job.prefix` [#40nn](https://github.com/zowe/zowe-install-packaging/pull/40nn)
 
 ## `3.0.0`
 

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -465,11 +465,11 @@
           "description": "Customize your Zowe z/OS JES job.",
           "properties": {
             "name": {
-              "type": "string",
+              "$ref": "/schemas/v2/server-common#zoweJobname",
               "description": "Job name of Zowe primary ZWESLSTC started task."
             },
             "prefix": {
-              "type": "string",
+              "$ref": "/schemas/v2/server-common#zoweJobname",
               "description": "A short prefix to customize address spaces created by Zowe job."
             }
           }


### PR DESCRIPTION
Schema validation update for `zowe.job.name` and `zowe.job.prefix`:
* validate as zowe job name

Partially for https://github.com/zowe/zowe-install-packaging/issues/3950.

## Zowe.yaml
```yaml
zowe:
  job:
    # Zowe JES job name
    name: '1111111111111111111111111'
    # Prefix of component address space
    prefix: '2222222222222222222222222222222222'
```

## Without fix `zwe start -c zowe.yaml`
```
>> STARTING ZOWE

- opercmd S ZWESLSTC,HAINST=ca32,JOBNAME=1111111111111111111111111
  * Succeeded
  * Exit code: 0
  * Output:
    CA32      2024297  07:30:39.32             ISF031I CONSOLE ZEIMA02 ACTIVATED
    CA32      2024297  07:30:39.32            -S ZWESLSTC,HAINST=ca32,JOBNAME=1111111111111111111111111
    CA32      2024297  07:30:39.33             IEE308I START    TERM LENGTH ERROR
    .
ERROR: Error ZWEL0165E: Failed to start ZWESLSTC: IEE308I START    TERM LENGTH ERROR.
```

## With fix `zwe start -c zowe.yaml`
```
Error: Validation of FILE(./zowe.yaml):FILE(/zowe/runtime/3000/files/defaults.yaml) against schema /zowe/runtime/3000/schemas/zowe-yaml-schema.json:/zowe/runtime/3000/schemas/server-common.json found invalid JSON Schema data
Validity Exceptions(s) with object at
  Validity Exceptions(s) with object at /zowe
    Validity Exceptions(s) with object at /zowe/job
      Validity Exceptions(s) with string at /zowe/job/name
        string too long (len=25) '1111111111111111111111111' 25 > MAX=8 at /zowe/job/name
        string pattern match fail s='1111111111111111111111111', pat='^([A-Z\$\#\@]){1}([A-Z0-9\$\#\@]){0,7}$', at /zowe/job/name
      Validity Exceptions(s) with string at /zowe/job/prefix
        string too long (len=34) '2222222222222222222222222222222222' 34 > MAX=8 at /zowe/job/prefix
        string pattern match fail s='2222222222222222222222222222222222', pat='^([A-Z\$\#\@]){1}([A-Z0-9\$\#\@]){0,7}$', at /zowe/job/prefix
```