### PR TITLE
Another wrong description in MVS JCL samples

### DIFF
--- a/files/SZWESAMP/ZWEIMVS
+++ b/files/SZWESAMP/ZWEIMVS
@@ -16,7 +16,7 @@
 //* "runtime" datasets that are created upon install of Zowe / SMPE.
 //*
 //* If your chosen value of 'zowe.setup.dataset.authLoadlib' is not
-//*  equal to 'zowe.setup.prefix' + 'SZWEAUTH',
+//*  equal to 'zowe.setup.dataset.prefix' + 'SZWEAUTH',
 //*  then you must also run "ZWEIMVS2".
 //*
 //*********************************************************************

--- a/files/SZWESAMP/ZWEIMVS2
+++ b/files/SZWESAMP/ZWEIMVS2
@@ -14,7 +14,7 @@
 //* This job is used to create the APF load library for an instance
 //*  of Zowe. It is not needed if your chosen value of
 //* 'zowe.setup.dataset.authLoadlib' is equal to
-//* 'zowe.setup.prefix' + 'SZWEAUTH'.
+//* 'zowe.setup.dataset.prefix' + 'SZWEAUTH'.
 //*
 //* When running this job, you should also run ZWEIMVS
 //*

--- a/files/SZWESAMP/ZWERMVS
+++ b/files/SZWESAMP/ZWERMVS
@@ -16,7 +16,7 @@
 //* "runtime" datasets that are created upon install of Zowe / SMPE.
 //*
 //* If your chosen value of 'zowe.setup.dataset.authLoadlib' is not
-//*  equal to 'zowe.setup.prefix' + 'SZWEAUTH',
+//*  equal to 'zowe.setup.dataset.prefix' + 'SZWEAUTH',
 //*  then you must also run "ZWERMVS2".
 //*
 //*********************************************************************

--- a/files/SZWESAMP/ZWERMVS2
+++ b/files/SZWESAMP/ZWERMVS2
@@ -14,7 +14,7 @@
 //* This job is used to remove the APF load library for an instance
 //*  of Zowe. It is not needed if your chosen value of
 //* 'zowe.setup.dataset.authLoadlib' is equal to
-//* 'zowe.setup.prefix' + 'SZWEAUTH'.
+//* 'zowe.setup.dataset.prefix' + 'SZWEAUTH'.
 //*
 //* When running this job, you should also run ZWERMVS
 //*


### PR DESCRIPTION
* `zowe.setup.prefix` does not exist, it should be `zowe.setup.dataset.prefix`.
* Change in comment only