### PR TITLE
Update .examples to rename ".zowe.component" (v2)

### DIFF
--- a/bin/commands/config/get/.examples
+++ b/bin/commands/config/get/.examples
@@ -1,5 +1,5 @@
 zwe config get -p path-of-configuration -c /path/to/zowe.yaml
 zwe config get -p .zowe.certificate -c /path/to/zowe.yaml
-zwe config get -p .zowe.components[] -c /path/to/zowe.yaml
-zwe config get -p .zowe.components.gateway -c /path/to/zowe.yaml
-zwe config get -p .zowe.components.gateway.enabled -c /path/to/zowe.yaml
+zwe config get -p .components[] -c /path/to/zowe.yaml
+zwe config get -p .components.gateway -c /path/to/zowe.yaml
+zwe config get -p .components.gateway.enabled -c /path/to/zowe.yaml


### PR DESCRIPTION
The examples file references a ".zowe.components", but no such YAML object exists.
The correct example would be ".components", which I have updated here.
Same as https://github.com/zowe/zowe-install-packaging/pull/4204