### PR TITLE
Add variable for apiml registration for attls (v3)

### DIFF
--- a/files/defaults.yaml
+++ b/files/defaults.yaml
@@ -84,6 +84,9 @@ zowe:
       # Default to caching service entry as it predates this one
       name: "${{ ()=> { if (components['caching-service']?.storage?.vsam?.name) { return components['caching-service'].storage.vsam.name } else { return '' } }() }}"
 
+  network:
+    # This is a variable derived from gateway's ATTLS state to be used by servers proxied through it in eureka or static definitions.
+    proxyType: "${{ components.gateway?.zowe?.network?.server?.tls?.attls == true ? 'http' : zowe.network?.server?.tls?.attls == true ? 'http' : 'https' }}"
 
   configmgr:
     # STRICT=quit on any error, including missing schema

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -996,6 +996,10 @@
       "additionalProperties": false,
       "description": "Optional, advanced network configuration parameters",
       "properties": {
+        "proxyType": {
+          "type": "string",
+          "description": "This is a variable derived from gateway's ATTLS state to be used by servers proxied through it in eureka or static definitions"
+        },
         "server": {
           "type": "object",
           "description": "Optional, advanced network configuration parameters for Zowe servers",


### PR DESCRIPTION
This is the v3 PR that matches the v2 one already merged at https://github.com/zowe/zowe-install-packaging/pull/4215

This PR adds a zowe yaml variable zowe.network.proxyType
It defaults to 'https', unless either attls is on globally or just for gateway.
This variable is not intended to be edited.
It is intended to be determined by the state of attls, and used by anyone onboarding their servers to apiml, so that no decision making would need to be done by apiml extenders.