### PR TITLE
SZWESAMP MVS JCLs update

### DIFF
--- a/files/SZWESAMP/ZWEIMVS
+++ b/files/SZWESAMP/ZWEIMVS
@@ -15,9 +15,9 @@
 //* Instances represent a configuration of Zowe, different from the
 //* "runtime" datasets that are created upon install of Zowe / SMPE.
 //*
-//* If your choosen value of 'zowe.setup.dataset.authLoadlib' is not
-//* Equal to 'zowe.setup.prefix' + 'SZWEAUTH',
-//* Then you must also run "ZWEIMVS2".
+//* If your chosen value of 'zowe.setup.dataset.authLoadlib' is not
+//*  equal to 'zowe.setup.prefix' + 'SZWEAUTH',
+//*  then you must also run "ZWEIMVS2".
 //*
 //*********************************************************************
 //MKPDSE EXEC PGM=IKJEFT01

--- a/files/SZWESAMP/ZWEIMVS
+++ b/files/SZWESAMP/ZWEIMVS
@@ -16,7 +16,7 @@
 //* "runtime" datasets that are created upon install of Zowe / SMPE.
 //*
 //* If your choosen value of 'zowe.setup.dataset.authLoadlib' is not
-//* Equal to 'zowe.setup.prefix' + 'SZWELOAD',
+//* Equal to 'zowe.setup.prefix' + 'SZWEAUTH',
 //* Then you must also run "ZWEIMVS2".
 //*
 //*********************************************************************

--- a/files/SZWESAMP/ZWEIMVS2
+++ b/files/SZWESAMP/ZWEIMVS2
@@ -12,7 +12,7 @@
 //*********************************************************************
 //*
 //* This job is used to create the APF load library for an instance
-//* Of Zowe. It is not needed if your choosen value of
+//*  of Zowe. It is not needed if your chosen value of
 //* 'zowe.setup.dataset.authLoadlib' is equal to
 //* 'zowe.setup.prefix' + 'SZWEAUTH'.
 //*

--- a/files/SZWESAMP/ZWEIMVS2
+++ b/files/SZWESAMP/ZWEIMVS2
@@ -14,7 +14,7 @@
 //* This job is used to create the APF load library for an instance
 //* Of Zowe. It is not needed if your choosen value of
 //* 'zowe.setup.dataset.authLoadlib' is equal to
-//* 'zowe.setup.prefix' + 'SZWELOAD'.
+//* 'zowe.setup.prefix' + 'SZWEAUTH'.
 //*
 //* When running this job, you should also run ZWEIMVS
 //*

--- a/files/SZWESAMP/ZWERMVS
+++ b/files/SZWESAMP/ZWERMVS
@@ -15,9 +15,9 @@
 //* Instances represent a configuration of Zowe, different from the
 //* "runtime" datasets that are created upon install of Zowe / SMPE.
 //*
-//* If your choosen value of 'zowe.setup.dataset.authLoadlib' is not
-//* Equal to 'zowe.setup.prefix' + 'SZWEAUTH',
-//* Then you must also run "ZWERMVS2".
+//* If your chosen value of 'zowe.setup.dataset.authLoadlib' is not
+//*  equal to 'zowe.setup.prefix' + 'SZWEAUTH',
+//*  then you must also run "ZWERMVS2".
 //*
 //*********************************************************************
 //RMPDSE EXEC PGM=IKJEFT01

--- a/files/SZWESAMP/ZWERMVS
+++ b/files/SZWESAMP/ZWERMVS
@@ -16,7 +16,7 @@
 //* "runtime" datasets that are created upon install of Zowe / SMPE.
 //*
 //* If your choosen value of 'zowe.setup.dataset.authLoadlib' is not
-//* Equal to 'zowe.setup.prefix' + 'SZWELOAD',
+//* Equal to 'zowe.setup.prefix' + 'SZWEAUTH',
 //* Then you must also run "ZWERMVS2".
 //*
 //*********************************************************************

--- a/files/SZWESAMP/ZWERMVS2
+++ b/files/SZWESAMP/ZWERMVS2
@@ -12,7 +12,7 @@
 //*********************************************************************
 //*
 //* This job is used to remove the APF load library for an instance
-//* Of Zowe. It is not needed if your choosen value of
+//*  of Zowe. It is not needed if your chosen value of
 //* 'zowe.setup.dataset.authLoadlib' is equal to
 //* 'zowe.setup.prefix' + 'SZWEAUTH'.
 //*

--- a/files/SZWESAMP/ZWERMVS2
+++ b/files/SZWESAMP/ZWERMVS2
@@ -14,7 +14,7 @@
 //* This job is used to remove the APF load library for an instance
 //* Of Zowe. It is not needed if your choosen value of
 //* 'zowe.setup.dataset.authLoadlib' is equal to
-//* 'zowe.setup.prefix' + 'SZWELOAD'.
+//* 'zowe.setup.prefix' + 'SZWEAUTH'.
 //*
 //* When running this job, you should also run ZWERMVS
 //*


### PR DESCRIPTION
## JCL Samples for mvs
* Referring to `SZWELOAD` instead of `SZWEAUTH`
* Change in comments only
* The `SZWELOAD` dataset contains code for REXX configmgr. It is supposed to be unauthorized dataset.
* Help is referring to `SZWEAUTH`, which is correct