### PR TITLE
adds python sdk to sourceDependencies. adds new field "core" to sourc…

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -122,7 +122,7 @@
       "version": "~2.0.0-SNAPSHOT"
     },
     "org.zowe.licenses": {
-      "version": "2.3.0",
+      "version": "3.0.0",
       "artifact": "zowe_licenses_full.zip"
     }
   },
@@ -346,6 +346,14 @@
         "repository": "explorer-ip",
         "tag": "v2.x/master",
         "destinations": ["Zowe PAX"]
+      }]
+    }, {
+      "componentGroup": "Zowe Client Python SDK",
+      "entries": [{
+        "repository": "zowe-client-python-sdk",
+        "core": false,
+        "tag": "main",
+        "destinations": ["Zowe Client Python SDK"]
       }]
     }
   ],


### PR DESCRIPTION
Adds zowe-client-python-sdk as a sourceDependency to be tracked by downstream automation. This is in response to https://github.com/zowe/zowe-cli-standalone-package/issues/318 . 

This PR also creates a new field in a sourceDependency entry called 'core', which if not present should be assumed to default to true. This field lets downstream automation better decide how to handle non-core projects going forward.