### PR TITLE
all zlux ui plugin tests through apiml

### DIFF
--- a/tests/sanity/test/e2e/test-07-iframe.js
+++ b/tests/sanity/test/e2e/test-07-iframe.js
@@ -47,7 +47,7 @@ describe.skip(`test ${APP_TO_TEST}`, function() {
     // load MVD login page
     await loginMVD(
       driver,
-      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_ZLUX_HTTPS_PORT}/`,
+      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_API_MEDIATION_GATEWAY_HTTP_PORT}/zlux/ui/v1/ZLUX/plugins/org.zowe.zlux.bootstrap/web/`,
       process.env.SSH_USER,
       process.env.SSH_PASSWD
     );

--- a/tests/sanity/test/e2e/test-08-subsys.js
+++ b/tests/sanity/test/e2e/test-08-subsys.js
@@ -40,7 +40,7 @@ describe.skip(`test ${APP_TO_TEST}`, function() {
     // load MVD login page
     await loginMVD(
       driver,
-      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_ZLUX_HTTPS_PORT}/`,
+      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_API_MEDIATION_GATEWAY_HTTP_PORT}/zlux/ui/v1/ZLUX/plugins/org.zowe.zlux.bootstrap/web/`,
       process.env.SSH_USER,
       process.env.SSH_PASSWD
     );

--- a/tests/sanity/test/e2e/test-10-api-catalog.js
+++ b/tests/sanity/test/e2e/test-10-api-catalog.js
@@ -45,7 +45,7 @@ describe(`test ${APP_TO_TEST}`, function() {
     // load MVD login page
     await loginMVD(
       driver,
-      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_ZLUX_HTTPS_PORT}/zlux/ui/v1/ZLUX/plugins/org.zowe.zlux.bootstrap/web/`,
+      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_API_MEDIATION_GATEWAY_HTTP_PORT}/zlux/ui/v1/ZLUX/plugins/org.zowe.zlux.bootstrap/web/`,
       process.env.SSH_USER,
       process.env.SSH_PASSWD
     );

--- a/tests/sanity/test/e2e/test-10-api-catalog.js
+++ b/tests/sanity/test/e2e/test-10-api-catalog.js
@@ -45,7 +45,7 @@ describe(`test ${APP_TO_TEST}`, function() {
     // load MVD login page
     await loginMVD(
       driver,
-      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_ZLUX_HTTPS_PORT}/`,
+      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_ZLUX_HTTPS_PORT}/zlux/ui/v1/ZLUX/plugins/org.zowe.zlux.bootstrap/web/`,
       process.env.SSH_USER,
       process.env.SSH_PASSWD
     );
@@ -79,6 +79,8 @@ describe(`test ${APP_TO_TEST}`, function() {
     try {
       const searchBox = await waitUntilElement(driver, '.search-bar');
       expect(searchBox).to.be.an('object');
+      await saveScreenshotWithIframeAppContext(this, driver, testName, 'login-pre-success', APP_TO_TEST, MVD_IFRAME_APP_CONTENT);
+
     } catch (e) {
       // try to save screenshot for debug purpose
       await saveScreenshotWithIframeAppContext(this, driver, testName, 'login-failed', APP_TO_TEST, MVD_IFRAME_APP_CONTENT);

--- a/tests/sanity/test/e2e/test-11-workflows.js
+++ b/tests/sanity/test/e2e/test-11-workflows.js
@@ -40,7 +40,7 @@ describe.skip(`test ${APP_TO_TEST}`, function() {
     // load MVD login page
     await loginMVD(
       driver,
-      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_ZLUX_HTTPS_PORT}/`,
+      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_API_MEDIATION_GATEWAY_HTTP_PORT}/zlux/ui/v1/ZLUX/plugins/org.zowe.zlux.bootstrap/web/`,
       process.env.SSH_USER,
       process.env.SSH_PASSWD
     );

--- a/tests/sanity/test/e2e/test-12-angular-sample.js
+++ b/tests/sanity/test/e2e/test-12-angular-sample.js
@@ -44,7 +44,7 @@ describe.skip(`test ${APP_TO_TEST}`, function() {
     // load MVD login page
     await loginMVD(
       driver,
-      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_ZLUX_HTTPS_PORT}/`,
+      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_API_MEDIATION_GATEWAY_HTTP_PORT}/zlux/ui/v1/ZLUX/plugins/org.zowe.zlux.bootstrap/web/`,
       process.env.SSH_USER,
       process.env.SSH_PASSWD
     );

--- a/tests/sanity/test/e2e/test-13-react-sample.js
+++ b/tests/sanity/test/e2e/test-13-react-sample.js
@@ -44,7 +44,7 @@ describe.skip(`test ${APP_TO_TEST}`, function() {
     // load MVD login page
     await loginMVD(
       driver,
-      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_ZLUX_HTTPS_PORT}/`,
+      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_API_MEDIATION_GATEWAY_HTTP_PORT}/zlux/ui/v1/ZLUX/plugins/org.zowe.zlux.bootstrap/web/`,
       process.env.SSH_USER,
       process.env.SSH_PASSWD
     );

--- a/tests/sanity/test/e2e/test-14-ip-explorer.js
+++ b/tests/sanity/test/e2e/test-14-ip-explorer.js
@@ -40,7 +40,7 @@ describe(`test ${APP_TO_TEST}`, function() {
     // load MVD login page
     await loginMVD(
       driver,
-      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_ZLUX_HTTPS_PORT}/`,
+      `https://${process.env.ZOWE_EXTERNAL_HOST}:${process.env.ZOWE_API_MEDIATION_GATEWAY_HTTP_PORT}/zlux/ui/v1/ZLUX/plugins/org.zowe.zlux.bootstrap/web/`,
       process.env.SSH_USER,
       process.env.SSH_PASSWD
     );


### PR DESCRIPTION
Web Desktop Plugin / Application tests were still using the zlux port to access the Web Desktop rather than the gateway port, which could cause test failures due to violations of the `x-frame-options: sameorigin` policy, since apps are loaded through the gateway port. This PR normalizes all tests to use the gateway port to access the web desktop, so all apps will comply with the `sameorigin` policy.

Frustratingly and for posterity, the tests did not always fail. Sometimes the selenium web browser would redirect from the zlux port to the gateway port before loading the web desktop, and other times it did not. The test presented as flaky due to this inconsistent redirection.