### PR TITLE
Migrate to JCL: Small JCL update + typo

### DIFF
--- a/files/SZWESAMP/ZWEIACF
+++ b/files/SZWESAMP/ZWEIACF
@@ -31,7 +31,7 @@
 //* Note(s):
 //*
 //* 1. THE USER ID THAT RUNS THIS JOB MUST HAVE SUFFICIENT AUTHORITY
-//*    TO ALTER SECURITY DEFINITONS
+//*    TO ALTER SECURITY DEFINITIONS
 //*
 //* 2. The sample ACF2 commands create ROLEs that match the group
 //*    names. Due to permits assigned to the &STCGRP ROLE, it is

--- a/files/SZWESAMP/ZWEIACFZ
+++ b/files/SZWESAMP/ZWEIACFZ
@@ -26,19 +26,15 @@
 //* Note(s):
 //*
 //* 1. THE USER ID THAT RUNS THIS JOB MUST HAVE SUFFICIENT AUTHORITY
-//*    TO ALTER SECURITY DEFINITONS
+//*    TO ALTER SECURITY DEFINITIONS
 //*
 //*********************************************************************
-//         EXPORT SYMLIST=*
-//*
-//*
 //RUN      EXEC PGM=IKJEFT01,REGION=0M
 //SYSTSPRT DD SYSOUT=*
-//SYSTSIN  DD DDNAME=ACF2
-//ACF2     DD DATA,DLM=$$,SYMBOLS=JCLONLY
+//SYSTSIN  DD *,DLM=$$
 ACF
 *
-* DEFINE ZOWE RESOURCE PROTECTION .................................
+* DEFINE ZOWE RESOURCE PROTECTION ................................
 *
 * - Defines new resource class for Zowe that protects access to
 *   sensitive Zowe resources.

--- a/files/SZWESAMP/ZWEINSTL
+++ b/files/SZWESAMP/ZWEINSTL
@@ -11,6 +11,16 @@
 //*
 //*********************************************************************
 //*
+//* This job is used to create the MVS data sets under the
+//* zowe.setup.dataset.prefix definition:
+//*   - SZWEAUTH - Zowe load modules (++PROGRAM)
+//*   - SZWESAMP - sample configurations
+//*   - SZWEEXEC - utilities used by Zowe
+//*   - SZWELOAD - config manager for REXX
+//*
+//* The following step will copy required members.
+//*
+//*********************************************************************
 //MKPDSE EXEC PGM=IKJEFT01,DYNAMNBR=4
 //SYSTSPRT DD SYSOUT=A
 //SYSTSIN DD *

--- a/files/SZWESAMP/ZWEIRAC
+++ b/files/SZWESAMP/ZWEIRAC
@@ -31,7 +31,7 @@
 //* Note(s):
 //*
 //* 1. THE USER ID THAT RUNS THIS JOB MUST HAVE SUFFICIENT AUTHORITY
-//*    TO ALTER SECURITY DEFINITONS
+//*    TO ALTER SECURITY DEFINITIONS
 //*
 //* 2. The Zowe started task user ID 'zowe.setup.security.users.zowe'
 //*    Writes persistent data to 'zowe.workspaceDirectory'

--- a/files/SZWESAMP/ZWEIRACZ
+++ b/files/SZWESAMP/ZWEIRACZ
@@ -26,15 +26,12 @@
 //* Note(s):
 //*
 //* 1. THE USER ID THAT RUNS THIS JOB MUST HAVE SUFFICIENT AUTHORITY
-//*    TO ALTER SECURITY DEFINITONS
+//*    TO ALTER SECURITY DEFINITIONS
 //*
 //*********************************************************************
-//         EXPORT SYMLIST=*
-//*
 //RUN      EXEC PGM=IKJEFT01,REGION=0M
 //SYSTSPRT DD SYSOUT=*
-//SYSTSIN  DD DDNAME=RACF
-//RACF     DD DATA,DLM=$$,SYMBOLS=JCLONLY
+//SYSTSIN  DD *,DLM=$$
 
 /* DEFINE ZOWE RESOURCE PROTECTION ................................. */
 

--- a/files/SZWESAMP/ZWEITSS
+++ b/files/SZWESAMP/ZWEITSS
@@ -31,7 +31,7 @@
 //* Note(s):
 //*
 //* 1. THE USER ID THAT RUNS THIS JOB MUST HAVE SUFFICIENT AUTHORITY
-//*    TO ALTER SECURITY DEFINITONS
+//*    TO ALTER SECURITY DEFINITIONS
 //*
 //* 2. The Zowe started task user ID 'zowe.setup.security.users.zowe'
 //*    Writes persistent data to 'zowe.workspaceDirectory'

--- a/files/SZWESAMP/ZWEITSSZ
+++ b/files/SZWESAMP/ZWEITSSZ
@@ -26,15 +26,12 @@
 //* Note(s):
 //*
 //* 1. THE USER ID THAT RUNS THIS JOB MUST HAVE SUFFICIENT AUTHORITY
-//*    TO ALTER SECURITY DEFINITONS
+//*    TO ALTER SECURITY DEFINITIONS
 //*
 //*********************************************************************
-//         EXPORT SYMLIST=*
-//*
 //RUN      EXEC PGM=IKJEFT01,REGION=0M
 //SYSTSPRT DD SYSOUT=*
-//SYSTSIN  DD DDNAME=TSS
-//TSS      DD DATA,DLM=$$,SYMBOLS=JCLONLY
+//SYSTSIN  DD *,DLM=$$
 
 /* DEFINE ZOWE RESOURCE PROTECTION ................................. */
 

--- a/files/SZWESAMP/ZWENOSEC
+++ b/files/SZWESAMP/ZWENOSEC
@@ -28,7 +28,7 @@
 //* Note(s):
 //*
 //* 1. THE USER ID THAT RUNS THIS JOB MUST HAVE SUFFICIENT AUTHORITY
-//*    TO ALTER SECURITY DEFINITONS
+//*    TO ALTER SECURITY DEFINITIONS
 //*
 //* 2. Remove users from the Zowe administrator group before removing
 //*    the group itself.

--- a/workflows/templates/ZWESECUR.properties
+++ b/workflows/templates/ZWESECUR.properties
@@ -54,7 +54,7 @@
 # Note(s):
 #
 # 1. THE USER ID THAT RUNS THIS JOB MUST HAVE SUFFICIENT AUTHORITY
-#    TO ALTER SECURITY DEFINITONS
+#    TO ALTER SECURITY DEFINITIONS
 #
 # 2. The sample ACF2 commands create ROLEs that match the group
 #    names. Due to permits assigned to the &STCGRP ROLE, it is

--- a/workflows/templates/ZWESECUR.vtl
+++ b/workflows/templates/ZWESECUR.vtl
@@ -80,7 +80,7 @@
 //* Note(s):
 //*
 //* 1. THE USER ID THAT RUNS THIS JOB MUST HAVE SUFFICIENT AUTHORITY
-//*    TO ALTER SECURITY DEFINITONS
+//*    TO ALTER SECURITY DEFINITIONS
 //*
 //* 2. The sample ACF2 commands create ROLEs that match the group
 //*    names. Due to permits assigned to the &STCGRP ROLE, it is

--- a/workflows/templates/ZWESECUR.xml
+++ b/workflows/templates/ZWESECUR.xml
@@ -259,7 +259,7 @@
 		<instructions substitution="false">Run this step to initialize variable values.&lt;br/&gt;
     Note(s):&lt;br/&gt;
        1. THE USER ID THAT RUNS THIS JOB MUST HAVE SUFFICIENT AUTHORITY &lt;br/&gt;
-       TO ALTER SECURITY DEFINITONS &lt;br/&gt;
+       TO ALTER SECURITY DEFINITIONS &lt;br/&gt;
        2. The sample ACF2 commands create ROLEs that match the group &lt;br/&gt;
        names. Due to permits assigned to the &amp;STCGRP ROLE, it is &lt;br/&gt;
        advised to ensure this ROLE has a unique identifier. &lt;br/&gt;


### PR DESCRIPTION
Changes:
* Couple JCLs
  * Typo in `DEFINITONS`
* `ZWEIACFZ`, `ZWEITSSZ`, `ZWEIRACZ`
  * removing unused `EXPORT SYMLIST=*`
  * removing extra DD
* `ZWEINSTL`
  * Description on comment