### PR TITLE
Remove defaulted parameter of zss from example

### DIFF
--- a/example-zowe.yaml
+++ b/example-zowe.yaml
@@ -540,8 +540,6 @@ components:
     port: 7557
     crossMemoryServerName: ZWESIS_STD
     agent:
-      jwt:
-        fallback: true
       64bit: true
 
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>


### PR DESCRIPTION
I have never seen anyone want to change "components.zss.agent.jwt.fallback" to "false" from "true", and it already is set to "true" by default within zss' own YAML file here https://github.com/zowe/zss/blob/fcf5b83dfe080feeca3871ad2b0a573188d3ed13/defaults.yaml#L14

So, it just looks like extra content to distract people, not the sort of thing that should be in example-zowe.yaml