### PR TITLE
Don't convert certificates already in EBCDIC during init

### DIFF
--- a/bin/libs/certificate.sh
+++ b/bin/libs/certificate.sh
@@ -647,7 +647,7 @@ EOF
       fi
       if [ `uname` = "OS/390" ]; then
         # check if certificate is in EBCDIC before converting
-        if [[ "$(head -c 10 "${keystore_dir}/${alias_lc}.cer")" = "-----BEGIN" ]]; then
+        if [[ "$(head -c 10 \"${keystore_dir}/${alias_lc}.cer\")" = "-----BEGIN" ]]; then
           print_message ">>>> Certificate \"${keystore_dir}/${alias_lc}.cer is in EBCDIC."
         else
           print_message ">>>> Converting certificate \"${keystore_dir}/${alias_lc}.cer\" to EBCDIC."

--- a/bin/libs/certificate.sh
+++ b/bin/libs/certificate.sh
@@ -647,7 +647,7 @@ EOF
       fi
       if [ `uname` = "OS/390" ]; then
         # check if certificate is in EBCDIC before converting
-        if [[ "$(head -c 10 "./zosmf00.cer")" = "-----BEGIN" ]]; then
+        if [[ "$(head -c 10 "${keystore_dir}/${alias_lc}.cer")" = "-----BEGIN" ]]; then
           print_message ">>>> Certificate \"${keystore_dir}/${alias_lc}.cer is in EBCDIC."
         else
           print_message ">>>> Converting certificate \"${keystore_dir}/${alias_lc}.cer\" to EBCDIC."

--- a/bin/libs/certificate.sh
+++ b/bin/libs/certificate.sh
@@ -646,8 +646,14 @@ EOF
         return 1
       fi
       if [ `uname` = "OS/390" ]; then
-        iconv -f ISO8859-1 -t IBM-1047 "${keystore_dir}/${alias_lc}.cer" > "${keystore_dir}/${alias_lc}.cer-ebcdic"
-        mv "${keystore_dir}/${alias_lc}.cer-ebcdic" "${keystore_dir}/${alias_lc}.cer"
+        # check if certificate is in EBCDIC before converting
+        if [[ "$(head -c 10 "./zosmf00.cer")" = "-----BEGIN" ]]; then
+          print_message ">>>> Certificate \"${keystore_dir}/${alias_lc}.cer is in EBCDIC."
+        else
+          print_message ">>>> Converting certificate \"${keystore_dir}/${alias_lc}.cer\" to EBCDIC."
+          iconv -f ISO8859-1 -t IBM-1047 "${keystore_dir}/${alias_lc}.cer" >"${keystore_dir}/${alias_lc}.cer-ebcdic"
+          mv "${keystore_dir}/${alias_lc}.cer-ebcdic" "${keystore_dir}/${alias_lc}.cer"
+        fi
         ensure_file_encoding "${keystore_dir}/${alias_lc}.cer" "CERTIFICATE"
       fi
     fi

--- a/bin/libs/certificate.sh
+++ b/bin/libs/certificate.sh
@@ -647,7 +647,7 @@ EOF
       fi
       if [ `uname` = "OS/390" ]; then
         # check if certificate is in EBCDIC before converting
-        if [[ "$(head -c 10 \"${keystore_dir}/${alias_lc}.cer\")" = "-----BEGIN" ]]; then
+        if [[ "$(head -c 10 ${keystore_dir}/${alias_lc}.cer)" = "-----BEGIN" ]]; then
           print_message ">>>> Certificate \"${keystore_dir}/${alias_lc}.cer is in EBCDIC."
         else
           print_message ">>>> Converting certificate \"${keystore_dir}/${alias_lc}.cer\" to EBCDIC."


### PR DESCRIPTION
This fixes a test failure captured in external certificate verification. The `certificate init` scripts were setup to always convert keytool-exported certificates from ASCII to EBCDIC, however some newer versions of keytool export the certificate in EBCDIC.

This PR fixes the error where an EBCDIC cer was created and became unreadable due to conversion. If we can't recognize the certificate as EBCDIC, the conversion still happens, which matches the prior behavior.