### PR TITLE
Update CLI component versions for 2.18.1

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -231,7 +231,7 @@
       "componentGroup": "IBM&reg Db2&reg Plug-in for Zowe CLI",
       "entries": [{
         "repository": "zowe-cli-db2-plugin",
-        "tag": "v5.0.11",
+        "tag": "v5.0.12",
         "destinations": ["Zowe CLI Package"]
       }]
     }, {


### PR DESCRIPTION
This PR updates the following package versions in manifest.json.template for `zowe-v2-lts`
| Updated Package | Old Version | New Version |
| --- | --- | --- |
| db2-for-zowe-cli | v5.0.11 | v5.0.12 |