### PR TITLE
Print versions and ESM for better diagnosis

### DIFF
--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -27,6 +27,7 @@ import * as java from '../../../../libs/java';
 import * as javaCI from '../../../../libs/java_ci';
 import * as node from '../../../../libs/node';
 import * as zosmf from '../../../../libs/zosmf';
+import * as zoslib from '../../../../libs/zos';
 
 //# This command prepares everything needed to start Zowe.
 const cliParameterConfig = std.getenv('ZWE_CLI_PARAMETER_CONFIG');
@@ -440,6 +441,7 @@ if (zoweVersion) {
 export function execute() {
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `Zowe version: v${zoweVersion}`);
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `build and hash: ${runtimeManifest.build.branch}#${runtimeManifest.build.number} (${runtimeManifest.build.commitHash})`);
+  common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `z/OS Version: ${zoslib.formatZosVersion('{major}.{minor}')}`);
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `ESM: ${zos.getEsm()}`);
 
   // validation

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -440,7 +440,6 @@ if (zoweVersion) {
 export function execute() {
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `Zowe version: v${zoweVersion}`);
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `build and hash: ${runtimeManifest.build.branch}#${runtimeManifest.build.number} (${runtimeManifest.build.commitHash})`);
-  common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `z/OS Version: ${zos.getZosVersion()}`);
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `ESM: ${zos.getEsm()}`);
 
   // validation

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -440,6 +440,8 @@ if (zoweVersion) {
 export function execute() {
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `Zowe version: v${zoweVersion}`);
   common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `build and hash: ${runtimeManifest.build.branch}#${runtimeManifest.build.number} (${runtimeManifest.build.commitHash})`);
+  common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `z/OS Version: ${zos.getZosVersion()}`);
+  common.printFormattedInfo("ZWELS", "zwe-internal-start-prepare", `ESM: ${zos.getEsm()}`);
 
   // validation
   if (stringlib.itemInList(std.getenv('ZWE_PRIVATE_CORE_COMPONENTS_REQUIRE_JAVA'), std.getenv('ZWE_CLI_PARAMETER_COMPONENT'))) {

--- a/bin/libs/java_ci.ts
+++ b/bin/libs/java_ci.ts
@@ -52,6 +52,7 @@ export function validateJavaHome(javaHome:string|undefined=std.getenv("JAVA_HOME
       common.printError("could not find java version");
       return false;
     }
+    common.printFormattedInfo('ZWELS', 'validateJavaHome', 'Java version: '+javaVersionShort);
     let versionParts = javaVersionShort.split('.');
     const javaMajorVersion=Number(versionParts[0]);
     const javaMinorVersion=Number(versionParts[1]);

--- a/bin/libs/node.ts
+++ b/bin/libs/node.ts
@@ -108,7 +108,7 @@ export function validateNodeHome(nodeHome:string|undefined=std.getenv("NODE_HOME
       const nodeMajorVersion = Number(parts[0].substring(1));
       //const nodeMinorVersion = Number(parts[1]);
       //const nodePatchVersion = Number(parts[2]);
-
+      common.printFormattedInfo('ZWELS', 'validateNodeHome', 'NodeJS version: '+version);
       if (version == 'v18.12.1') {
         common.printError(`Node ${version} specifically is not compatible with Zowe. Please use a different version. See https://github.com/ibmruntimes/node-zos/issues/21 for more details.`);
         return false;

--- a/bin/libs/node.ts
+++ b/bin/libs/node.ts
@@ -108,7 +108,7 @@ export function validateNodeHome(nodeHome:string|undefined=std.getenv("NODE_HOME
       const nodeMajorVersion = Number(parts[0].substring(1));
       //const nodeMinorVersion = Number(parts[1]);
       //const nodePatchVersion = Number(parts[2]);
-      common.printFormattedInfo('ZWELS', 'validateNodeHome', 'NodeJS version: '+version);
+      common.printFormattedInfo('ZWELS', 'validateNodeHome', 'NodeJS version: '+ version);
       if (version == 'v18.12.1') {
         common.printError(`Node ${version} specifically is not compatible with Zowe. Please use a different version. See https://github.com/ibmruntimes/node-zos/issues/21 for more details.`);
         return false;


### PR DESCRIPTION
This PR prints out already gathered node and java versions whenever validateNodeHome() or validateJavaHome() are called.
Additionally, at startup (through zwe internal start prepare), ~zOS version~ and ESM type are printed.
This allows the reader of a normal log to have information they would normally have to turn on tracing, run zwe support, or look up elsewhere to find.

I was going to add zOS version print out, but the value printed did not look human readable, so postponing that.