### PR TITLE
`zwe support` messages update

### DIFF
--- a/bin/commands/.errors
+++ b/bin/commands/.errors
@@ -27,6 +27,7 @@ ZWEL0138E|138|Failed to update key %s of file %s.
 ZWEL0139E|139|Failed to create directory %s.
 ZWEL0140E|140|Failed to translate Zowe configuration (%s).
 ZWEL0142E|142|Failed to refresh APIML static registrations.
+ZWEL0151E|151|Failed to create temporary file %s. Please check permission or volume free space.
 ZWEL0172E||Component %s has %s defined but the file is missing.
 ZWEL0200E||Failed to copy USS file %s to MVS data set %s.
 ZWEL0201E||File %s does not exist.
@@ -34,3 +35,4 @@ ZWEL0202E||Unable to find samplib key for %s.
 ZWEL0203E||Env value in key-value pair %s has not been defined.
 ZWEL0316E||Command requires zowe.useConfigmgr=true to use.
 ZWEL0319E||NodeJS required but not found. Errors such as ZWEL0157E may occur as a result. The value 'node.home' in the Zowe YAML is not correct. 
+ZWEL0321E|321|%s is not a valid directory.

--- a/bin/commands/.errors
+++ b/bin/commands/.errors
@@ -35,4 +35,4 @@ ZWEL0202E||Unable to find samplib key for %s.
 ZWEL0203E||Env value in key-value pair %s has not been defined.
 ZWEL0316E||Command requires zowe.useConfigmgr=true to use.
 ZWEL0319E||NodeJS required but not found. Errors such as ZWEL0157E may occur as a result. The value 'node.home' in the Zowe YAML is not correct. 
-ZWEL0321E|321|%s is not a valid directory.
+ZWEL0322E|322|%s is not a valid directory.

--- a/bin/commands/components/uninstall/.errors
+++ b/bin/commands/components/uninstall/.errors
@@ -3,4 +3,4 @@ ZWEL0307E|307|Component %s cannot be uninstalled, because it is a core component
 ZWEL0308W|308|Component directory %s could not be removed, rc=%s.
 ZWEL0309W|309|Skipping removal of component %s because it is a core component.
 ZWEL0312W|312|Component %s marked for removal but is not installed.
-ZWEL????E|???|Command requires zowe.useConfigmgr=true to use.
+ZWEL0316E|316|Command requires zowe.useConfigmgr=true to use.

--- a/bin/commands/support/.errors
+++ b/bin/commands/support/.errors
@@ -1,3 +1,3 @@
 ZWEL0150E|150|Failed to find file %s. Zowe runtimeDirectory is invalid.
 ZWEL0151E|151|Failed to create temporary file %s. Please check permission or volume free space.
-ZWEL0321E|325|%s is not a valid directory.
+ZWEL0322E|322|%s is not a valid directory.

--- a/bin/commands/support/.errors
+++ b/bin/commands/support/.errors
@@ -1,2 +1,3 @@
 ZWEL0150E|150|Failed to find file %s. Zowe runtimeDirectory is invalid.
 ZWEL0151E|151|Failed to create temporary file %s. Please check permission or volume free space.
+ZWEL0321E|325|%s is not a valid directory.

--- a/bin/commands/support/index.ts
+++ b/bin/commands/support/index.ts
@@ -56,7 +56,7 @@ export function execute(): void {
   }
 
   if (!fs.directoryExists(targetDirectory, true)) {
-    common.printErrorAndExit(`Error ZWELxxxx: "${targetDirectory}" is not a valid directory.`, undefined, 999);
+    common.printErrorAndExit(`Error ZWEL0321E: ${targetDirectory} is not a valid directory.`, undefined, 325);
   }
 
   const tmpFilePrefix = 'zwe-support';
@@ -146,7 +146,7 @@ export function execute(): void {
   common.printMessage(JSON.stringify(environment, null, 2));
   const saveEnvRc = xplatform.storeFileUTF8(environmentFile, xplatform.AUTO_DETECT, JSON.stringify(environment, null, 2));
   if (saveEnvRc) {
-    common.printErrorAndExit(`Error ZWEL0151E: Failed to create temporary file "${environmentFile}". Please check permission or volume free space.`, undefined, 151);
+    common.printErrorAndExit(`Error ZWEL0151E: Failed to create temporary file ${environmentFile}. Please check permission or volume free space.`, undefined, 151);
   }
 
   common.printLevel1Message('Collecting Zowe configurations');
@@ -233,6 +233,6 @@ export function execute(): void {
   if (fs.fileExists(`${tmpPax}.Z`)) {
     common.printLevel1Message(`Zowe support package is generated as ${tmpPax}.Z`);
   } else {
-    common.printErrorAndExit(`Error ZWEL0151E: Failed to create file "${tmpPax}.Z". Please check permission or volume free space.`, undefined, 151);
+    common.printErrorAndExit(`Error ZWEL0151E: Failed to create temporary file ${tmpPax}.Z. Please check permission or volume free space.`, undefined, 151);
   }
 }

--- a/bin/commands/support/index.ts
+++ b/bin/commands/support/index.ts
@@ -56,7 +56,7 @@ export function execute(): void {
   }
 
   if (!fs.directoryExists(targetDirectory, true)) {
-    common.printErrorAndExit(`Error ZWEL0321E: ${targetDirectory} is not a valid directory.`, undefined, 321);
+    common.printErrorAndExit(`Error ZWEL0322E: ${targetDirectory} is not a valid directory.`, undefined, 322);
   }
 
   const tmpFilePrefix = 'zwe-support';

--- a/bin/commands/support/index.ts
+++ b/bin/commands/support/index.ts
@@ -56,7 +56,7 @@ export function execute(): void {
   }
 
   if (!fs.directoryExists(targetDirectory, true)) {
-    common.printErrorAndExit(`Error ZWEL0321E: ${targetDirectory} is not a valid directory.`, undefined, 325);
+    common.printErrorAndExit(`Error ZWEL0321E: ${targetDirectory} is not a valid directory.`, undefined, 321);
   }
 
   const tmpFilePrefix = 'zwe-support';


### PR DESCRIPTION
* Forgotten undefined message updated:
```
common.printErrorAndExit(`Error ZWELxxxx: "${targetDirectory}" is not a valid directory.`, undefined, 999);
```
* Few minor updates to reduce number of issues found by `zwe_message_checks`

### Quick test

* `--target-dir` is a file
```
$: /zowe/bin/zwe support -c ./yaml/zowe.basic.yaml --target-dir ./zowe.env
===============================================================================
>> COLLECT INFORMATION FOR ZOWE SUPPORT

ERROR: Error ZWEL0321E: /qa/support/zowe.env is not a valid directory.
```

* `--target-dir` is a special file
```
$: /zowe/bin/zwe support -c ./yaml/zowe.basic.yaml --target-dir /dev/null
===============================================================================
>> COLLECT INFORMATION FOR ZOWE SUPPORT

ERROR: Error ZWEL0321E: /dev/null is not a valid directory.
```


