### PR TITLE
Build fix - lock in dependency versions

### DIFF
--- a/.dependency/zwe_message_checks/package.json
+++ b/.dependency/zwe_message_checks/package.json
@@ -9,8 +9,8 @@
   "author": "",
   "license": "EPL-2.0",
   "devDependencies": {
-    "fs-extra": "^11.3.0",
-    "lodash": "^4.17.21",
-    "string-comparison": "^1.3.0"
+    "fs-extra": "11.3.0",
+    "lodash": "4.17.21",
+    "string-comparison": "1.3.0"
   }
 }


### PR DESCRIPTION
Fixes PAX build, which stops on any dependency version in any directory containing a semantic version.