### PR TITLE
jclHeader support for install workflows

### DIFF
--- a/workflows/files/ZWEAMLCF.xml
+++ b/workflows/files/ZWEAMLCF.xml
@@ -11,6 +11,15 @@
         <General/>
     </workflowInfo>
     <!--variables-->
+    <variable name="zowe_setup_job_stmt_parms" scope="global" visibility="public">
+      <label>JOB statement parameters used by Zowe during installation and configuration.</label>
+      <abstract>JOB statement parameters used by Zowe during installation and configuration.</abstract>
+      <description>These additional JOB statement parameters are optional, and by default empty. These are separate from z/OSMF JOB statements.</description>
+      <category>zowe</category>
+      <string multiLine="true" valueMustBeChoice="false">
+        <default></default>
+      </string>
+    </variable>
     <variable name="zowe_setup_dataset_prefix" scope="instance" visibility="public">
         <label>Prefix of Zowe setup MVS datasets</label>
         <abstract>Prefix of datasets where remaining runtime datasets will be created</abstract>
@@ -625,6 +634,7 @@ some use cases, like containerization, this port could be different.</descriptio
             <!-- pre-requisite step -->
             <!-- condition -->
             <!--variableValues-->
+            <variableValue name="zowe_setup_job_stmt_parms" scope="global" noPromptIfSet="false" required="true" />
             <variableValue name="zowe_setup_dataset_prefix" scope="instance" noPromptIfSet="false" required="true"/>
             <variableValue name="zowe_setup_dataset_proclib" scope="instance" noPromptIfSet="false" required="true"/>
             <variableValue name="zowe_setup_dataset_parmlib" scope="instance" noPromptIfSet="false" required="true"/>
@@ -1087,7 +1097,16 @@ echo '' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '  # You can un-comment and define any extra environment variables as key/value' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '  # pairs here.' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+#if (${global-zowe_setup_job_stmt_parms} == "true")
+echo '  environments:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+echo '    jclHeaders:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+  #foreach($line in ${global-zowe_setup_job_stmt_parms}.split("\n"))
+echo '     - // ${line}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+  #end
+# 
+#else
 echo '  # environments:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+#end
 echo '  #   # Example of a global environment variable for all components' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '  #   MY_ENV_VAR: my_env_val' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"

--- a/workflows/files/ZWEAMLCF.xml
+++ b/workflows/files/ZWEAMLCF.xml
@@ -12,12 +12,11 @@
     </workflowInfo>
     <!--variables-->
     <variable name="zowe_setup_job_stmt_parms" scope="global" visibility="public">
-      <label>JOB statement parameters used by Zowe during installation and configuration.</label>
-      <abstract>JOB statement parameters used by Zowe during installation and configuration.</abstract>
-      <description>These additional JOB statement parameters are optional, and by default empty. These are separate from z/OSMF JOB statements.</description>
+      <label>JOB statement positional parameters and keywords used by Zowe during installation and configuration.</label>
+      <abstract>JOB statement positional parameters and keywords used by Zowe during installation and configuration.</abstract>
+      <description>These parameters and keywords are optional, and by default empty. These are used separately from z/OSMF defined JOB cards. Each line should be less than 70 characters, use commas for end-of-line continuation, and omit identifier statements such as "//", "/*", etc.</description>
       <category>zowe</category>
       <string multiLine="true" valueMustBeChoice="false">
-        <default>MSGCLASS=X</default>
       </string>
     </variable>
     <variable name="zowe_setup_dataset_prefix" scope="instance" visibility="public">
@@ -634,7 +633,7 @@ some use cases, like containerization, this port could be different.</descriptio
             <!-- pre-requisite step -->
             <!-- condition -->
             <!--variableValues-->
-            <variableValue name="zowe_setup_job_stmt_parms" scope="global" noPromptIfSet="false" required="true" />
+            <variableValue name="zowe_setup_job_stmt_parms" scope="global" noPromptIfSet="false" required="false" />
             <variableValue name="zowe_setup_dataset_prefix" scope="instance" noPromptIfSet="false" required="true"/>
             <variableValue name="zowe_setup_dataset_proclib" scope="instance" noPromptIfSet="false" required="true"/>
             <variableValue name="zowe_setup_dataset_parmlib" scope="instance" noPromptIfSet="false" required="true"/>
@@ -1099,11 +1098,14 @@ echo '  # You can un-comment and define any extra environment variables as key/v
 echo '  # pairs here.' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 #if (${global-zowe_setup_job_stmt_parms.trim().length()} > 0 )
 echo '  environments:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
-echo '    jclHeaders:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+echo '    jclHeader:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
   #foreach($line in ${global-zowe_setup_job_stmt_parms.split("\n")})
-echo '     - // ${line}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+    #if (${foreach.index} == 0) 
+echo '     - ${line}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+    #else
+echo '     - //    ${line}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+    #end
   #end
-# 
 #else
 echo '  # environments:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 #end

--- a/workflows/files/ZWEAMLCF.xml
+++ b/workflows/files/ZWEAMLCF.xml
@@ -17,7 +17,7 @@
       <description>These additional JOB statement parameters are optional, and by default empty. These are separate from z/OSMF JOB statements.</description>
       <category>zowe</category>
       <string multiLine="true" valueMustBeChoice="false">
-        <default></default>
+        <default>MSGCLASS=X</default>
       </string>
     </variable>
     <variable name="zowe_setup_dataset_prefix" scope="instance" visibility="public">
@@ -1097,10 +1097,10 @@ echo '' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '  # You can un-comment and define any extra environment variables as key/value' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '  # pairs here.' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
-#if (${global-zowe_setup_job_stmt_parms} == "true")
+#if (${global-zowe_setup_job_stmt_parms.trim().length()} > 0 )
 echo '  environments:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '    jclHeaders:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
-  #foreach($line in ${global-zowe_setup_job_stmt_parms}.split("\n"))
+  #foreach($line in ${global-zowe_setup_job_stmt_parms.split("\n")})
 echo '     - // ${line}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
   #end
 # 

--- a/workflows/files/ZWECONF.properties
+++ b/workflows/files/ZWECONF.properties
@@ -750,3 +750,10 @@ zowe_setup_security_stcs_zis=ZWESISTC
 #  STC name of Auxiliary Service
 zowe_setup_security_stcs_aux=ZWESASTC
 
+# zowe_setup_job_stmt_parms
+# Label: JOB statement parameters used by Zowe during installation and configuration
+# Abstract: JOB statement parameters used by Zowe during installation and configuration
+# Category: jclHeaders
+# Description:
+#  These additional JOB statement parameters are optional, and by default empty. These are separate from the z/OSMF JOB statements.
+zowe_setup_job_stmt_parms=

--- a/workflows/files/ZWECONF.xml
+++ b/workflows/files/ZWECONF.xml
@@ -11,6 +11,15 @@
         <General/>
     </workflowInfo>
     <!--variables-->
+    <variable name="zowe_setup_job_stmt_parms" scope="global" visibility="public">
+      <label>JOB statement parameters used by Zowe during installation and configuration.</label>
+      <abstract>JOB statement parameters used by Zowe during installation and configuration.</abstract>
+      <description>These additional JOB statement parameters are optional, and by default empty. These are separate from z/OSMF JOB statements.</description>
+      <category>zowe</category>
+      <string multiLine="true" valueMustBeChoice="false">
+        <default></default>
+      </string>
+    </variable>
     <variable name="zowe_setup_dataset_prefix" scope="instance" visibility="public">
         <label>Prefix of Zowe setup MVS datasets</label>
         <abstract>Prefix of datasets where remaining runtime datasets will be created</abstract>
@@ -1786,7 +1795,16 @@ echo '' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '  # You can un-comment and define any extra environment variables as key/value' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '  # pairs here.' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+#if (${global-zowe_setup_job_stmt_parms} == "true")
+echo '  environments:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+echo '    jclHeaders:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+  #foreach($line in ${global-zowe_setup_job_stmt_parms}.split("\n"))
+echo '     - // ${line}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+  #end
+# 
+#else
 echo '  # environments:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+#end
 echo '  #   # Example of a global environment variable for all components' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '  #   MY_ENV_VAR: my_env_val' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"

--- a/workflows/files/ZWECONF.xml
+++ b/workflows/files/ZWECONF.xml
@@ -17,8 +17,8 @@
       <description>These additional JOB statement parameters are optional, and by default empty. These are separate from z/OSMF JOB statements.</description>
       <category>zowe</category>
       <string multiLine="true" valueMustBeChoice="false">
-        <default></default>
-      </string>
+        <default>MSGCLASS=X</default>
+    </string>
     </variable>
     <variable name="zowe_setup_dataset_prefix" scope="instance" visibility="public">
         <label>Prefix of Zowe setup MVS datasets</label>
@@ -1795,10 +1795,10 @@ echo '' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '  # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '  # You can un-comment and define any extra environment variables as key/value' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '  # pairs here.' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
-#if (${global-zowe_setup_job_stmt_parms} == "true")
+#if (${global-zowe_setup_job_stmt_parms.trim().length()} > 0 )
 echo '  environments:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '    jclHeaders:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
-  #foreach($line in ${global-zowe_setup_job_stmt_parms}.split("\n"))
+  #foreach($line in ${global-zowe_setup_job_stmt_parms.split("\n")})
 echo '     - // ${line}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
   #end
 # 

--- a/workflows/files/ZWECONF.xml
+++ b/workflows/files/ZWECONF.xml
@@ -12,13 +12,12 @@
     </workflowInfo>
     <!--variables-->
     <variable name="zowe_setup_job_stmt_parms" scope="global" visibility="public">
-      <label>JOB statement parameters used by Zowe during installation and configuration.</label>
-      <abstract>JOB statement parameters used by Zowe during installation and configuration.</abstract>
-      <description>These additional JOB statement parameters are optional, and by default empty. These are separate from z/OSMF JOB statements.</description>
+      <label>JOB statement positional parameters and keywords used by Zowe during installation and configuration.</label>
+      <abstract>JOB statement positional parameters and keywords used by Zowe during installation and configuration.</abstract>
+      <description>These parameters and keywords are optional, and by default empty. These are used separately from z/OSMF defined JOB cards. Each line should be less than 70 characters, use commas for end-of-line continuation, and omit identifier statements such as "//", "/*", etc.</description>
       <category>zowe</category>
       <string multiLine="true" valueMustBeChoice="false">
-        <default>MSGCLASS=X</default>
-    </string>
+      </string>
     </variable>
     <variable name="zowe_setup_dataset_prefix" scope="instance" visibility="public">
         <label>Prefix of Zowe setup MVS datasets</label>
@@ -1089,6 +1088,7 @@ How we want to verify SSL certificates of services. Valid values are:
             <!-- pre-requisite step -->
             <!-- condition -->
             <!--variableValues-->
+            <variableValue name="zowe_setup_job_stmt_parms" scope="global" noPromptIfSet="false" required="false" />
             <variableValue name="zowe_setup_dataset_prefix" scope="instance" noPromptIfSet="false" required="true"/>
             <variableValue name="zowe_setup_dataset_proclib" scope="instance" noPromptIfSet="false" required="true"/>
             <variableValue name="zowe_setup_dataset_parmlib" scope="instance" noPromptIfSet="false" required="true"/>
@@ -1797,11 +1797,14 @@ echo '  # You can un-comment and define any extra environment variables as key/v
 echo '  # pairs here.' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 #if (${global-zowe_setup_job_stmt_parms.trim().length()} > 0 )
 echo '  environments:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
-echo '    jclHeaders:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+echo '    jclHeader:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
   #foreach($line in ${global-zowe_setup_job_stmt_parms.split("\n")})
-echo '     - // ${line}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+    #if (${foreach.index} == 0) 
+echo '     - ${line}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+    #else
+echo '     - //    ${line}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+    #end
   #end
-# 
 #else
 echo '  # environments:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 #end


### PR DESCRIPTION
PR that allows users to define JOB statement parameters used by ZWEGENER, etc. within z/OSMF configuration workflows.

Notes:

* z/OSMF has a way to define a JOB card for workflows run on a system, but I couldn't find any way to access it, either in system or workflow variables. So we have to define our own variable capturing JCL statement parameters.
* The default JOB positional and keyword parameters will be empty, so no JCL headers are applied.
* Syntax is set so users should not input JCL identifier fields, i.e. '//'. The workflow handles this for users when it creates the zowe.yaml file. In the current design, line 1 has no identifier fields since it follows `//<JOBNAME> JOB`, and lines 2...n will prepend `//    `.
* z/OSMF does not support regex validation for multiline strings that I could see. It just won't apply the regex I defined.

Tested:

zwe init generate using zowe.yaml from:
* Workflow with no job statement params
* Workflow with single line job statement
* Workflow with multi-line job statement
* One invalid job statement (error is only uncovered in `init generate`, which happens in step 3 of workflow)