### PR TITLE
`validateJavaHome` returns better message

### DIFF
--- a/bin/libs/java.ts
+++ b/bin/libs/java.ts
@@ -102,8 +102,9 @@ export function validateJavaHome(javaHome:string|undefined=std.getenv("JAVA_HOME
     let versionLines = (version as string).split('\n'); // valid because of above rc check
     for (let i = 0; i < versionLines.length; i++) {
       if ((index = versionLines[i].indexOf('java version')) != -1) {
-        //format of: java version "1.8.0_321"
-        javaVersionShort=versionLines[i].substring(index+('java version'.length)+2, versionLines[i].length-1);
+        //format of: java version "1.8.0_321" OR java version "17.0.10" 2024-01-02
+        javaVersionShort = versionLines[i].substring(index+('java version'.length)+2);
+        javaVersionShort = javaVersionShort.replace(/"/g, '');
         break;
       } else if ((index = versionLines[i].indexOf('openjdk version')) != -1) {
         javaVersionShort=versionLines[i].substring(index+('openjdk version'.length)+2, versionLines[i].length-1);


### PR DESCRIPTION
For Java 17, the function `java.validateJavaHome();` could return `Java 17.0.0" 2024-01-0` (extra quote and incomplete date).

The original implementation was made for Java 8 with different output.

This fixes both cases:
 * `java version "1.8.0_321"`
 * `java version "17.0.10" 2024-01-02`

Tests:
```
java version "1.17.0" 2024-01-16 -> Java 17.0.10 2024-01-16 is supported.
java version "1.17.0"            -> Java 1.17.0 is supported.
java version "1.8.0_321"         -> ERROR: Java 1.8.0_321 is less than the minimum level required of Java 17.
```