### PR TITLE
Update common-java to 2.0.6 and API ML to 2.18.10

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -73,39 +73,39 @@
       "artifact": "explorer-ip*.pax"
     },
     "org.zowe.apiml.api-catalog-package": {
-      "version": "2.18.9",
+      "version": "2.18.10",
       "artifact": "api-catalog*.zip"
     },
     "org.zowe.apiml.discovery-package": {
-      "version": "2.18.9",
+      "version": "2.18.10",
       "artifact": "discovery*.zip"
     },
     "org.zowe.apiml.gateway-package": {
-      "version": "2.18.9",
+      "version": "2.18.10",
       "artifact": "gateway*.zip"
     },
     "org.zowe.apiml.caching-service-package": {
-      "version": "2.18.9",
+      "version": "2.18.10",
       "artifact": "caching-service*.zip"
     },
     "org.zowe.apiml.metrics-service-package": {
-      "version": "2.18.9",
+      "version": "2.18.10",
       "artifact": "metrics-service*.zip"
     },
     "org.zowe.apiml.apiml-common-lib-package": {
-      "version": "2.18.9",
+      "version": "2.18.10",
       "artifact": "apiml-common-lib-*.zip"
     },
     "org.zowe.apiml.sdk.common-java-lib-package": {
-      "version": "2.0.5",
+      "version": "2.0.6",
       "artifact": "common-java-lib-*.zip"
     },
     "org.zowe.apiml.sdk.apiml-sample-extension-package": {
-      "version": "2.18.9",
+      "version": "2.18.10",
       "artifact": "apiml-sample-extension-*.zip"
     },
     "org.zowe.apiml.cloud-gateway-package": {
-      "version": "2.18.9",
+      "version": "2.18.10",
       "artifact": "cloud-gateway-*.zip"
     },
     "org.zowe.configmgr-rexx": {
@@ -152,7 +152,7 @@
        "componentGroup": "Zowe common java libraries",
        "entries": [{
          "repository": "common-java",
-         "tag": "v2.0.5",
+         "tag": "v2.0.6",
          "destinations": ["Zowe PAX"]
        }]
      }, {
@@ -410,23 +410,23 @@
     "api-catalog": {
       "registry": "zowe-docker-release.jfrog.io",
       "name": "ompzowe/api-catalog-services",
-      "tag" : "2.18.9-ubuntu"
+      "tag" : "2.18.10-ubuntu"
     },
     "caching": {
       "registry": "zowe-docker-release.jfrog.io",
       "name": "ompzowe/caching-service",
-      "tag" : "2.18.9-ubuntu"
+      "tag" : "2.18.10-ubuntu"
     },
     "discovery": {
       "kind": "statefulset",
       "registry": "zowe-docker-release.jfrog.io",
       "name": "ompzowe/discovery-service",
-      "tag" : "2.18.9-ubuntu"
+      "tag" : "2.18.10-ubuntu"
     },
     "gateway": {
       "registry": "zowe-docker-release.jfrog.io",
       "name": "ompzowe/gateway-service",
-      "tag" : "2.18.9-ubuntu"
+      "tag" : "2.18.10-ubuntu"
     },
     "app-server": {
       "registry": "zowe-docker-release.jfrog.io",


### PR DESCRIPTION
Update API ML dependencies to 2.18.10
Update common-java to 2.0.6

Targetting Zowe 2.18.1-RC5
