### PR TITLE
fix: restore v3 default ports in infinispan

### DIFF
--- a/files/defaults.yaml
+++ b/files/defaults.yaml
@@ -192,9 +192,9 @@ components:
       infinispan:
         # this is required if storage mode is infinispan
         jgroups:
-          port: 7098
+          port: 7600
           keyExchange:
-            port: 7099
+            port: 7601
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   app-server:


### PR DESCRIPTION
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [ ] DCO signoffs have been added to all commits, including this PR

#### PR type

- [ ] Bugfix

#### Changes proposed in this PR

- Defaults are 7600 for JGroups bind port and 7601 for keyExchange port.

#### Is there a related doc issue or Pull Request? 

Doc issue/PR number: 


