### PR TITLE
Print error message on invalid extension install package (v2)

### DIFF
--- a/bin/commands/components/install/extract/.errors
+++ b/bin/commands/components/install/extract/.errors
@@ -4,4 +4,5 @@ ZWEL0154E|154|Temporary directory is empty.
 ZWEL0155E|155|Component %s already exists in %s. If you meant to upgrade this component, run the command 'zwe components upgrade' instead.
 ZWEL0167E|167|Cannot find component name from %s package manifest.
 ZWEL0204E|204|Symlink creation failure, error=%s
-ZWEL0313E|313|Cannot file component file %s.
+ZWEL0313E|313|Cannot find component file %s.
+ZWEL0318E|318|File extension invalid. Supported file extensions: .pax, .tar, .zip

--- a/bin/commands/components/install/extract/index.ts
+++ b/bin/commands/components/install/extract/index.ts
@@ -98,6 +98,8 @@ export function execute(componentFile: string, autoEncoding?: string, upgrade?: 
       result = shell.execSync('sh', '-c', `cd ${tmpDir} && jar xf ${componentFile}`);
     } else if (componentFile.endsWith('.tar')) {
       result = shell.execSync('sh', '-c', `_CEE_RUNOPTS="FILETAG() POSIX(ON)" cd ${tmpDir} && pax -x tar -rf "${componentFile}"`);
+    } else {
+      common.printErrorAndExit(`Error ZWEL0318E File extension invalid. Supported file extensions: .pax, .tar, .zip`, undefined, 318);
     }
     if (result.rc) {
       common.printError(`Extract completed with rc=${result.rc}`);
@@ -106,7 +108,7 @@ export function execute(componentFile: string, autoEncoding?: string, upgrade?: 
     result = shell.execOutSync('sh', '-c', `cd ${tmpDir} && ls -la 2>&1`);
     common.printTrace(stringlib.paddingLeft(result.out, "    "));
   } else {
-    common.printErrorAndExit(`Error ZWEL0313E: Cannot file component file ${componentFile}.`, undefined, 313);
+    common.printErrorAndExit(`Error ZWEL0313E: Cannot find component file ${componentFile}.`, undefined, 313);
   }
 
   // automatically tag files


### PR DESCRIPTION
Today, if you try to install an extension with a filename ending in something other than .tar, .pax, or .zip you'll get an error like:

TypeError: cannot read property 'rc' of undefined
  at execute (/zowe/bin/commands/components/install/extract/index:83)

This is because there is no "else" case on the file extension types.
So, this PR adds an "else" that just prints the error:

> Error ZWEL0318E File extension invalid. Supported file extensions: .pax, .tar, .zip

