### PR TITLE
Update upload-artifact action version, fix scp

### DIFF
--- a/.github/workflows/cicd-test.yml
+++ b/.github/workflows/cicd-test.yml
@@ -382,7 +382,7 @@ jobs:
 
       - name: '[After Test 2] Upload test report'
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: InstallTestReports-${{ env.TEST_NAME }}-${{ steps.more-test-prep.outputs.TEST_SERVER_NICKNAME }}-${{ github.run_id }}-${{ env.CURRENT_TIME }}
           path: ${{ env.INSTALL_TEST_PATH }}/reports/

--- a/.github/workflows/diff-schema.yml
+++ b/.github/workflows/diff-schema.yml
@@ -34,7 +34,7 @@ jobs:
       - name: '[Build] Make diff'
         run: git diff ${{ env.FROM }} ${{ env.TO }} -- schemas > schemas.diff
       - name: '[Upload]'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: schemas.diff
           path: schemas.diff

--- a/.github/workflows/diff-yaml
+++ b/.github/workflows/diff-yaml
@@ -34,7 +34,7 @@ jobs:
       - name: '[Build] Make diff'
         run: git diff ${{ env.FROM }} ${{ env.TO }} -- example-zowe.yaml > example-yaml.diff
       - name: '[Upload]'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: example-yaml.diff
           path: example-yaml.diff

--- a/playbooks/roles/common/templates/scp.with-key.sh.j2
+++ b/playbooks/roles/common/templates/scp.with-key.sh.j2
@@ -4,4 +4,4 @@ FILE_LOCAL=$1
 FILE_REMOTE=$2
 
 echo "SCP $FILE_LOCAL ==> $FILE_REMOTE"
-scp -oHostKeyAlgorithms=+ssh-rsa -P {{ hostvars[inventory_hostname].ansible_port | default('22') }} -i {{ hostvars[inventory_hostname].ansible_ssh_private_key_file }} $FILE_LOCAL {{ hostvars[inventory_hostname].ansible_user }}@{{ hostvars[inventory_hostname].ansible_ssh_host }}:$FILE_REMOTE
+scp -O -oHostKeyAlgorithms=+ssh-rsa -P {{ hostvars[inventory_hostname].ansible_port | default('22') }} -i {{ hostvars[inventory_hostname].ansible_ssh_private_key_file }} $FILE_LOCAL {{ hostvars[inventory_hostname].ansible_user }}@{{ hostvars[inventory_hostname].ansible_ssh_host }}:$FILE_REMOTE

--- a/playbooks/roles/common/templates/scp.with-pwd.sh.j2
+++ b/playbooks/roles/common/templates/scp.with-pwd.sh.j2
@@ -4,4 +4,4 @@ FILE_LOCAL=$1
 FILE_REMOTE=$2
 
 echo "SCP $FILE_LOCAL ==> $FILE_REMOTE"
-sshpass -p "{{ hostvars[inventory_hostname].ansible_password }}" scp -oHostKeyAlgorithms=+ssh-rsa -P {{ hostvars[inventory_hostname].ansible_port | default('22') }} $FILE_LOCAL {{ hostvars[inventory_hostname].ansible_user }}@{{ hostvars[inventory_hostname].ansible_ssh_host }}:$FILE_REMOTE
+sshpass -p "{{ hostvars[inventory_hostname].ansible_password }}" scp -O -oHostKeyAlgorithms=+ssh-rsa -P {{ hostvars[inventory_hostname].ansible_port | default('22') }} $FILE_LOCAL {{ hostvars[inventory_hostname].ansible_user }}@{{ hostvars[inventory_hostname].ansible_ssh_host }}:$FILE_REMOTE


### PR DESCRIPTION
All uses of upload-artifact@v3 must be updated to v4. Builds will be failed out of the gate by GHA if the deprecated upload-artifact version is part of a workflow file's spec.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Adds `-O` to scp for the new ubuntu-24 being pulled in by `ubuntu-latest` images.