### PR TITLE
fix: update defaults for infinispan in v3

### DIFF
--- a/files/defaults.yaml
+++ b/files/defaults.yaml
@@ -192,9 +192,9 @@ components:
       infinispan:
         # this is required if storage mode is infinispan
         jgroups:
-          port: 7600
+          port: 7098
           keyExchange:
-            port: 7601
+            port: 7099
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   app-server:


### PR DESCRIPTION
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [ ] DCO signoffs have been added to all commits, including this PR

#### PR type

- [ ] Bugfix <!-- non-breaking change which fixes an issue -->

#### Changes proposed in this PR

- API ML assumes port 7098 for JGroups and 7099 for the key exchange port. The documentation establishes that if infinispan is configured, it should be set in zowe.yaml. The current defaults are in conflict.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


