### PR TITLE
Add formatZosVersion in bin/libs/zos.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Zowe Installer will be documented in this file.
 
+## `3.2.0`
+- Enhancement: Added new library function formatZosVersion() [#4134](https://github.com/zowe/zowe-install-packaging/pull/4134)
+
 ## `3.1.0`
 - Bugfix: When logging `zwe` command, sometimes the log has wrong file tag and the log is unreadable. [#4071](https://github.com/zowe/zowe-install-packaging/pull/4071)
 - Bugfix: When `--log-dir` parameter for `zwe` command is a file, there might be an error "InternalError: stack overflow". [#4064](https://github.com/zowe/zowe-install-packaging/pull/4064)

--- a/bin/libs/zos.ts
+++ b/bin/libs/zos.ts
@@ -14,6 +14,7 @@ import * as std from 'cm_std';
 import * as common from './common';
 import * as shell from './shell';
 import * as stringlib from './string';
+import * as zos from 'zos';
 
 export function tsoCommand(...args:string[]): { rc: number, out: string } {
   let message = "tsocmd " + '"' + args.join(' ') + '"';
@@ -63,4 +64,43 @@ export function operatorCommand(command: string): { rc: number, out: string } {
   }
   //we strip the '.' we added above
   return { rc: result.rc, out: result.out ? result.out.substring(0, result.out.length-1) : '' };
+}
+
+export function formatZosVersion(format?: string, versionNumber?: string | number): string {
+  const ZOS_VERS = {
+    'Z1030100': { 'osname': 'z/OS', 'hbb': 'HBB77E0', 'major': '3', 'minor': '1' },
+    'Z1020500': { 'osname': 'z/OS', 'hbb': 'HBB77D0', 'major': '2', 'minor': '5' },
+    'Z1020400': { 'osname': 'z/OS', 'hbb': 'HBB77C0', 'major': '2', 'minor': '4' },
+    'Z1020300': { 'osname': 'z/OS', 'hbb': 'HBB77B0', 'major': '2', 'minor': '3' },
+    'Z1020200': { 'osname': 'z/OS', 'hbb': 'HBB77A0', 'major': '2', 'minor': '2' },
+  //    'Z01020100': search for 'ECVTPSEQ' in IBM document to find more versions to be supported
+  };
+  const DEF_FORMAT = '{major}.{minor}';
+
+  common.printDebug(`formatZosVersion format=${format}, versionNumber=${versionNumber}`);
+
+  let resolvedFormat = format, resolvedVersionNumber = versionNumber;
+  if (typeof resolvedFormat !== 'string') {
+    resolvedFormat = DEF_FORMAT;
+  }
+  if (resolvedVersionNumber === undefined) {
+    // getZosVersion must return a number
+    resolvedVersionNumber = zos.getZosVersion();
+  }
+  if (typeof resolvedVersionNumber === 'number') {
+    resolvedVersionNumber = `Z${resolvedVersionNumber.toString(16)}`;
+  }
+
+  common.printDebug(`formatZosVersion parameter resolution format=${resolvedFormat}, versionNumber=${resolvedVersionNumber}`);
+
+  let zosVer = ZOS_VERS[resolvedVersionNumber];
+  if (!zosVer) {
+    //TODO: should throw exception?
+    zosVer = { 'osname': '?', 'hbb': '?', 'major': '?', 'minor': '?' };
+    common.printError(`formatZosVersion unsupported z/OS version: specified=${versionNumber} resolved=${resolvedVersionNumber}`);
+  }
+  return resolvedFormat.replace(/\{\s*osname\s*\}/g, zosVer.osname)
+    .replace(/\{\s*hbb\s*\}/g, zosVer.hbb)
+    .replace(/\{\s*major\s*\}/g, zosVer.major)
+    .replace(/\{\s*minor\s*\}/g, zosVer.minor);
 }


### PR DESCRIPTION
<!-- Thank you for your pull request! Please provide a description of the changes in this PR in the field above and provide the following information. -->

Please check if your PR fulfills the following requirements. This is simply a reminder of what we are going to look for before merging your PR. If you don't know all of this information when you create this PR, don't worry. You can edit this template as you're working on it.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Necessary documentation (if appropriate) have been added / updated
- [X] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [X] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

#### Relevant issues
<!-- Link to a relevant GitHub issue if any. If this PR applies to multiple issues, preface each issue reference with the "Fixes" keyword. For example, Fixes #123, Fixes #456. -->

Fixes #4125 

#### Changes proposed in this PR
<!-- Please describe your Pull Request. -->
- Added new function formatZosVersion() in bin/libs/zos.ts
- Added 3.2.0 section in CHANGELOG

#### Does this PR introduce a breaking change?
<!-- Is this a fix or feature that would cause existing functionality to not work as expected? -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path below.-->

#### Does this PR do something the person installing Zowe should know about?

<!-- Is this a fix or a feature that changes customizable files (e.g. configuration files, sample JCL, etc),
product requirements, or other installation or configuration related area? If so, please fill out the template below. 
There is no need to report the need to restart the servers to activate the change. Note that the provided text will be formatted in 64-character lines, and that round brackets, ( and ), must always be used in matching pairs. -->

No.

---
* Affected function: _general area of interest_ *

---
* Description: _1 line description_ *

---
* Part: _name of customizable file involved_  *

---
_multi-line description_

#### Is there a related doc issue or Pull Request? 
<!-- Link to a relevant documentation issue or Pull Request if any. -->

Doc issue/PR number: 

N/A

#### Other information

Here is the testing script I used to test the new function:

```javascript
import * as zoslib from '/path/to/zowe/bin/libs/zos'

//////////////////////////////////////////////////////////////////////
// happy path examples
console.log(zoslib.formatZosVersion("{osname} {hbb} {major}.{minor}")); // ZOS HBB77C0 2.4
console.log(zoslib.formatZosVersion(null, "Z1020400")); // 2.4
console.log(zoslib.formatZosVersion(null, 0x1020400)); // 2.4
console.log(zoslib.formatZosVersion(null, 123)); // ?.? log: "formatZosVersion unsupported z/OS version: specified=123 resolved=Z7b"

//////////////////////////////////////////////////////////////////////
// unit tests
const TESTS = [
    '',
    null,
    true,
    false,
    undefined,
    123,
    '{major}.{minor}',
    'Hello, world!',
    'My ZOS is {major}',
    '{hbb}',
    '{hbb} is major({major}) and minor({minor})',
    '{major}{major}{major}{major}',
    '{{major}}'
];

const EXPECTED = [
    '',
    '2.4',
    '2.4',
    '2.4',
    '2.4',
    '2.4',
    '2.4',
    'Hello, world!',
    'My ZOS is 2',
    'HBB77C0',
    'HBB77C0 is major(2) and minor(4)',
    '2222',
    '{2}'
];

const VERSION = "Z1020400";

for (let index in TESTS) {
    const test = TESTS[index];
    const expected = EXPECTED[index];
    const result = zoslib.formatZosVersion(test, VERSION);
    if (result === expected) {
        console.log(`SUCCESS: ${test} -> ${result}`);
    } else {
        console.log(`ERROR: ${test} -> ${result} (expected: ${expected})`);
    }
}

//////////////////////////////////////////////////////////////////////
// jsdoc of the function
/**
 * Get formatted z/OS version string. The format string can contain user-defined text and placeholders. The placeholders are enclosed in
 * curly braces and will be replaced with the corresponding parts of the z/OS version. The available placeholders are: {osname} - the
 * operating system name; {hbb} - the base control program version (HBB or JBB version); {major} - the major version number; {minor} -
 * the minor version number.
 * @param {string} [format] format string with placeholders. Default value is '{major}.{minor}'.
 * @param {string|number} [versionNumber] z/OS version number. Default value is the current z/OS version.
 * @returns {string} the formatted string with z/OS version information.
 * @note It only supports the z/OS versions that equal to or newer than HBB77A0 (z/OS 2.2). If versionNumber is specified as a string, it
 * must be the hexadecimal representation of the z/OS version number without leading 0s and prefixed with 'Z'. You can ran "sysvar SYSOSLVL"
 * in USS to see the correct format.
 * @example
 * // suppose the current z/OS version is z/OS 3.1
 * formatZosVersion() // '3.1'
 * formatZosVersion('osname: {osname}, hbb: {hbb}, major: {major}, minor: {minor}') // 'osname: z/OS, hbb: HBB77E0, major: 3, minor: 1'
 */
//function formatZosVersion(format?: string, versionNumber?: string | number): string;
```

The output of the above test:

```
z/OS HBB77E0 3.1
2.4
2.4
ERROR: formatZosVersion unsupported z/OS version: specified=123 resolved=Z7b
?.?
SUCCESS:  -> 
SUCCESS: null -> 2.4
SUCCESS: true -> 2.4
SUCCESS: false -> 2.4
SUCCESS: undefined -> 2.4
SUCCESS: 123 -> 2.4
SUCCESS: {major}.{minor} -> 2.4
SUCCESS: Hello, world! -> Hello, world!
SUCCESS: My ZOS is {major} -> My ZOS is 2
SUCCESS: {hbb} -> HBB77C0
SUCCESS: {hbb} is major({major}) and minor({minor}) -> HBB77C0 is major(2) and minor(4)
SUCCESS: {major}{major}{major}{major} -> 2222
SUCCESS: {{major}} -> {2}
```