### PR TITLE
remove jwt fallback to match example-zowe.yaml

### DIFF
--- a/workflows/files/ZWECONF.xml
+++ b/workflows/files/ZWECONF.xml
@@ -2063,8 +2063,10 @@ echo '    enabled: ${instance-components_zss_enabled}' >> "${instance-zowe_runti
 echo '    port: ${instance-components_zss_port}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '    crossMemoryServerName: $!{instance-components_zss_crossMemoryServerName}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '    agent:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+#if (${instance-components_zss_agent_jwt_fallback} == "false")
 echo '      jwt:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '        fallback: ${instance-components_zss_agent_jwt_fallback}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+#end
 echo '      64bit: ${instance-components_zss_agent_64bit}' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 #end
 #if (${instance-components_zss_enabled} == "false" )
@@ -2072,8 +2074,6 @@ echo '    enabled: ${instance-components_zss_enabled}' >> "${instance-zowe_runti
 echo '    port: 7557' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '    crossMemoryServerName: ZWESIS_STD' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '    agent:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
-echo '      jwt:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
-echo '        fallback: true' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '      64bit: true' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 #end
 echo '' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"


### PR DESCRIPTION
The PSWI zowe.yaml validation is failing after the merge of #4296, and this PR fixes it.

I will make the PSWI yaml validation a **required** check going forward, as it's been stable and correctly identifies problems that should be addressed.