### PR TITLE
Java & Node function names update

### DIFF
--- a/bin/libs/java.ts
+++ b/bin/libs/java.ts
@@ -26,7 +26,7 @@ export function ensureJavaIsOnPath(): void {
   }
 }
 
-export function shellReadYamlJavaHome(configList?: string, skipValidate?: boolean): string {
+export function readConfigJavaHome(configList?: string, skipValidate?: boolean): string {
   const zoweConfig = config.getZoweConfig();
   if (zoweConfig && zoweConfig.java && zoweConfig.java.home) {
     if (!skipValidate) {
@@ -60,7 +60,7 @@ export function requireJava() {
     return;
   }
   if (std.getenv('ZWE_CLI_PARAMETER_CONFIG')) {
-    const customJavaHome = shellReadYamlJavaHome();
+    const customJavaHome = readConfigJavaHome();
     if (customJavaHome) {
       std.setenv('JAVA_HOME', customJavaHome);
     }

--- a/bin/libs/node.ts
+++ b/bin/libs/node.ts
@@ -38,7 +38,7 @@ export function ensureNodeIsOnPath(): void {
   }
 }
 
-export function shellReadYamlNodeHome(configList?: string, skipValidate?: boolean): string {
+export function readConfigNodeHome(configList?: string, skipValidate?: boolean): string {
   const zoweConfig = config.getZoweConfig();
   if (zoweConfig && zoweConfig.node && zoweConfig.node.home) {
     if (!skipValidate) {
@@ -66,7 +66,7 @@ export function requireNode() {
     return;
   }
   if (std.getenv('ZWE_CLI_PARAMETER_CONFIG')) {
-    const customNodeHome = shellReadYamlNodeHome();
+    const customNodeHome = readConfigNodeHome();
     if (customNodeHome) {
       std.setenv('NODE_HOME', customNodeHome);
     }


### PR DESCRIPTION
As the functionality for java and node was rewritten from shell script, some function names do not correspond to the function itself. This is only changing the names of 2 similar functions.

The functions are used only in the java or node module at this time. 