### PR TITLE
Change validation for `zowe.setup.dataset.parmlibMembers.zis`

### DIFF
--- a/schemas/server-common.json
+++ b/schemas/server-common.json
@@ -40,6 +40,14 @@
       "minLength": 1,
       "maxLength": 8
     },
+    "datasetZISMember": {
+      "$anchor": "zoweDatasetZISMember",
+      "type": "string",
+      "description": "A 'ZWESIP' prefix followed by 2 characters",
+      "pattern": "^ZWESIP([0-9A-Z\\$\\#\\@]){2}$",
+      "minLength": 8,
+      "maxLength": 8
+    },
     "jobname": {
       "$anchor": "zoweJobname",
       "type": "string",

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -38,7 +38,7 @@
                   "description": "Holds Zowe PARMLIB members for plugins",
                   "properties": {
                     "zis": {
-                      "$ref": "/schemas/v2/server-common#zoweDatasetMember",
+                      "$ref": "/schemas/v2/server-common#zoweDatasetZISMember",
                       "description": "PARMLIB member used by ZIS"
                     }
                   }


### PR DESCRIPTION
`zowe.setup.dataset.parmlibMembers.zis` is a parmlib name with default of `ZWESIP00`, where you can actually change only last 2 characters (suffix).

But users might expect to use any valid member name there, which is not true.

Updated schema validation is checking this.

```diff
! [misc.makeYaml]: ./yaml/zowe.ok1.yaml:
zowe:
  setup:
    dataset:
      parmlibMembers:
        zis: ZWESIP01

! [misc.makeYaml]: ./yaml/zowe.ok2.yaml:
zowe:
  setup:
    dataset:
      parmlibMembers:
        zis: ZWESIP@@

! [misc.makeYaml]: ./yaml/zowe.er1.yaml:
zowe:
  setup:
    dataset:
      parmlibMembers:
        zis: ZWESIP0

! [misc.makeYaml]: ./yaml/zowe.er2.yaml:
zowe:
  setup:
    dataset:
      parmlibMembers:
        zis: ABCDEF00

! [misc.exportEnv]: ZWE_CLI_PARAMETER_CONFIG=
  [1/4]: /zowe/bin/zwe config validate -c ./yaml/zowe.ok1.yaml
! [Output]:
Temporary directory '/tmp/.zweenv-9511' created.
Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
2025-02-27 10:03:02 <ZWELS:50727027> T800 INFO (zwe-internal-start-prepare) Zowe version: v3.2.0
2025-02-27 10:03:02 <ZWELS:50727027> T800 INFO (zwe-internal-start-prepare) build and hash: PR-4210#7088 (272a3de028308174a7f15db79195b268d4ed353b)
Validating Zowe core configuration for file(s)=/tmp/.zweenv-9511/.zowe-merged.yaml
Zowe core configuration is valid
+ [1/4][expected rc=  0, result rc=  0  ]: /zowe/bin/zwe config validate -c ./yaml/zowe.ok1.yaml
  [1/4]: --------------------------------

  [2/4]: /zowe/bin/zwe config validate -c ./yaml/zowe.ok2.yaml
! [Output]:
Temporary directory '/tmp/.zweenv-3789' created.
Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
2025-02-27 10:03:13 <ZWELS:50725452> T800 INFO (zwe-internal-start-prepare) Zowe version: v3.2.0
2025-02-27 10:03:13 <ZWELS:50725452> T800 INFO (zwe-internal-start-prepare) build and hash: PR-4210#7088 (272a3de028308174a7f15db79195b268d4ed353b)
Validating Zowe core configuration for file(s)=/tmp/.zweenv-3789/.zowe-merged.yaml
Zowe core configuration is valid
+ [2/4][expected rc=  0, result rc=  0  ]: /zowe/bin/zwe config validate -c ./yaml/zowe.ok2.yaml
  [2/4]: --------------------------------

  [3/4]: /zowe/bin/zwe config validate -c ./yaml/zowe.er1.yaml
! [Output]:
Error: Validation of FILE(./yaml/zowe.er1.yaml):FILE(/zowe/files/defaults.yaml) against schema /zowe/schemas/zowe-yaml-schema.json:/zowe/schemas/server-common.json found invalid JSON Schema data
Validity Exceptions(s) with object at
  Validity Exceptions(s) with object at /zowe
    Validity Exceptions(s) with object at /zowe/setup
      Validity Exceptions(s) with object at /zowe/setup/dataset
        Validity Exceptions(s) with object at /zowe/setup/dataset/parmlibMembers
          Validity Exceptions(s) with string at /zowe/setup/dataset/parmlibMembers/zis
            string too short (len=7) 'ZWESIP0' 7 < MIN=8 at /zowe/setup/dataset/parmlibMembers/zis
            string pattern match fail s='ZWESIP0', pat='^ZWESIP([0-9A-Z\$\#\@]){2}$', at /zowe/setup/dataset/parmlibMembers/zis
+ [3/4][expected rc=  1, result rc=  1  ]: /zowe/bin/zwe config validate -c ./yaml/zowe.er1.yaml
  [3/4]: --------------------------------

  [4/4]: /zowe/bin/zwe config validate -c ./yaml/zowe.er2.yaml
! [Output]:
Error: Validation of FILE(./yaml/zowe.er2.yaml):FILE(/zowe/files/defaults.yaml) against schema /zowe/schemas/zowe-yaml-schema.json:/zowe/schemas/server-common.json found invalid JSON Schema data
Validity Exceptions(s) with object at
  Validity Exceptions(s) with object at /zowe
    Validity Exceptions(s) with object at /zowe/setup
      Validity Exceptions(s) with object at /zowe/setup/dataset
        Validity Exceptions(s) with object at /zowe/setup/dataset/parmlibMembers
          Validity Exceptions(s) with string at /zowe/setup/dataset/parmlibMembers/zis
            string pattern match fail s='ABCDEF00', pat='^ZWESIP([0-9A-Z\$\#\@]){2}$', at /zowe/setup/dataset/parmlibMembers/zis
+ [4/4][expected rc=  1, result rc=  1  ]: /zowe/bin/zwe config validate -c ./yaml/zowe.er2.yaml
  [4/4]: --------------------------------

! [Time elapsed]: 00:00:43

    ..::|[ T E S T     O V E R V I E W ]|::..
    -----------------------------------------

+ [1/4][expected rc=  0, result rc=  0  ]: /zowe/bin/zwe config validate -c ./yaml/zowe.ok1.yaml
+ [2/4][expected rc=  0, result rc=  0  ]: /zowe/bin/zwe config validate -c ./yaml/zowe.ok2.yaml
+ [3/4][expected rc=  1, result rc=  1  ]: /zowe/bin/zwe config validate -c ./yaml/zowe.er1.yaml
+ [4/4][expected rc=  1, result rc=  1  ]: /zowe/bin/zwe config validate -c ./yaml/zowe.er2.yaml
```