### PR TITLE
`zwe init apfauth` more optional

### DIFF
--- a/bin/commands/init/apfauth/.help
+++ b/bin/commands/init/apfauth/.help
@@ -9,11 +9,14 @@ zowe:
   setup:
     dataset:
       prefix: IBMUSER.ZWE
+      jcllib: IBMUSER.ZWE.CUST.JCLLIB
       authLoadlib: IBMUSER.ZWE.CUST.ZWESALL
       authPluginLib: IBMUSER.ZWE.CUST.ZWESAPL
 ```
 
 - `zowe.setup.dataset.prefix` shows where the `SZWEAUTH` data set is installed.
+- `zowe.setup.dataset.jcllib` is the custom JCL library. Zowe server command may
+  generate sample JCLs and put into this data set.
 - `zowe.setup.dataset.authLoadlib` is the user custom APF LOADLIB. This field is
   optional. If it's not defined, `SZWEAUTH` from `zowe.setup.dataset.prefix` data
   set will be APF authorized.

--- a/bin/commands/init/apfauth/.help
+++ b/bin/commands/init/apfauth/.help
@@ -19,4 +19,3 @@ zowe:
   set will be APF authorized.
 - `zowe.setup.dataset.authPluginLib` is the user custom APF PLUGINLIB.
   You can install Zowe ZIS plugins into this load library. This field is optional.
-  

--- a/bin/commands/init/apfauth/.help
+++ b/bin/commands/init/apfauth/.help
@@ -19,3 +19,4 @@ zowe:
   set will be APF authorized.
 - `zowe.setup.dataset.authPluginLib` is the user custom APF PLUGINLIB.
   You can install Zowe ZIS plugins into this load library. This field is optional.
+  

--- a/bin/commands/init/apfauth/.help
+++ b/bin/commands/init/apfauth/.help
@@ -18,4 +18,4 @@ zowe:
   optional. If it's not defined, `SZWEAUTH` from `zowe.setup.dataset.prefix` data
   set will be APF authorized.
 - `zowe.setup.dataset.authPluginLib` is the user custom APF PLUGINLIB.
-  You can install Zowe ZIS plugins into this load library.
+  You can install Zowe ZIS plugins into this load library. This field is optional.

--- a/bin/commands/init/apfauth/index.ts
+++ b/bin/commands/init/apfauth/index.ts
@@ -50,6 +50,7 @@ export function execute() {
   let authLoadlib = ZOWE_CONFIG.zowe?.setup?.dataset?.authLoadlib;
   if (!authLoadlib) {
     common.printMessage(`ZWEL0158I: zowe.setup.dataset.authLoadlib is not defined in Zowe YAML configuration file. Using the default value ${ZOWE_CONFIG.zowe.setup.dataset.prefix}.SZWEAUTH.`);
+    needUpdate = true;
     authLoadlib = `${ZOWE_CONFIG.zowe.setup.dataset.prefix}.SZWEAUTH`;
   }
 

--- a/bin/commands/init/apfauth/index.ts
+++ b/bin/commands/init/apfauth/index.ts
@@ -46,9 +46,10 @@ export function execute() {
     return common.printErrorAndExit(`Error ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL ${prefix}.SZWESAMP(ZWEGENER) before running this command.`, undefined, 319);
   }
 
+  let needUpdate = false;
   let authLoadlib = ZOWE_CONFIG.zowe?.setup?.dataset?.authLoadlib;
   if (!authLoadlib) {
-    common.printMessage(`ZWEL0158I: zowe.setup.dataset.authLoadlib is not defined in Zowe YAML configuration file. Using the default value.`);
+    common.printMessage(`ZWEL0158I: zowe.setup.dataset.authLoadlib is not defined in Zowe YAML configuration file. Using the default value ${ZOWE_CONFIG.zowe.setup.dataset.prefix}.SZWEAUTH.`);
     authLoadlib = `${ZOWE_CONFIG.zowe.setup.dataset.prefix}.SZWEAUTH`;
   }
 
@@ -56,41 +57,41 @@ export function execute() {
   if (!zosDs.isDatasetExists(authLoadlib)) {
     common.printErrorAndExit(`Error ZWEL0320E: The dataset specified in 'zowe.setup.dataset.authLoadlib' does not exist.`, undefined, 320);
   }
-
-  const authPluginLib = ZOWE_CONFIG.zowe?.setup?.dataset?.authPluginLib;
+  let authPluginLib = ZOWE_CONFIG.zowe?.setup?.dataset?.authPluginLib;
   if (!authPluginLib) {
     //TODO: is there a better message?
     common.printMessage('ZWEL0158I: zowe.setup.dataset.authPluginLib is not defined in Zowe YAML configuration file. Skipping.');
+    needUpdate = true;
+  } else {
+    if (authLoadlib == authPluginLib) {
+      // Skip APF command for the same dataset
+      authPluginLib = undefined;
+      needUpdate = true;
+    }
   }
   // AuthPluginLib must exist only if defined by user
   if (authPluginLib && !zosDs.isDatasetExists(authPluginLib)) {
-      common.printErrorAndExit(`Error ZWEL0320E: The dataset specified in 'zowe.setup.dataset.authPluginLib' does not exist.`, undefined, 320);
+    common.printErrorAndExit(`Error ZWEL0320E: The dataset specified in 'zowe.setup.dataset.authPluginLib' does not exist.`, undefined, 320);
   }
 
   const authSMS = zosDs.isDatasetSmsManaged(authLoadlib).smsManaged;
-  let auth = {
-    sms: authSMS,
-    volume: authSMS == true ? undefined : zosDs.getDatasetVolume(authLoadlib).volume,
-    replacer: ''
+  let authLocation = `LOADLOC=SMS`;
+  if (!authSMS) {
+    needUpdate = true;
+    authLocation = `LOADLOC="VOLUME=${zosDs.getDatasetVolume(authLoadlib).volume}"`;
   }
+
   const plugSMS = authPluginLib ? zosDs.isDatasetSmsManaged(authPluginLib).smsManaged : undefined;
-  let plug = {
-    sms: plugSMS,
-    volume: plugSMS == true ? undefined : (authPluginLib ? zosDs.getDatasetVolume(authPluginLib).volume : undefined),
-    replacer: ''
+  let plugLocation = `PLUGLOC=SMS`;
+  if (plugSMS == false) {
+    needUpdate = true;
+    plugLocation = `PLUGLOC="VOLUME=${zosDs.getDatasetVolume(authPluginLib).volume}"`
   }
 
-  if (!auth.sms && auth.volume) {
-    auth.replacer = `LOADLOC="VOLUME=${auth.volume}"`
-  }
-
-  if (!plug.sms && plug.volume) {
-    plug.replacer = `PLUGLOC="VOLUME=${plug.volume}"`
-  }
-
-  if (!auth.replacer && !plug.replacer) {
+  if (!needUpdate) {
     zosJes.printAndHandleJcl(`//'${jcllib}(ZWEIAPF2)'`, `ZWEIAPF2`, jcllib, prefix);
-  } else {
+  }
+  else {
     const COMMAND_LIST = std.getenv('ZWE_CLI_COMMANDS_LIST');
     const tmpfile = fs.createTmpFile(`zwe ${COMMAND_LIST}`.replace(new RegExp('\ ', 'g'), '-'));
     common.printDebug(`- Copy ${jcllib}(ZWEIAPF2) to ${tmpfile}`);
@@ -99,12 +100,18 @@ export function execute() {
       common.printDebug(`  * Succeeded`);
       common.printTrace(`  * Output:`);
       common.printTrace(stringlib.paddingLeft(jclContent.out, "    "));
-      if (auth.replacer) {
-        jclContent.out = jclContent.out.replace("LOADLOC=SMS", auth.replacer);
+      // Remove the shell after 'cd bin/utils &&'
+      const BIN_UTILS = 'cd bin/utils &&';
+      jclContent.out = jclContent.out.substring(0, jclContent.out.indexOf(BIN_UTILS) + BIN_UTILS.length + 1);
+      jclContent.out = jclContent.out.concat(`LOADLIB='${authLoadlib}' &&\n`);
+      jclContent.out = jclContent.out.concat(`${authLocation} &&\n`);
+      jclContent.out = jclContent.out.concat(`./opercmd.rex "SETPROG APF,ADD,DSN=$LOADLIB,$LOADLOC"${authPluginLib ? ' &&' : ''}\n`);
+      if (authPluginLib) {
+        jclContent.out = jclContent.out.concat(`PLUGLIB='${authPluginLib}' &&\n`);
+        jclContent.out = jclContent.out.concat(`${plugLocation} &&\n`);
+        jclContent.out = jclContent.out.concat(`./opercmd.rex "SETPROG APF,ADD,DSN=$PLUGLIB,$PLUGLOC"\n`);
       }
-      if (plug.replacer) {
-        jclContent.out = jclContent.out.replace("PLUGLOC=SMS", plug.replacer);
-      }
+      jclContent.out = jclContent.out.concat(`//*\n`);
       xplatform.storeFileUTF8(tmpfile, xplatform.AUTO_DETECT, jclContent.out);
       common.printTrace(`  * Stored:`);
       common.printTrace(stringlib.paddingLeft(jclContent.out, "    "));
@@ -112,7 +119,7 @@ export function execute() {
       if (!fs.fileExists(tmpfile)) {
         common.printErrorAndExit(`Error ZWEL0159E: Failed to prepare ZWEIAPF2`, undefined, 159);
       }
-        zosJes.printAndHandleJcl(tmpfile, `ZWEIAPF2`, jcllib, prefix, true);
+      zosJes.printAndHandleJcl(tmpfile, `ZWEIAPF2`, jcllib, prefix, true);
     }
   }
   common.printLevel2Message(`Zowe load libraries are APF authorized successfully.`);

--- a/bin/commands/init/apfauth/index.ts
+++ b/bin/commands/init/apfauth/index.ts
@@ -48,7 +48,7 @@ export function execute() {
 
   let authLoadlib = ZOWE_CONFIG.zowe?.setup?.dataset?.authLoadlib;
   if (!authLoadlib) {
-    common.printMessage(`ZWEL0158I: zowe.setup.dataset.authLoadlib is not defined in Zowe YAML configuration file. Using the defualt value.`);
+    common.printMessage(`ZWEL0158I: zowe.setup.dataset.authLoadlib is not defined in Zowe YAML configuration file. Using the default value.`);
     authLoadlib = `${ZOWE_CONFIG.zowe.setup.dataset.prefix}.SZWEAUTH`;
   }
 

--- a/bin/commands/init/apfauth/index.ts
+++ b/bin/commands/init/apfauth/index.ts
@@ -3,26 +3,25 @@
   under the terms of the Eclipse Public License v2.0 which
   accompanies this distribution, and is available at
   https://www.eclipse.org/legal/epl-v20.html
- 
+
   SPDX-License-Identifier: EPL-2.0
- 
+
   Copyright Contributors to the Zowe Project.
 */
-
 import * as std from 'cm_std';
-import * as zosJes from '../../../libs/zos-jes';
-import * as zosDs  from '../../../libs/zos-dataset';
-import * as zoslib from '../../../libs/zos';
+import * as xplatform from 'xplatform';
+
 import * as common from '../../../libs/common';
 import * as config from '../../../libs/config';
-import * as fs     from '../../../libs/fs';
-import * as shell  from '../../../libs/shell';
-import * as stringlib from '../../../libs/string';
-import * as xplatform from 'xplatform';
+import * as fs from '../../../libs/fs';
 import * as initGenerate from '../generate/index';
+import * as shell from '../../../libs/shell';
+import * as stringlib from '../../../libs/string';
+import * as zosDs from '../../../libs/zos-dataset';
+import * as zosJes from '../../../libs/zos-jes';
+import * as zoslib from '../../../libs/zos';
 
 export function execute() {
-
   common.printLevel1Message(`APF authorize load libraries`);
 
   // Validation
@@ -30,13 +29,13 @@ export function execute() {
   const ZOWE_CONFIG = config.getZoweConfig();
 
   // read prefix and validate
-  const prefix=ZOWE_CONFIG.zowe?.setup?.dataset?.prefix;
+  const prefix = ZOWE_CONFIG.zowe?.setup?.dataset?.prefix;
   if (!prefix) {
     common.printErrorAndExit(`Error ZWEL0157E: Zowe dataset prefix (zowe.setup.dataset.prefix) is not defined in Zowe YAML configuration file.`, undefined, 157);
   }
 
   // check if user passed --generate
-  const forceGen = !!std.getenv('ZWE_CLI_PARAMETER_GENERATE') 
+  const forceGen = !!std.getenv('ZWE_CLI_PARAMETER_GENERATE');
   if (forceGen) {
     initGenerate.execute();
   }
@@ -47,33 +46,51 @@ export function execute() {
     return common.printErrorAndExit(`Error ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL ${prefix}.SZWESAMP(ZWEGENER) before running this command.`, undefined, 319);
   }
 
-  let shouldAuthPluginLib = true;
-
-  if (!ZOWE_CONFIG.zowe?.setup?.dataset?.authLoadlib) {
-    common.printErrorAndExit(`Error ZWEL0157E: zowe.setup.dataset.authLoadlib is not defined in Zowe YAML configuration file.`, undefined, 157);
+  let authLoadlib = ZOWE_CONFIG.zowe?.setup?.dataset?.authLoadlib;
+  if (!authLoadlib) {
+    common.printMessage(`ZWEL0158I: zowe.setup.dataset.authLoadlib is not defined in Zowe YAML configuration file. Using the defualt value.`);
+    authLoadlib = `${ZOWE_CONFIG.zowe.setup.dataset.prefix}.SZWEAUTH`;
   }
-  if (!ZOWE_CONFIG.zowe?.setup?.dataset?.authPluginLib) {
-    //TODO: is there a better message?
-    common.printMessage('ZWEL0158I: zowe.setup.dataset.authPluginLib is not defined in Zowe YAML configuration file. Skipping.', undefined);
-    shouldAuthPluginLib = false;
-  }
- 
-  let result1 = zosDs.isDatasetSmsManaged(ZOWE_CONFIG.zowe.setup.dataset.authLoadlib);
 
-  let result2: {rc: number, smsManaged?: boolean | null } = {rc: 1, smsManaged: null}; // default used when shouldAuthPlugin=false
-  if (shouldAuthPluginLib) {
-    result2 = zosDs.isDatasetSmsManaged(ZOWE_CONFIG.zowe.setup.dataset.authPluginLib);
-  } 
-
-  if (result1.rc != 0) {
+  // Authloadlib must exist, either user defined or default "zowe.setup.dataset.prefix.SZWEAUTH"
+  if (!zosDs.isDatasetExists(authLoadlib)) {
     common.printErrorAndExit(`Error ZWEL0320E: The dataset specified in 'zowe.setup.dataset.authLoadlib' does not exist.`, undefined, 320);
   }
-  if (result2.rc != 0 && shouldAuthPluginLib) {
-    common.printErrorAndExit(`Error ZWEL0320E: The dataset specified in 'zowe.setup.dataset.authPluginLib' does not exist.`, undefined, 320);
+
+  const authPluginLib = ZOWE_CONFIG.zowe?.setup?.dataset?.authPluginLib;
+  if (!authPluginLib) {
+    //TODO: is there a better message?
+    common.printMessage('ZWEL0158I: zowe.setup.dataset.authPluginLib is not defined in Zowe YAML configuration file. Skipping.');
+  }
+  // AuthPluginLib must exist only if defined by user
+  if (authPluginLib && !zosDs.isDatasetExists(authPluginLib)) {
+      common.printErrorAndExit(`Error ZWEL0320E: The dataset specified in 'zowe.setup.dataset.authPluginLib' does not exist.`, undefined, 320);
   }
 
-  // if neither ds is sms managed, or we're not apf authorizing pluginlib, then we need to modify IAPF2
-  if (!result1.smsManaged || !result2.smsManaged || !shouldAuthPluginLib) {
+  const authSMS = zosDs.isDatasetSmsManaged(authLoadlib).smsManaged;
+  let auth = {
+    sms: authSMS,
+    volume: authSMS == true ? undefined : zosDs.getDatasetVolume(authLoadlib).volume,
+    replacer: ''
+  }
+  const plugSMS = authPluginLib ? zosDs.isDatasetSmsManaged(authPluginLib).smsManaged : undefined;
+  let plug = {
+    sms: plugSMS,
+    volume: plugSMS == true ? undefined : (authPluginLib ? zosDs.getDatasetVolume(authPluginLib).volume : undefined),
+    replacer: ''
+  }
+
+  if (!auth.sms && auth.volume) {
+    auth.replacer = `LOADLOC="VOLUME=${auth.volume}"`
+  }
+
+  if (!plug.sms && plug.volume) {
+    plug.replacer = `PLUGLOC="VOLUME=${plug.volume}"`
+  }
+
+  if (!auth.replacer && !plug.replacer) {
+    zosJes.printAndHandleJcl(`//'${jcllib}(ZWEIAPF2)'`, `ZWEIAPF2`, jcllib, prefix);
+  } else {
     const COMMAND_LIST = std.getenv('ZWE_CLI_COMMANDS_LIST');
     const tmpfile = fs.createTmpFile(`zwe ${COMMAND_LIST}`.replace(new RegExp('\ ', 'g'), '-'));
     common.printDebug(`- Copy ${jcllib}(ZWEIAPF2) to ${tmpfile}`);
@@ -82,47 +99,21 @@ export function execute() {
       common.printDebug(`  * Succeeded`);
       common.printTrace(`  * Output:`);
       common.printTrace(stringlib.paddingLeft(jclContent.out, "    "));
-      
-      if (result1.rc === 0 && !result1.smsManaged) {
-        let result3 = zosDs.getDatasetVolume(ZOWE_CONFIG.zowe.setup.dataset.authLoadlib);
-        if (result3.volume) {
-          jclContent.out = jclContent.out.replace("export LOADLOC=SMS", `export LOADLOC="VOLUME=${result3.volume}"`);
-        }
+      if (auth.replacer) {
+        jclContent.out = jclContent.out.replace("LOADLOC=SMS", auth.replacer);
       }
-      if (shouldAuthPluginLib && result2.rc === 0 && !result2.smsManaged) {
-        let result4 = zosDs.getDatasetVolume(ZOWE_CONFIG.zowe.setup.dataset.authPluginLib);
-        if (result4.volume) {
-          jclContent.out = jclContent.out.replace("export PLUGLOC=SMS", `export PLUGLOC="VOLUME=${result4.volume}"`);
-        }
+      if (plug.replacer) {
+        jclContent.out = jclContent.out.replace("PLUGLOC=SMS", plug.replacer);
       }
-
-      if (!shouldAuthPluginLib) {
-        // replace 2 export lines (33 and 34 in IAPF2 at time of writing)
-        jclContent.out = jclContent.out.replace(/\nexport PLUGLIB=.*\nexport PLUGLOC=SMS.*$/gm, '');
-        jclContent.out = jclContent.out.replace(/\n\.\/opercmd\.rex.*?PLUGLOC.*$/gm, '');
-      }
-
       xplatform.storeFileUTF8(tmpfile, xplatform.AUTO_DETECT, jclContent.out);
       common.printTrace(`  * Stored:`);
       common.printTrace(stringlib.paddingLeft(jclContent.out, "    "));
-
       shell.execSync('chmod', '700', tmpfile);
       if (!fs.fileExists(tmpfile)) {
         common.printErrorAndExit(`Error ZWEL0159E: Failed to prepare ZWEIAPF2`, undefined, 159);
       }
-      
-      zosJes.printAndHandleJcl(tmpfile, `ZWEIAPF2`, jcllib, prefix, true);
-    } else {
-      common.printDebug(`  * Failed`);
-      common.printError(`  * Exit code: ${jclContent.rc}`);
-      common.printError(`  * Output:`);
-      if (jclContent.out) {
-        common.printError(stringlib.paddingLeft(jclContent.out, "    "));
-      }
-      std.exit(1);
+        zosJes.printAndHandleJcl(tmpfile, `ZWEIAPF2`, jcllib, prefix, true);
     }
-  } else {
-    zosJes.printAndHandleJcl(`//'${jcllib}(ZWEIAPF2)'`, `ZWEIAPF2`, jcllib, prefix);      
   }
   common.printLevel2Message(`Zowe load libraries are APF authorized successfully.`);
 }

--- a/files/SZWEEXEC/ZWEGEN00
+++ b/files/SZWEEXEC/ZWEGEN00
@@ -345,9 +345,9 @@ do i = 1 to members.0
       if old = '{zowe.environments.jclHeader}' then do
         if pos(x2c('15'), new) > 0 then
           iterate j
-        if symbol('CFG.'members.i.substitutions.j) = 'LIT' then
-          iterate j
       end
+      if symbol('CFG.'members.i.substitutions.j) = 'LIT' then
+        iterate j
       apostrophes1 = "'"
       apostrophes2 = "'"
       if pos("'", new) > 0 & pos('"', new) = 0 then do

--- a/files/SZWESAMP/ZWEIAPF2
+++ b/files/SZWESAMP/ZWEIAPF2
@@ -12,12 +12,17 @@
 //*********************************************************************
 //*
 //*  This JCL is used to set APF for the two datasets of Zowe
-//*  Which need it. You can issue this, or use another
-//*  Way to accomplish the task.
+//*  which need it. You can issue this, or use another
+//*  way to accomplish the task.
 //*
 //*  The following variables are derived from the zowe YAML config:
-//*  LOADLIB: the dataset that holds the APF portion of Zowe
-//*  PLUGLIB: The dataset that holds the extensions for ZIS.
+//*  LOADLIB: the dataset that holds the APF portion of Zowe.
+//*    If not set, zowe.setup.dataset.prefix + SZWEAUTH is used.
+//*  PLUGLIB: the dataset that holds the extensions for ZIS.
+//*    If not set, no PLUGLIB authorization is done.
+//*
+//*  Note: if you plan NOT to use Zowe Cross Memory Server at all,
+//*    you can skip this step.
 //*
 //*********************************************************************
 //*
@@ -28,10 +33,15 @@
 //STDPARM DD *
 SH cd '{zowe.runtimeDirectory}' &&
 cd bin/utils &&
-export LOADLIB='{zowe.setup.dataset.authLoadlib}' &&
-export LOADLOC=SMS &&
-export PLUGLIB='{zowe.setup.dataset.authPluginLib}' &&
-export PLUGLOC=SMS &&
+LOADLIB='{zowe.setup.dataset.authLoadlib}' &&
+if [ "${LOADLIB}" = "CFG.ZOWE.SETUP.DATASET.AUTHLOADLIB" ]; then
+  LOADLIB='{zowe.setup.dataset.prefix}.SZWEAUTH';
+fi &&
+LOADLOC=SMS &&
 ./opercmd.rex "SETPROG APF,ADD,DSN=$LOADLIB,$LOADLOC" &&
-./opercmd.rex "SETPROG APF,ADD,DSN=$PLUGLIB,$PLUGLOC"
+PLUGLIB='{zowe.setup.dataset.authPluginLib}' &&
+if [ "${PLUGLIB}" != "CFG.ZOWE.SETUP.DATASET.AUTHPLUGINLIB" ]; then
+  PLUGLOC=SMS &&
+  ./opercmd.rex "SETPROG APF,ADD,DSN=$PLUGLIB,$PLUGLOC";
+fi
 //*

--- a/files/SZWESAMP/ZWEIAPF2
+++ b/files/SZWESAMP/ZWEIAPF2
@@ -34,14 +34,9 @@
 SH cd '{zowe.runtimeDirectory}' &&
 cd bin/utils &&
 LOADLIB='{zowe.setup.dataset.authLoadlib}' &&
-if [ "$LOADLIB" = "CFG.ZOWE.SETUP.DATASET.AUTHLOADLIB" ]; then
-  LOADLIB='{zowe.setup.dataset.prefix}.SZWEAUTH';
-fi &&
 LOADLOC=SMS &&
 ./opercmd.rex "SETPROG APF,ADD,DSN=$LOADLIB,$LOADLOC" &&
 PLUGLIB='{zowe.setup.dataset.authPluginLib}' &&
-if [ "$PLUGLIB" != "CFG.ZOWE.SETUP.DATASET.AUTHPLUGINLIB" ]; then
-  PLUGLOC=SMS &&
-  ./opercmd.rex "SETPROG APF,ADD,DSN=$PLUGLIB,$PLUGLOC";
-fi
+PLUGLOC=SMS &&
+./opercmd.rex "SETPROG APF,ADD,DSN=$PLUGLIB,$PLUGLOC"
 //*

--- a/files/SZWESAMP/ZWEIAPF2
+++ b/files/SZWESAMP/ZWEIAPF2
@@ -34,13 +34,13 @@
 SH cd '{zowe.runtimeDirectory}' &&
 cd bin/utils &&
 LOADLIB='{zowe.setup.dataset.authLoadlib}' &&
-if [ "${LOADLIB}" = "CFG.ZOWE.SETUP.DATASET.AUTHLOADLIB" ]; then
+if [ "$LOADLIB" = "CFG.ZOWE.SETUP.DATASET.AUTHLOADLIB" ]; then
   LOADLIB='{zowe.setup.dataset.prefix}.SZWEAUTH';
 fi &&
 LOADLOC=SMS &&
 ./opercmd.rex "SETPROG APF,ADD,DSN=$LOADLIB,$LOADLOC" &&
 PLUGLIB='{zowe.setup.dataset.authPluginLib}' &&
-if [ "${PLUGLIB}" != "CFG.ZOWE.SETUP.DATASET.AUTHPLUGINLIB" ]; then
+if [ "$PLUGLIB" != "CFG.ZOWE.SETUP.DATASET.AUTHPLUGINLIB" ]; then
   PLUGLOC=SMS &&
   ./opercmd.rex "SETPROG APF,ADD,DSN=$PLUGLIB,$PLUGLOC";
 fi

--- a/files/defaults.yaml
+++ b/files/defaults.yaml
@@ -32,7 +32,6 @@ zowe:
   setup:
     # MVS data set related configurations
     dataset: 
-      authLoadlib: ${{ zowe.setup.dataset.prefix }}.SZWEAUTH
       parmlibMembers:
         # For ZIS plugins
         zis: ZWESIP00

--- a/files/defaults.yaml
+++ b/files/defaults.yaml
@@ -31,7 +31,7 @@ zowe:
     jclHeader: ''
   setup:
     # MVS data set related configurations
-    dataset: 
+    dataset:
       parmlibMembers:
         # For ZIS plugins
         zis: ZWESIP00
@@ -62,7 +62,7 @@ zowe:
     # This section fully defines a default for certificate scenario 1, but makes way when detecting any other scenarios.
     certificate:
       type: PKCS12
-      pkcs12: 
+      pkcs12:
         directory: "${{ zowe.setup.certificate.type != 'PKCS12' ? null : '/var/zowe/keystore' }}"
         lock: "${{ zowe.setup.certificate.type != 'PKCS12' ? null : true }}"
         name: "${{ zowe.setup.certificate.type == 'PKCS12' && !zowe.setup.certificate.pkcs12.import ? 'localhost' : null }}"
@@ -71,7 +71,7 @@ zowe:
         caPassword: "${{ zowe.setup.certificate.type == 'PKCS12' && !zowe.setup.certificate.pkcs12.import ? 'local_ca_password' : null }}"
 
       # Distinguished name for Zowe generated certificates.
-      dname: 
+      dname:
         caCommonName: "${{ (zowe.setup.certificate.pkcs12?.name || zowe.setup.certificate.keyring?.name) ? 'Zowe Development Instances CA' : null }}"
         commonName: "${{ (zowe.setup.certificate.pkcs12?.name || zowe.setup.certificate.keyring?.name) ? 'Zowe Development Instances Certificate' : null }}"
         orgUnit: "${{ (zowe.setup.certificate.pkcs12?.name || zowe.setup.certificate.keyring?.name) ? 'API Mediation Layer' : null }}"
@@ -103,14 +103,14 @@ zowe:
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   # This is an ID you use to separate multiple Zowe installs when determining
   # resource names used in RBAC authorization checks such as dataservices with RBAC
-  # expects this ID in SAF resources 
+  # expects this ID in SAF resources
   rbacProfileIdentifier: "1"
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-  # This is an ID that can be used by servers that distinguish their cookies from unrelated Zowe installs, 
+  # This is an ID that can be used by servers that distinguish their cookies from unrelated Zowe installs,
   # for purposes such as to allow multiple copies of Zowe to be used within the same client
   cookieIdentifier: "1"
-  
+
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   # This is the port you use to access Zowe Gateway from your web browser.
   #
@@ -135,7 +135,7 @@ zowe:
   #              This mode does not validate certificate Common Name and Subject
   #              Alternative Name (SAN).
   # - DISABLED:  disable certificate validation. This is NOT recommended for
-  #              security. 
+  #              security.
   verifyCertificates: STRICT
 
 #-------------------------------------------------------------------------------

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -40,7 +40,7 @@
       "artifact": "*.pax"
     },
     "org.zowe.zss": {
-      "version": "^3.1.0-PR-739",
+      "version": "^3.2.0-PR-683",
       "artifact": "*.pax"
     },
     "org.zowe.explorer-jes": {


### PR DESCRIPTION
`zwe init apfauth` update:
* Removing `authLoadlib: ${{ zowe.setup.dataset.prefix }}.SZWEAUTH` from `defaults.yaml`
  * This could be set only if `zowe.setup.dataset.prefix` is mandatory

```jcl
//STDPARM DD *
SH cd '{zowe.runtimeDirectory}' &&
cd bin/utils &&
LOADLIB='{zowe.setup.dataset.authLoadlib}' &&
LOADLOC=SMS &&
./opercmd.rex "SETPROG APF,ADD,DSN=$LOADLIB,$LOADLOC" &&
PLUGLIB='{zowe.setup.dataset.authPluginLib}' &&
PLUGLOC=SMS &&
./opercmd.rex "SETPROG APF,ADD,DSN=$PLUGLIB,$PLUGLOC";
//*
```
If `zowe.setup.dataset.authLoadlib` not set, we will use `zowe.setup.dataset.prefix.SZWEAUTH`.
If `zowe.setup.dataset.authPluginLib` not set, `PLUGLIB=..` + 2 following lines are deleted.
If `zowe.setup.dataset.authPluginLib` same as `zowe.setup.dataset.authLoadlib`, `PLUGLIB=...` + 2 following lines are deleted.

## Update
There was a bug in `ZWEGEN00` causing undefined `yaml` items were propagated as `CFG.` + `"yaml property path"`, e.g. for `zowe.setup.dataset.prefix` -> `CFG.ZOWE.DATASET.PREFIX`. Originally it was keeping undefined template variable as it was and with this fix we will be doing the same again.

For example: if there is no `zowe.runtimeDirectory` in yaml, this will be the same before and after `generate` action: 
* `SH cd '{zowe.runtimeDirectory}' &&` 

## Changes
* `.help` - mentioning `jcllib`
* `index.ts` - when detects need for update, it will delete major part of shell and recreate it again. The goal was to have simple code.
* `ZWEGEN00` - condition for checking uninitialized variable was incorrectly nested 
* `ZWEIAPF2` - `export` not needed, lines reorganized
* `defaults.yaml` - default for `authLoadlib` removed
