### PR TITLE
Fix v2 PTF Failures

### DIFF
--- a/playbooks/roles/ptf/tasks/main.yml
+++ b/playbooks/roles/ptf/tasks/main.yml
@@ -128,6 +128,8 @@
     dest: "{{ work_dir_local }}/{{ inventory_hostname }}/HOLDDATA.jcl"
     newline_sequence: '\n'
     mode: 0700
+  vars:
+    smpe_csi: "{{ zowe_smpe_hlq_csi }}.CSI"
   delegate_to: localhost
 
 - name: Upload HOLDDATA.jcl to server

--- a/tests/installation/src/utils.ts
+++ b/tests/installation/src/utils.ts
@@ -128,7 +128,7 @@ type PlaybookResponse = {
  * @param  {Object}    extraVars
  * @param  {String}    verbose
  */
-export function runAnsiblePlaybook(testcase: string, playbook: string, serverId: string, extraVars: {[key: string]: any} = {}, verbose = '-vvv'): Promise<PlaybookResponse> {
+export function runAnsiblePlaybook(testcase: string, playbook: string, serverId: string, extraVars: {[key: string]: any} = {}, verbose = '-v'): Promise<PlaybookResponse> {
   return new Promise((resolve, reject) => {
     const result: PlaybookResponse = {
       reportHash: calculateHash(testcase),

--- a/tests/installation/src/utils.ts
+++ b/tests/installation/src/utils.ts
@@ -128,7 +128,7 @@ type PlaybookResponse = {
  * @param  {Object}    extraVars
  * @param  {String}    verbose
  */
-export function runAnsiblePlaybook(testcase: string, playbook: string, serverId: string, extraVars: {[key: string]: any} = {}, verbose = '-v'): Promise<PlaybookResponse> {
+export function runAnsiblePlaybook(testcase: string, playbook: string, serverId: string, extraVars: {[key: string]: any} = {}, verbose = '-vvv'): Promise<PlaybookResponse> {
   return new Promise((resolve, reject) => {
     const result: PlaybookResponse = {
       reportHash: calculateHash(testcase),

--- a/tests/installation/src/utils.ts
+++ b/tests/installation/src/utils.ts
@@ -135,7 +135,7 @@ export function runAnsiblePlaybook(testcase: string, playbook: string, serverId:
       code: null,
       stdout: '',
       stderr: '',
-    };
+    }; 
     // import default vars
     if (!extraVars) {
       extraVars = {};

--- a/tests/installation/src/utils.ts
+++ b/tests/installation/src/utils.ts
@@ -135,7 +135,7 @@ export function runAnsiblePlaybook(testcase: string, playbook: string, serverId:
       code: null,
       stdout: '',
       stderr: '',
-    }; 
+    };
     // import default vars
     if (!extraVars) {
       extraVars = {};


### PR DESCRIPTION
The variable `smpe_csi` was implicitly attached to the HOLDDATA step before, but due to an upgraded version of Ansible that came with the latest ubuntu runners, we have to explicitly define it for the HOLDDATA template to render.