### PR TITLE
disable flaky vt terminal test

### DIFF
--- a/tests/sanity/test/e2e/test-06-vt.js
+++ b/tests/sanity/test/e2e/test-06-vt.js
@@ -8,7 +8,7 @@
  * Copyright IBM Corporation 2018, 2019
  */
 
-
+/*
 const path = require('path');
 const expect = require('chai').expect;
 const debug = require('debug')('zowe-sanity-test:e2e:vt');
@@ -105,3 +105,4 @@ describe(`test ${APP_TO_TEST}`, function() {
   });
 });
 
+*/


### PR DESCRIPTION
VT Terminal test is causing errors randomly across all 3 systems somewhere between 30-50% of runs. Disable the test until we can investigate it.