### PR TITLE
Fix v3 PTF Build

### DIFF
--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -351,7 +351,7 @@ jobs:
       - name: '[PSWI 0] PSWI pre-build check for existing smpe'
         if: env.INPUTS_BUILD_PSWI == 'true' && github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH != '' && github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH != ''
         run: |
-          jfrog rt dl ${{github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH}}/AZWE002*.zip --flat=true .pax/AZWE002.zip
+          jfrog rt dl ${{github.event.inputs.PSWI_SMPE_AZWE_ARTIFACTORY_PATH}}/AZWE003*.zip --flat=true .pax/AZWE003.zip
           jfrog rt dl ${{github.event.inputs.PSWI_SMPE_ARTIFACTORY_PATH}}/zowe-smpe-*.zip --flat=true .pax/zowe-smpe.zip
 
       - name: '[SMPE Pax 4] Build PSWI'

--- a/.github/workflows/cicd-test.yml
+++ b/.github/workflows/cicd-test.yml
@@ -65,7 +65,7 @@ env:
   SANITY_TEST_PATH: tests/sanity
   DEFAULT_ZOWE_PAX_ARTIFACTORY_PATTERN: libs-snapshot-local/org/zowe/*zowe*{branch-name}*.pax
   DEFAULT_ZOWE_SMPE_ARTIFACTORY_PATTERN: libs-snapshot-local/org/zowe/*zowe-smpe*{branch-name}*.zip
-  DEFAULT_ZOWE_CLI_ARTIFACTORY_PATTERN: PLACE_HOLDER/org/zowe/cli/zowe-cli-package/*zowe-cli-package-2*.zip
+  DEFAULT_ZOWE_CLI_ARTIFACTORY_PATTERN: PLACE_HOLDER/org/zowe/cli/zowe-cli-package/*zowe-cli-package-3*.zip
   DEFAULT_ZOWE_EXT_ARTIFACTORY_PATTERN: libs-snapshot-local/org/zowe/{ext-name}/{ext-version}/{ext-name}-*.pax
 
   # below block can be overwritten, adjusted by DevOps only

--- a/playbooks/install-fmid.yml
+++ b/playbooks/install-fmid.yml
@@ -60,7 +60,7 @@
 
   # ============================================================================
   # if zowe_build_remote is set, we copy the FMID from zowe_fmids_dir_remote to our work folder
-  # the value of zowe_build_remote should be FMID like AZWE002
+  # the value of zowe_build_remote should be FMID like AZWE003
   - name: Copy Zowe FMID files from {{ zowe_fmids_dir_remote }}/{{ zowe_build_remote }} if it has value
     when: zowe_build_remote is defined
     import_role:

--- a/playbooks/roles/ptf/templates/HOLDDATA.jcl.j2
+++ b/playbooks/roles/ptf/templates/HOLDDATA.jcl.j2
@@ -1,5 +1,5 @@
 //HOLDDATA JOB
 //* This job can be customized if holddata actions are added to Zowe PTFs
 //*  For example, adding a new load module to an SMP/e-managed dataset.
-//DUMMY EXEC IEFBR14
+//DUMMY EXEC PGM=IEFBR14
 //*

--- a/playbooks/roles/ptf/templates/HOLDDATA.jcl.j2
+++ b/playbooks/roles/ptf/templates/HOLDDATA.jcl.j2
@@ -1,24 +1,5 @@
-//SZWELOAD JOB
-//         EXPORT SYMLIST=(TZON,TRGT)
-//         SET TRGT={{ zowe_smpe_hlq_tzone }}
-//         SET SMPE={{ zowe_smpe_hlq_csi }}
-//         SET TZON=TZONE
-//UCLIN    EXEC PGM=GIMSMP,REGION=0M,COND=(4,LT)
-//SZWELOAD DD SPACE=(TRK,(30,15,15)),
-//            UNIT=SYSALLDA,
-//            DISP=(MOD,CATLG),
-//            DSNTYPE=LIBRARY,
-//            RECFM=U,
-//            LRECL=0,
-//            BLKSIZE=32760,
-//            DSN=&TRGT..SZWELOAD
-//SMPCSI   DD DISP=OLD,DSN={{ smpe_csi }}
-//SMPCNTL  DD *,SYMBOLS=JCLONLY
-   SET   BDY(&TZON).
-   UCLIN.
-   ADD DDDEF (SZWELOAD)
-       DATASET(&TRGT..SZWELOAD)
-       UNIT(SYSALLDA)
-       WAITFORDSN
-       SHR .
-   ENDUCL.
+//HOLDDATA JOB
+//* This job can be customized if holddata actions are added to Zowe PTFs
+//*  For example, adding a new load module to an SMP/e-managed dataset.
+//DUMMY EXEC IEFBR14
+//*

--- a/tests/installation/src/constants.ts
+++ b/tests/installation/src/constants.ts
@@ -13,7 +13,7 @@ import * as path from 'path';
 // const debug = Debug('zowe-install-test:constants');
 
 // the FMID we will use to test PTF
-export const ZOWE_FMID = 'AZWE002';
+export const ZOWE_FMID = 'AZWE003';
 
 // where ansible playbooks located
 export const ANSIBLE_ROOT_DIR: string = path.resolve(__dirname, '../../../playbooks');

--- a/tests/sanity/test/cli/test-01-version.js
+++ b/tests/sanity/test/cli/test-01-version.js
@@ -28,6 +28,6 @@ describe('cli version', function() {
     expect(result).to.have.property('stderr');
 
     expect(result.stderr).to.be.empty;
-    expect(result.stdout).to.match(/^8\./);
+    expect(result.stdout).to.match(/^CLI Version: 8\./);
   });
 });

--- a/tests/sanity/test/cli/test-01-version.js
+++ b/tests/sanity/test/cli/test-01-version.js
@@ -28,6 +28,6 @@ describe('cli version', function() {
     expect(result).to.have.property('stderr');
 
     expect(result.stderr).to.be.empty;
-    expect(result.stdout).to.match(/^7\./);
+    expect(result.stdout).to.match(/^8\./);
   });
 });


### PR DESCRIPTION
found some lingering azwe002 references which escaped notice earlier. The v3 PTF builds are failing because they're trying to install over v2 Zowe FMID instead of v3.