### PR TITLE
Update md-content.js

### DIFF
--- a/.dependency/zwe_doc_generation/md-content.js
+++ b/.dependency/zwe_doc_generation/md-content.js
@@ -71,7 +71,7 @@ function generateDocumentationForNode(curNode, assembledParentNode) {
 function assembleDocumentationElementsForNode(curNode, assembledParentNode) {
     const fileName = assembledParentNode.fileName ? `${assembledParentNode.fileName}-${curNode.command}` : curNode.command;
     const command = assembledParentNode.command ? assembledParentNode.command + ' ' + curNode.command : curNode.command;
-    const link = `[${curNode.command}](./${fileName})`;
+    const link = `[${curNode.command}](./${fileName}.md)`;
     const linkCommandElements = assembledParentNode.linkCommandElements ? [...assembledParentNode.linkCommandElements, link] : [link];
 
     let relPathToParentLinks = './';


### PR DESCRIPTION
There is an issue with how browsers/docusaurus/markdown all interact which can break browsers ability to redirect to non-404 pages that is prevented by ensuring markdown links in the documentation explicitly say ".md".

The zwe command reference is one such places that lacks this, and it appears to be coming from the automatically generated content here.

I need help reviewing this - I am not sure how to test that this works, but it looks like the right edit to make.
