### PR TITLE
Explain missing nodeJS error better 

### DIFF
--- a/bin/commands/.errors
+++ b/bin/commands/.errors
@@ -33,3 +33,4 @@ ZWEL0201E||File %s does not exist.
 ZWEL0202E||Unable to find samplib key for %s.
 ZWEL0203E||Env value in key-value pair %s has not been defined.
 ZWEL0316E||Command requires zowe.useConfigmgr=true to use.
+ZWEL0319E||NodeJS required but not found. Errors such as ZWEL0157E may occur as a result. The value 'node.home' in the Zowe YAML is not correct. 

--- a/bin/libs/json.sh
+++ b/bin/libs/json.sh
@@ -87,7 +87,7 @@ read_yaml() {
     missing_id_check=$(echo "${ZWE_PRIVATE_YAML_CACHE}" | grep "FSUM7351" 2>&1)
     if [ -n "${missing_id_check}" ]; then
       print_error "Error ZWEL0319E: NodeJS required but not found. Errors such as ZWEL0157E may occur as a result."
-      print_error "The value 'node.home' in the Zowe YAML is not correct. Set it to the directory that contains 'bin/node' within."
+      print_error "The value 'node.home' in the Zowe YAML is not correct. Set it to the parent directory of 'bin/node'."
       print_error "For example, if NodeJS is at '/opt/nodejs/bin/node', then set 'node.home' to '/opt/nodejs'."
     fi
     print_error "  * Output:"

--- a/bin/libs/json.sh
+++ b/bin/libs/json.sh
@@ -83,6 +83,13 @@ read_yaml() {
   code=$?
   print_trace "  * Exit code: ${code}"
   if [ ${code} -ne 0 ]; then
+    # Check for "node ... FSUM7351 not found". Common user error that we can solve more quickly by providing advice below.
+    missing_id_check=$(echo "${ZWE_PRIVATE_YAML_CACHE}" | grep "FSUM7351" 2>&1)
+    if [ -n "${missing_id_check}" ]; then
+      print_error "Error ZWEL0319E: NodeJS required but not found. Errors such as ZWEL0157E may occur as a result."
+      print_error "The value 'node.home' in the Zowe YAML is not correct. Set it to the directory that contains 'bin/node' within."
+      print_error "For example, if NodeJS is at '/opt/nodejs/bin/node', then set 'node.home' to '/opt/nodejs'."
+    fi
     print_error "  * Output:"
     print_error "$(padding_left "${ZWE_PRIVATE_YAML_CACHE}" "    ")"
     return ${code}


### PR DESCRIPTION
If you configure "node.home" wrong, you will likely encounter

>  * Output:
>    node: read_yaml 10: /zowe-release-2.18.0/bin/commands/init/certificate/index.sh 20: .: zwecli_process_command 4: /zowe-release-2.18.0/bin/zwe 98: FSUM7351 not found
> Error ZWEL0157E: Zowe dataset prefix (zowe.setup.dataset.prefix) is not defined in Zowe YAML configuration file.


This has time and time again caused people to believe the problem is "zowe.setup.dataset.prefix" when it isnt.

With this change, it will now print:

> Error ZWEL0319E: NodeJS required but not found. Errors such as ZWEL0157E may occur as a result.
> The value 'node.home' in the Zowe YAML is not correct. Set it to the parent directory of 'bin/node'.
> For example, if NodeJS is at '/opt/nodejs/bin/node', then set 'node.home' to '/opt/nodejs'.
>  * Output:
>    node: read_yaml 10: /zowe-release-2.18.0/bin/commands/init/certificate/index.sh 20: .: zwecli_process_command 4: /zowe-release-2.18.0/bin/zwe 98: FSUM7351 not found
>
> Error ZWEL0157E: Zowe dataset prefix (zowe.setup.dataset.prefix) is not defined in Zowe YAML configuration file.



ZWEL0157E still is printed, because of how this read_yaml function is called, doing an `exit` wont stop execution. So, the first message at least warns about the second.

Fixes https://github.com/zowe/zowe-install-packaging/issues/3426  for v3