### PR TITLE
Update ZWEISTC to use DISP=SHR (V3)

### DIFF
--- a/files/SZWESAMP/ZWEISTC
+++ b/files/SZWESAMP/ZWEISTC
@@ -21,7 +21,7 @@
 //MCOPY EXEC PGM=IEBCOPY
 //SYSPRINT DD SYSOUT=A
 //SYSUT1 DD DSN={zowe.setup.dataset.jcllib},DISP=SHR
-//SYSUT2 DD DSN={zowe.setup.dataset.proclib},DISP=OLD
+//SYSUT2 DD DSN={zowe.setup.dataset.proclib},DISP=SHR
 //SYSIN DD *
   COPY OUTDD=SYSUT2,INDD=SYSUT1
   SELECT MEMBER=((ZWESLSTC,{zowe.setup.security.stcs.zowe},R))


### PR DESCRIPTION

This PR fixes the DISP property of the proclib used in the job ZWEISTC.
When it was DISP=OLD, an exclusive lock was requested which is very likely to fail and hang.
Using DISP=SHR is better for this command, as it is non-disruptive.

This fixes a bug in which using the job ZWEISTC may never complete, and prevent others from accessing the system proclib.

Related to https://github.com/zowe/zowe-install-packaging/pull/4198
