### PR TITLE
Update API ML dependencies to 2.18.7

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -52,11 +52,11 @@
       "artifact": "zss-2.18.1-rc-1270-20250304134859.pax"
     },
     "org.zowe.explorer.jobs.jobs-api-package": {
-      "version": "2.0.37",
+      "version": "2.0.38",
       "artifact": "jobs-api-package-*.zip"
     },
     "org.zowe.explorer.files.files-api-package": {
-      "version": "2.0.36",
+      "version": "2.0.37",
       "artifact": "files-api-package-*.zip"
     },
     "org.zowe.explorer-jes": {
@@ -73,27 +73,27 @@
       "artifact": "explorer-ip*.pax"
     },
     "org.zowe.apiml.api-catalog-package": {
-      "version": "2.18.6",
+      "version": "2.18.7",
       "artifact": "api-catalog*.zip"
     },
     "org.zowe.apiml.discovery-package": {
-      "version": "2.18.6",
+      "version": "2.18.7",
       "artifact": "discovery*.zip"
     },
     "org.zowe.apiml.gateway-package": {
-      "version": "2.18.6",
+      "version": "2.18.7",
       "artifact": "gateway*.zip"
     },
     "org.zowe.apiml.caching-service-package": {
-      "version": "2.18.6",
+      "version": "2.18.7",
       "artifact": "caching-service*.zip"
     },
     "org.zowe.apiml.metrics-service-package": {
-      "version": "2.18.6",
+      "version": "2.18.7",
       "artifact": "metrics-service*.zip"
     },
     "org.zowe.apiml.apiml-common-lib-package": {
-      "version": "2.18.6",
+      "version": "2.18.7",
       "artifact": "apiml-common-lib-*.zip"
     },
     "org.zowe.apiml.sdk.common-java-lib-package": {
@@ -101,11 +101,11 @@
       "artifact": "common-java-lib-*.zip"
     },
     "org.zowe.apiml.sdk.apiml-sample-extension-package": {
-      "version": "2.18.6",
+      "version": "2.18.7",
       "artifact": "apiml-sample-extension-*.zip"
     },
     "org.zowe.apiml.cloud-gateway-package": {
-      "version": "2.18.6",
+      "version": "2.18.7",
       "artifact": "cloud-gateway-*.zip"
     },
     "org.zowe.configmgr-rexx": {
@@ -410,23 +410,23 @@
     "api-catalog": {
       "registry": "zowe-docker-release.jfrog.io",
       "name": "ompzowe/api-catalog-services",
-      "tag" : "2.18.6-ubuntu"
+      "tag" : "2.18.7-ubuntu"
     },
     "caching": {
       "registry": "zowe-docker-release.jfrog.io",
       "name": "ompzowe/caching-service",
-      "tag" : "2.18.6-ubuntu"
+      "tag" : "2.18.7-ubuntu"
     },
     "discovery": {
       "kind": "statefulset",
       "registry": "zowe-docker-release.jfrog.io",
       "name": "ompzowe/discovery-service",
-      "tag" : "2.18.6-ubuntu"
+      "tag" : "2.18.7-ubuntu"
     },
     "gateway": {
       "registry": "zowe-docker-release.jfrog.io",
       "name": "ompzowe/gateway-service",
-      "tag" : "2.18.6-ubuntu"
+      "tag" : "2.18.7-ubuntu"
     },
     "app-server": {
       "registry": "zowe-docker-release.jfrog.io",
@@ -460,12 +460,12 @@
     "files-api": {
       "registry": "zowe-docker-release.jfrog.io",
       "name": "ompzowe/files-api",
-      "tag" : "2.0.36-ubuntu"
+      "tag" : "2.0.37-ubuntu"
     },
     "jobs-api": {
       "registry": "zowe-docker-release.jfrog.io",
       "name": "ompzowe/jobs-api",
-      "tag" : "2.0.37-ubuntu"
+      "tag" : "2.0.38-ubuntu"
     },
     "base": {
       "registry": "zowe-docker-release.jfrog.io",


### PR DESCRIPTION
Update API ML dependencies to 2.18.7
Update jobs and files APIs to latest

Targetting Zowe 2.18.1-RC3