### PR TITLE
Simplify `zwe init stc`

### DIFF
--- a/bin/commands/init/stc/.help
+++ b/bin/commands/init/stc/.help
@@ -1,7 +1,7 @@
 This command will copy Zowe started tasks `ZWESLSTC`, `ZWESISTC`, `ZWESASTC` to
 your target procedure library.
 
-NOTE: You require proper permission to write to target procedure library.
+NOTE: You require proper permission to write to the target procedure library.
 
 These Zowe YAML configurations showing with sample values are used:
 
@@ -29,7 +29,7 @@ zowe:
   started tasks here before putting into target procedure library.
 - `zowe.setup.dataset.authLoadlib` is the user custom APF LOADLIB. This field is
   optional. If this is not defined, `SZWEAUTH` from `zowe.setup.dataset.prefix`
-  data set will be used as STEPLIB in STCs.
+  dataset will be used as STEPLIB in STCs.
 - `zowe.setup.security.stcs.zowe` is Zowe started task name.
   This configuration is optional. Default value is `ZWESLSTC`.
 - `zowe.setup.security.stcs.zis` is ZIS started task name.

--- a/bin/commands/init/stc/index.ts
+++ b/bin/commands/init/stc/index.ts
@@ -3,40 +3,30 @@
   under the terms of the Eclipse Public License v2.0 which
   accompanies this distribution, and is available at
   https://www.eclipse.org/legal/epl-v20.html
- 
+
   SPDX-License-Identifier: EPL-2.0
- 
+
   Copyright Contributors to the Zowe Project.
 */
 
-
 import * as std from 'cm_std';
-import * as zos from 'zos';
-import * as xplatform from 'xplatform';
-
-import * as fs from '../../../libs/fs';
 import * as common from '../../../libs/common';
-import * as stringlib from '../../../libs/string';
-import * as shell from '../../../libs/shell';
 import * as config from '../../../libs/config';
-import * as zoslib from '../../../libs/zos';
-import * as zosJes from '../../../libs/zos-jes';
-import * as zosdataset from '../../../libs/zos-dataset';
 import * as initGenerate from '../generate/index';
+import * as zosdataset from '../../../libs/zos-dataset';
+import * as zosJes from '../../../libs/zos-jes';
+import * as zoslib from '../../../libs/zos';
 
 export function execute(allowOverwrite: boolean = false) {
 
   common.printLevel1Message(`Install Zowe main started task`);
   
-  // constants
-  const COMMAND_LIST = std.getenv('ZWE_CLI_COMMANDS_LIST');
-  
   let stcExistence: boolean;
-  
+
   // validation
   common.requireZoweYaml();
   const ZOWE_CONFIG=config.getZoweConfig();
-  
+
   // read prefix and validate
   const prefix=ZOWE_CONFIG.zowe?.setup?.dataset?.prefix;
   if (!prefix) {
@@ -49,7 +39,7 @@ export function execute(allowOverwrite: boolean = false) {
   }
 
   // check if user passed --generate
-  const forceGen = !!std.getenv('ZWE_CLI_PARAMETER_GENERATE') 
+  const forceGen = !!std.getenv('ZWE_CLI_PARAMETER_GENERATE')
   if (forceGen) {
     initGenerate.execute();
   }
@@ -60,18 +50,10 @@ export function execute(allowOverwrite: boolean = false) {
     return common.printErrorAndExit(`Error ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL ${prefix}.SZWESAMP(ZWEGENER) before running this command.`, undefined, 319);
   }
 
-  let security_stcs_zowe=ZOWE_CONFIG.zowe.setup?.security?.stcs?.zowe;
-  if (!security_stcs_zowe) {
-    common.printErrorAndExit(`Error ZWEL0157E: (zowe.setup.security.stcs.zowe) is not defined in Zowe YAML configuration file.`, undefined, 157);
-  }
-  let security_stcs_zis=ZOWE_CONFIG.zowe.setup?.security?.stcs?.zis;
-  if (!security_stcs_zis) {
-    common.printErrorAndExit(`Error ZWEL0157E: (zowe.setup.security.stcs.zis) is not defined in Zowe YAML configuration file.`, undefined, 157);
-  }
-  let security_stcsAux=ZOWE_CONFIG.zowe.setup?.security?.stcs?.aux;
-  if (!security_stcsAux) {
-    common.printErrorAndExit(`Error ZWEL0157E: (zowe.setup.security.stcs.aux) is not defined in Zowe YAML configuration file.`, undefined, 157);
-  }
+  // zowe.setup.security.stcs.* defined in defaults
+  const security_stcs_zowe = ZOWE_CONFIG.zowe.setup.security.stcs.zowe;
+  const security_stcs_zis = ZOWE_CONFIG.zowe.setup.security.stcs.zis;
+  const security_stcsAux = ZOWE_CONFIG.zowe.setup.security.stcs.aux;
 
   [security_stcs_zowe, security_stcs_zis, security_stcsAux].forEach((mb: string) => {
     // STCs in target proclib
@@ -90,42 +72,12 @@ export function execute(allowOverwrite: boolean = false) {
   if (stcExistence == true && !allowOverwrite) {
     common.printMessage(`Skipped writing to ${proclib}. To write, you must use --allow-overwrite.`);
   } else {
-    // Fix JCL if needed - cannot copy member with same name via (foo,foo,R)
-    //                     must instead be (foo,,R), so do string replace if see dual name.
     if (stcExistence == true) {
       zosJes.printAndHandleJcl(`//'${jcllib}(ZWERSTC)'`, `ZWERSTC`, jcllib, prefix, false, true);
     }
-    
-    const tmpfile = fs.createTmpFile(`zwe ${COMMAND_LIST}`.replace(new RegExp('\ ', 'g'), '-'));
-    common.printDebug(`- Copy ${jcllib}(ZWEISTC) to ${tmpfile}`);
-    const jclContent = shell.execOutSync('sh', '-c', `cat "//'${stringlib.escapeDollar(jcllib)}(ZWEISTC)'" 2>&1`);
-    if (jclContent.out && jclContent.rc == 0) {
-      common.printDebug(`  * Succeeded`);
-      common.printTrace(`  * Output:`);
-      common.printTrace(stringlib.paddingLeft(jclContent.out, "    "));
 
-      const tmpFileContent = jclContent.out.replace("ZWESLSTC,ZWESLSTC", "ZWESLSTC,")
-                                           .replace("ZWESISTC,ZWESISTC", "ZWESISTC,")
-                                           .replace("ZWESASTC,ZWESASTC", "ZWESASTC,");
-      xplatform.storeFileUTF8(tmpfile, xplatform.AUTO_DETECT, tmpFileContent);
-      common.printTrace(`  * Stored:`);
-      common.printTrace(stringlib.paddingLeft(tmpFileContent, "    "));
+    zosJes.printAndHandleJcl(`//'${jcllib}(ZWEISTC)'`, `ZWEISTC`, jcllib, prefix, false, true);
 
-      shell.execSync('chmod', '700', tmpfile);
-    } else {
-      common.printDebug(`  * Failed`);
-      common.printError(`  * Exit code: ${jclContent.rc}`);
-      common.printError(`  * Output:`);
-      if (jclContent.out) {
-        common.printError(stringlib.paddingLeft(jclContent.out, "    "));
-      }
-      std.exit(1);
-    }
-    if (!fs.fileExists(tmpfile)) {
-      common.printErrorAndExit(`Error ZWEL0159E: Failed to modify ZWEISTC`, undefined, 159);
-    }
-    
-    zosJes.printAndHandleJcl(tmpfile, `ZWEISTC`, jcllib, prefix, true);
     common.printLevel2Message(`Zowe main started tasks are installed successfully.`);
   }
 }

--- a/files/SZWESAMP/ZWEISTC
+++ b/files/SZWESAMP/ZWEISTC
@@ -16,19 +16,31 @@
 //* Instances represent a configuration of Zowe, different from the
 //* "runtime" datasets that are created upon install of Zowe / SMPE.
 //*
+//* If you plan NOT to use Zowe Cross Memory Server, consider to
+//* copy Zowe Launcher STC only (ZWESLSTC).
+//*
 //*********************************************************************
 //*
-//MCOPY EXEC PGM=IEBCOPY
-//SYSPRINT DD SYSOUT=A
-//SYSUT1 DD DSN={zowe.setup.dataset.jcllib},DISP=SHR
-//SYSUT2 DD DSN={zowe.setup.dataset.proclib},DISP=OLD
-//SYSIN DD *
-  COPY OUTDD=SYSUT2,INDD=SYSUT1
-  SELECT MEMBER=((ZWESLSTC,{zowe.setup.security.stcs.zowe},R))
+//MCOPY EXEC PGM=IKJEFT01
+//SYSTSPRT DD SYSOUT=A
+//  SET PROCLIB={zowe.setup.dataset.proclib}
+//STCZOWE DD DISP=SHR,
+// DSN=&PROCLIB.({zowe.setup.security.stcs.zowe})
+//STCZIS DD DISP=SHR,
+// DSN=&PROCLIB.({zowe.setup.security.stcs.zis})
+//STCAUX DD DISP=SHR,
+// DSN=&PROCLIB.({zowe.setup.security.stcs.aux})
+//*
+//SYSTSIN DD *
+REPRO +
+INDATASET('{zowe.setup.dataset.jcllib}(ZWESLSTC)') +
+OUTFILE(STCZOWE)
 
-  COPY OUTDD=SYSUT2,INDD=SYSUT1
-  SELECT MEMBER=((ZWESISTC,{zowe.setup.security.stcs.zis},R))
+REPRO +
+INDATASET('{zowe.setup.dataset.jcllib}(ZWESISTC)') +
+OUTFILE(STCZIS)
 
-  COPY OUTDD=SYSUT2,INDD=SYSUT1
-  SELECT MEMBER=((ZWESASTC,{zowe.setup.security.stcs.aux},R))
+REPRO +
+INDATASET('{zowe.setup.dataset.jcllib}(ZWESASTC)') +
+OUTFILE(STCAUX)
 //*


### PR DESCRIPTION
Following simplifications were made:
* `ZWEISTC` is using `IKJEFT01 & REPRO`
  * No need to change target names as done for `IEBCOPY` before
  * `PROCLIB` allocated with `DISP=SHR`
* Defaults are not checked

Note: this is for `ZWEGEN00`, the record must fit into 80 chars:
```jcl
//STCZOWE DD DISP=SHR,
// DSN=&PROCLIB.({zowe.setup.security.stcs.zowe})
```
As the first template variable is changed, the result will not fit into 80 chars:
```jcl
//STCZOWE DD DISP=SHR,
// DSN={zowe.setup.dataset.proclib}.({zowe.setup.security.stcs.zowe})
----+----1----+----2----+----3----+----4----+----5----+----6----+----7----+----8
// DSN=----+----1----+----2----+----3----+----4----.({zowe.setup.security.stcs.zowe})
```

Testing in progress...
