### PR TITLE
add java 21 tests

### DIFF
--- a/.github/scripts/cicd_test/make_matrix.sh
+++ b/.github/scripts/cicd_test/make_matrix.sh
@@ -32,6 +32,14 @@ case $install_test_choice in
   test_file="$KEYRING_TESTFILE"
   ;;
 
+"Java 21")
+  test_file="$JAVA_V21_TESTFILE"
+  ;;
+
+"Java 21 Keyring")
+  test_file="$JAVA_V21_KEYRING_TESTFILE"
+  ;;
+
 "z/OS node v20")
   test_file="$ZOS_NODE_V20_TESTFILE"
   ;;

--- a/.github/workflows/cicd-test.yml
+++ b/.github/workflows/cicd-test.yml
@@ -31,6 +31,8 @@ on:
           - SMPE PTF
           - Extensions
           - Keyring
+          - Java 21
+          - Java 21 Keyring
           - z/OS node v20
           - z/OS node v22
           - Non-strict Verify External Certificate
@@ -81,6 +83,8 @@ env:
   SMPE_PTF_TESTFILE: basic/install-ptf.ts
   EXTENSIONS_TESTFILE: basic/install-ext.ts
   KEYRING_TESTFILE: extended/keyring.ts
+  JAVA_V21_TESTFILE: extended/java-versions/java-21.ts
+  JAVA_V21_KEYRING_TESTFILE: extended/java-versions/java-21-keyring.ts
   ZOS_NODE_V20_TESTFILE: extended/node-versions/node-v20.ts
   ZOS_NODE_V22_TESTFILE: extended/node-versions/node-v22.ts
   NON_STRICT_VERIFY_EXTERNAL_CERTIFICATE_TESTFILE: extended/certificates/nonstrict-verify-external-certificate.ts
@@ -90,7 +94,7 @@ env:
   CONFIG_MANAGER_TESTFILE: extended/config-manager/enable-config-manager.ts
   GENERAL_API_DOCUMENTATION_TESTFILE: basic/install-api-gen.ts
   ZOWE_NIGHTLY_TESTS_FULL: basic/install.ts(all);basic/install-ptf.ts(all)
-  ZOWE_RELEASE_TESTS_FULL: basic/install.ts(all);basic/install-ptf.ts(all);basic/install-ext.ts(any);extended/keyring.ts(all);extended/node-versions/node-v20.ts(any);extended/node-versions/node-v22.ts(any);extended/certificates/nonstrict-verify-external-certificate.ts(any);extended/caching-storages/infinispan-storage.ts(any);extended/config-manager/enable-config-manager.ts(any)
+  ZOWE_RELEASE_TESTS_FULL: basic/install.ts(all);basic/install-ptf.ts(all);basic/install-ext.ts(any);extended/keyring.ts(all);extended/java-versions/java-21.ts(any);extended/java-versions/java-21-keyring.ts(any);extended/node-versions/node-v20.ts(any);extended/node-versions/node-v22.ts(any);extended/certificates/nonstrict-verify-external-certificate.ts(any);extended/caching-storages/infinispan-storage.ts(any);extended/config-manager/enable-config-manager.ts(any)
 
 jobs:
   display-dispatch-event-id:

--- a/bin/libs/certificate.sh
+++ b/bin/libs/certificate.sh
@@ -625,6 +625,11 @@ pkcs12_export_pem() {
       if [ $? -ne 0 ]; then
         return 1
       fi
+      if [ `uname` = "OS/390" ]; then
+        iconv -f ISO8859-1 -t IBM-1047 "${keystore_dir}/${alias_lc}.cer" > "${keystore_dir}/${alias_lc}.cer-ebcdic"
+        mv "${keystore_dir}/${alias_lc}.cer-ebcdic" "${keystore_dir}/${alias_lc}.cer"
+        ensure_file_encoding "${keystore_dir}/${alias_lc}.cer" "CERTIFICATE"
+      fi
     fi
   done <<EOF
 $(echo "${aliases}")

--- a/bin/libs/certificate.sh
+++ b/bin/libs/certificate.sh
@@ -29,6 +29,8 @@ ZWE_PRIVATE_DEFAULT_CERTIFICATE_KEY_USAGE="keyEncipherment,digitalSignature,nonR
 ZWE_PRIVATE_DEFAULT_CERTIFICATE_EXTENDED_KEY_USAGE="clientAuth,serverAuth"
 
 JAVA_KEYTOOL_FLAG=" -J-Dkeystore.pkcs12.legacy "
+# COMPAT uses native.encoding, required for Java 21 which defaults to utf-8 instead of ebcdic
+JAVA_KEYTOOL_ENCODING=" -J-Dfile.encoding=COMPAT " 
 
 #######################################################################
 # Notes: some keyring related functions, like ncert, are using R_datalib behind the scene. It requires proper
@@ -615,7 +617,7 @@ pkcs12_export_pem() {
     if [ -n "${alias}" ]; then
       alias_lc=$(echo "${alias}" | lower_case)
       print_message ">>>> Export certificate \"${alias}\" to PEM format"
-      result=$(pkeytool -exportcert -v \
+      result=$(pkeytool ${JAVA_KEYTOOL_ENCODING} -exportcert -v \
                 -alias "${alias}" \
                 -keystore "${keystore_file}" \
                 -storepass "${password}" \
@@ -624,11 +626,6 @@ pkcs12_export_pem() {
                 -file "${keystore_dir}/${alias_lc}.cer")
       if [ $? -ne 0 ]; then
         return 1
-      fi
-      if [ `uname` = "OS/390" ]; then
-        iconv -f ISO8859-1 -t IBM-1047 "${keystore_dir}/${alias_lc}.cer" > "${keystore_dir}/${alias_lc}.cer-ebcdic"
-        mv "${keystore_dir}/${alias_lc}.cer-ebcdic" "${keystore_dir}/${alias_lc}.cer"
-        ensure_file_encoding "${keystore_dir}/${alias_lc}.cer" "CERTIFICATE"
       fi
     fi
   done <<EOF

--- a/playbooks/roles/common/tasks/upload_essentials.yml
+++ b/playbooks/roles/common/tasks/upload_essentials.yml
@@ -35,4 +35,4 @@
     . {{ zos_uss_user_profile }} \
     {{ zowe_environment_variable_overrides | default('') }} && \
     cd "{{ work_dir_remote }}" && \
-    javac MD5Checksum.java
+    javac -encoding IBM-1047 MD5Checksum.java

--- a/tests/installation/src/__tests__/extended/java-versions/java-21-keyring.ts
+++ b/tests/installation/src/__tests__/extended/java-versions/java-21-keyring.ts
@@ -1,0 +1,46 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright IBM Corporation 2020
+ */
+
+import {
+  checkMandatoryEnvironmentVariables,
+  installAndVerifyConvenienceBuild,
+  showZoweRuntimeLogs,
+} from '../../../utils';
+import {TEST_TIMEOUT_CONVENIENCE_BUILD, KEYSTORE_MODE_KEYRING} from '../../../constants';
+
+const testSuiteName = 'Test convenience build installation with java 21';
+describe(testSuiteName, () => {
+  beforeAll(() => {
+    // validate variables
+    checkMandatoryEnvironmentVariables([
+      'TEST_SERVER',
+      'ZOWE_BUILD_LOCAL',
+    ]);
+  });
+
+  test('install and verify', async () => {
+    await installAndVerifyConvenienceBuild(
+      testSuiteName,
+      process.env.TEST_SERVER,
+      {
+        'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
+        'zowe_custom_for_test': 'true',
+        'zos_keystore_mode': KEYSTORE_MODE_KEYRING,
+        'zos_java_home': '/ZOWE/node/J21.0_64',
+        'zowe_lock_keystore': 'false',
+      }
+    );
+  }, TEST_TIMEOUT_CONVENIENCE_BUILD);
+
+  afterAll(async () => {
+    await showZoweRuntimeLogs(process.env.TEST_SERVER);
+  })
+});
+  

--- a/tests/installation/src/__tests__/extended/java-versions/java-21.ts
+++ b/tests/installation/src/__tests__/extended/java-versions/java-21.ts
@@ -1,0 +1,45 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright IBM Corporation 2020
+ */
+
+import {
+  checkMandatoryEnvironmentVariables,
+  installAndVerifyConvenienceBuild,
+  showZoweRuntimeLogs,
+} from '../../../utils';
+import {TEST_TIMEOUT_CONVENIENCE_BUILD} from '../../../constants';
+
+const testSuiteName = 'Test convenience build installation with java 21';
+describe(testSuiteName, () => {
+  beforeAll(() => {
+    // validate variables
+    checkMandatoryEnvironmentVariables([
+      'TEST_SERVER',
+      'ZOWE_BUILD_LOCAL',
+    ]);
+  });
+
+  test('install and verify', async () => {
+    await installAndVerifyConvenienceBuild(
+      testSuiteName,
+      process.env.TEST_SERVER,
+      {
+        'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
+        'zowe_custom_for_test': 'true',
+        'zos_java_home': '/ZOWE/node/J21.0_64',
+        'zowe_lock_keystore': 'false',
+      }
+    );
+  }, TEST_TIMEOUT_CONVENIENCE_BUILD);
+
+  afterAll(async () => {
+    await showZoweRuntimeLogs(process.env.TEST_SERVER);
+  })
+});
+  


### PR DESCRIPTION
Adds Java 21 extended tests to Zowe v3. Fixes #4188 . Tests will be run on-demand and as part of the extended test suite run twice weekly and on release.