### PR TITLE
Allow different member names for PARMLIB entries of config

### DIFF
--- a/bin/libs/common.ts
+++ b/bin/libs/common.ts
@@ -373,8 +373,8 @@ export function isValidZoweYamlParmlib(parmlib: string): {ok: boolean; error: { 
       return {ok: false, error: errorContent}
     }
     const member = finalParmlib.substring(finalParmlib.indexOf('(')+1, finalParmlib.indexOf(')'));
-    // TODO: better member validation? Do we need to here or does schema cover this? (This was previously checking hard-coded ZWEYAML)
-    if (member.length > 8) {
+    // This regex ported from server-common.json#zoweDatasetMember
+    if (/^([A-Z$#@])([A-Z0-9$#@]){0,7}$/gi.test(member) === false) {
       return { ok: false, error: errorContent};
     }
     return {ok: true, error: {message: '', code: 0}};

--- a/bin/libs/common.ts
+++ b/bin/libs/common.ts
@@ -349,6 +349,39 @@ export function getZoweVersion(): string|undefined {
   return std.getenv('ZWE_VERSION');
 }
 
+/**
+ * Checks if the zowe.yaml provided via "PARMLIB" syntax will be accepted by configmgr.
+ * 
+ * Accepts both PARMLIB(MY.PARM(MEMBER)) and MY.PARM(MEMBER)
+ * 
+ * @param parmlib 
+ * 
+ */
+export function isValidZoweYamlParmlib(parmlib: string): {ok: boolean; error: { message: string; code: number }} {
+  let finalParmlib = parmlib.trim();
+  const errorContent = {message: `ZWEL0316E Invalid PARMLIB format ${parmlib}.`, code: 316}
+  if (finalParmlib.startsWith('PARMLIB(')) {
+    // unbalanced paren, PARMLIB(A.B.C
+    if (finalParmlib.slice(-1) != ')') {
+      return {ok: false, error: errorContent}
+    }
+    finalParmlib = parmlib.substring(8, parmlib.lastIndexOf(')')); // cover cases where a trailing colon may be present
+  }
+  if (finalParmlib.indexOf('(') != -1) {
+    // Case where PARMLIB is A.B.C(D, which covers unbalanced paren e.g. PARMLIB(A.B.C(D) 
+    if (finalParmlib.slice(-1) != ')') {
+      return {ok: false, error: errorContent}
+    }
+    const member = finalParmlib.substring(finalParmlib.indexOf('(')+1, finalParmlib.indexOf(')'));
+    // TODO: better member validation? Do we need to here or does schema cover this? (This was previously checking hard-coded ZWEYAML)
+    if (member.length > 8) {
+      return { ok: false, error: errorContent};
+    }
+    return {ok: true, error: {message: '', code: 0}};
+  }
+
+  return {ok: false, error: errorContent};
+}
 
 //From 'index.sh'
 std.setenv('ZWE_PRIVATE_DS_SZWESAMP', 'SZWESAMP');

--- a/bin/libs/configmgr.ts
+++ b/bin/libs/configmgr.ts
@@ -386,43 +386,6 @@ export function updateZoweConfig(updateObj: any, writeUpdate: boolean, arrayMerg
   return [ rc, ZOWE_CONFIG ];
 }
 
-function getMemberNameFromConfigPath(configPath: string): string|undefined {
-  let indexParm = 0;
-  let member = undefined;
-  while (indexParm != -1) {
-    indexParm = configPath.indexOf('PARMLIB(', indexParm);
-    if (indexParm != -1) {
-      const memberStart = configPath.indexOf('(', indexParm+8);
-      if (memberStart == -1) {
-        console.log(`Error: malformed PARMLIB syntax for ${configPath}. Must use syntax PARMLIB(dataset.name(member))`);
-        return undefined;
-      }
-      const memberEnd = configPath.indexOf('))', memberStart+1);
-      if (memberEnd == -1) {
-        console.log(`Error: malformed PARMLIB syntax for ${configPath}. Must use syntax PARMLIB(dataset.name(member))`);
-        return undefined;
-      }
-      const thisMember = configPath.substring(memberStart+1, memberEnd);
-      if (!member) {
-        member = thisMember;
-      } else if (thisMember != member) {
-        console.log(`Error: configmgr does not yet support different member names for PARMLIB. You must use the same member names for all datasets mentioned`);
-        return undefined;
-      }
-      //skip over )):
-      indexParm = memberEnd+3; 
-    }
-  }
-  return member;
-}
-
-function stripMemberName(configPath: string, memberName: string): string {
-  //Turn PARMLIB(my.zowe(yaml)):PARMLIB(my.other.zowe(yaml))
-  //Into PARMLIB(my.zowe):FILE(/some/path.yaml):PARMLIB(my.other.zowe)
-  const replacer = new RegExp('\\('+stringlib.escapeDollar(memberName)+'\\)\\)', 'gi');
-  return configPath.replace(replacer, ")");
-}
-  
 function getConfig(configName: string, configPath: string, schemas: string): any {
   let configRevisionName = getConfigRevisionName(configName);
   if (Number.isInteger(CONFIG_REVISIONS[configName])) {
@@ -430,17 +393,16 @@ function getConfig(configName: string, configPath: string, schemas: string): any
     return CONFIG_MGR.getConfigData(configRevisionName);
   }
 
-  let memberName;
   if (configPath) {
-    //In the form of PARMLIB(my.zowe(yaml)):PARMLIB(my.other.zowe(yaml))
-    //Member names must be same for all PARMLIB mentioned.
-    if (configPath.indexOf('PARMLIB(') != -1) {
-      memberName = getMemberNameFromConfigPath(configPath);
-      if (!memberName) {
-        console.log(`Error: Cannot continue due to missing or mixed member names for PARMLIB entries in ${configPath}`);
+    let index = configPath.indexOf('PARMLIB(');
+    while(index != -1) {
+      //In the form of PARMLIB(my.zowe(yaml)):PARMLIB(my.other.zowe(yaml))
+      let rParenIndex = configPath.indexOf('))', index);
+      if (rParenIndex == -1) {
+        console.log(`Error: Cannot continue due to missing member name for PARMLIB entry in ${configPath}`);
         std.exit(1);
       }
-      configPath = stripMemberName(configPath, memberName);
+      index = configPath.indexOf('PARMLIB(', rParenIndex);
     }
     
     let status;
@@ -458,13 +420,6 @@ function getConfig(configName: string, configPath: string, schemas: string): any
     if ((status = CONFIG_MGR.setConfigPath(configRevisionName, configPath))) {
       console.log(`Error: Could not set config path for ${configPath}, status=${status}`);
       std.exit(1);
-    }
-
-    if (memberName) {
-      if ((status = CONFIG_MGR.setParmlibMemberName(configRevisionName, memberName))) {
-        console.log(`Error: Could not set parmlib member name for ${memberName}, status=${status}`);
-        std.exit(1);
-      }
     }
 
     if ((status = CONFIG_MGR.loadConfiguration(configRevisionName))) {

--- a/bin/libs/configmgr.ts
+++ b/bin/libs/configmgr.ts
@@ -15,6 +15,7 @@ import * as xplatform from 'xplatform';
 import { ConfigManager } from 'Configuration';
 import * as fs from './fs';
 import * as stringlib from './string';
+import * as common from './common';
 
 import * as objUtils from '../utils/ObjUtils';
 
@@ -394,15 +395,15 @@ function getConfig(configName: string, configPath: string, schemas: string): any
   }
 
   if (configPath) {
-    let index = configPath.indexOf('PARMLIB(');
-    while(index != -1) {
-      //In the form of PARMLIB(my.zowe(yaml)):PARMLIB(my.other.zowe(yaml))
-      let rParenIndex = configPath.indexOf('))', index);
-      if (rParenIndex == -1) {
-        console.log(`Error: Cannot continue due to missing member name for PARMLIB entry in ${configPath}`);
-        std.exit(1);
+    let parts = configPath.split(':').filter((part) => part.trim().length > 0);
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i].trim();
+      if (part.startsWith('PARMLIB(')) {
+        const isValidParmlib = common.isValidZoweYamlParmlib(part);
+        if (!isValidParmlib.ok) {
+          common.printErrorAndExit(isValidParmlib.error.message, undefined, isValidParmlib.error.code);
+        }
       }
-      index = configPath.indexOf('PARMLIB(', rParenIndex);
     }
     
     let status;

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -101,7 +101,7 @@
       "artifact": "*.pax"
     },
     "org.zowe.configmgr": {
-      "version": "^3.0.0-V3.X-STAGING",
+      "version": "^3.2.0-FEATURE-V3-CONFIGMGR-MULTI-MEMBER-PARMLIBS",
       "artifact": "*.pax"
     },
     "org.zowe.configmgr-rexx": {
@@ -109,7 +109,7 @@
       "artifact": "*.pax"
     },
     "org.zowe.launcher": {
-      "version": "^3.0.0-STAGING"
+      "version": "^3.3.0-PR-146"
     },
     "org.zowe.keyring-utilities": {
       "version": "1.0.4",

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -101,7 +101,7 @@
       "artifact": "*.pax"
     },
     "org.zowe.configmgr": {
-      "version": "^3.2.0-FEATURE-V3-CONFIGMGR-MULTI-MEMBER-PARMLIBS",
+      "version": "^3.0.0-V3.X-STAGING",
       "artifact": "*.pax"
     },
     "org.zowe.configmgr-rexx": {
@@ -109,7 +109,7 @@
       "artifact": "*.pax"
     },
     "org.zowe.launcher": {
-      "version": "^3.3.0-PR-146"
+      "version": "^3.0.0-STAGING"
     },
     "org.zowe.keyring-utilities": {
       "version": "1.0.4",


### PR DESCRIPTION
Depends upon https://github.com/zowe/zowe-common-c/pull/522
Depends upon https://github.com/zowe/launcher/pull/146

This PR lifts the restriction that PARMLIB entries of the zwe config argument would need to all have the same member name. Now, they can have whatever valid & existing PDS member name is desired.