### PR TITLE
Zwe Doc Generation: remove `\n` from MD when used in parameters

### DIFF
--- a/.dependency/zwe_doc_generation/dot-file-structure.js
+++ b/.dependency/zwe_doc_generation/dot-file-structure.js
@@ -50,7 +50,8 @@ const parameterTable = {
         },
         {
             position: 8,
-            meaning: 'Help message'
+            meaning: 'Help message',
+            transform: (content) => content.replace(/\\n/g, ' ')
         }
     ]
 }

--- a/.dependency/zwe_doc_generation/md-content.js
+++ b/.dependency/zwe_doc_generation/md-content.js
@@ -159,8 +159,8 @@ function createMdTable(rawContent, docFileTableSyntax) {
 
     docContent += rawContent.split(DOT_FILE_TABLE_ROW_DELIMITER).map(line => line.trim().split(DOT_FILE_TABLE_ENTRY_DELIMITER) // transform table entries
         .map((segment, index) => {
-            if (docFileTableSyntax.orderedSegments[index] && docFileTableSyntax.orderedSegments[index].transform) {
-                return docFileTableSyntax.orderedSegments[index].transform(segment);
+            if (filteredSegments[index] && filteredSegments[index].transform) {
+                return filteredSegments[index].transform(segment);
             }
             return segment;
         })
@@ -169,6 +169,7 @@ function createMdTable(rawContent, docFileTableSyntax) {
 
     return docContent;
 }
+
 
 function getRelativeFilePathForChild(child, curCommandFileName) {
     if (curCommandFileName) {


### PR DESCRIPTION
There are few parameters defined with new line character, which is then displayed at [documentation](https://docs.zowe.org/v3.0.x/appendix/zwe_server_command_reference/zwe/zwe-install/#parameters): 
* For example: `Install Zowe to this dataset prefix.\nIf you specify this value, --config is not required.`

This PR:
* Adding simple `replace` to remove it.
* Fixing a bug, where the index of original table was unreachable as the filtered table should be used.
* No changelog as this is internal

**Note:** We can replace it with `<br/>` to keep it the same as in terminal. It is even expected [here](https://docs.zowe.org/v3.0.x/appendix/zwe_server_command_reference/zwe/sample/sub/zwe-sample-sub-deep/#inherited-from-parent-command-1).

## Small test 

Before the fix, MDs were generated to `generate_old`, with the fix to `generate_new`, then `diff -r ./generate_old ./generate_new`. Looks good, only the `\n` was removed from parameters.

```diff
diff -r ./generated_old/zwe/certificate/pkcs12/zwe-certificate-pkcs12-import.md ./generated_new/zwe/certificate/pkcs12/zwe-certificate-pkcs12-import.md
31c31
< --alias|-a|string|no|Alias in the destination PKCS12 keystore after imported.\nRequired if --source-alias is specified.
---
> --alias|-a|string|no|Alias in the destination PKCS12 keystore after imported. Required if --source-alias is specified.

diff -r ./generated_old/zwe/sample/sub/zwe-sample-sub-deep.md ./generated_new/zwe/sample/sub/zwe-sample-sub-deep.md
42c42
< --auto-encoding|-e|string|no|This parameter has default value.\nThis help message has multiple lines.\n  - another line
---
> --auto-encoding|-e|string|no|This parameter has default value. This help message has multiple lines.   - another line

diff -r ./generated_old/zwe/sample/sub/zwe-sample-sub-second.md ./generated_new/zwe/sample/sub/zwe-sample-sub-second.md
37c37
< --auto-encoding|-e|string|no|This parameter has default value.\nThis help message has multiple lines.\n  - another line
---
> --auto-encoding|-e|string|no|This parameter has default value. This help message has multiple lines.   - another line

diff -r ./generated_old/zwe/sample/sub/zwe-sample-sub.md ./generated_new/zwe/sample/sub/zwe-sample-sub.md
38c38
< --auto-encoding|-e|string|no|This parameter has default value.\nThis help message has multiple lines.\n  - another line
---
> --auto-encoding|-e|string|no|This parameter has default value. This help message has multiple lines.   - another line

diff -r ./generated_old/zwe/support/zwe-support-verify-fingerprints.md ./generated_new/zwe/support/zwe-support-verify-fingerprints.md
30c30
< --target-dir||string|no|Target directory where the support package will be created.\nIf it is not specified, system temporary directory will be used.
---
> --target-dir||string|no|Target directory where the support package will be created. If it is not specified, system temporary directory will be used.

diff -r ./generated_old/zwe/support/zwe-support.md ./generated_new/zwe/support/zwe-support.md
54c54
< --target-dir||string|no|Target directory where the support package will be created.\nIf it is not specified, system temporary directory will be used.
---
> --target-dir||string|no|Target directory where the support package will be created. If it is not specified, system temporary directory will be used.

diff -r ./generated_old/zwe/zwe-install.md ./generated_new/zwe/zwe-install.md
44c44
< --dataset-prefix,--ds-prefix||string|no|Install Zowe to this dataset prefix.\nIf you specify this value, --config is not required.
---
> --dataset-prefix,--ds-prefix||string|no|Install Zowe to this dataset prefix. If you specify this value, --config is not required.
```