### PR TITLE
`configmgr.ts`: update comment

### DIFF
--- a/bin/libs/configmgr.ts
+++ b/bin/libs/configmgr.ts
@@ -38,8 +38,8 @@ std.setenv('ZWE_PRIVATE_CONFIG_ORIG', parameterConfig);
   the config property of Zowe can take a few shapes:
   1. a single path, ex /my/zowe.yaml
   2. one or more file paths with FILE() syntax, ex FILE(/my/1.yaml):FILE(/my2.yaml)
-  3. one or more parmlib paths with PARMLIB() syntax, ex PARMLIB(my.zowe(yaml)):PARMLIB(my.other.zowe(yaml)) ... note the member names must be the same for every PARMLIB mentioned!
-  4. one or more of FILE and PARMLIB syntax combined, ex FILE(/my/1.yaml):FILE(/my2.yaml):PARMLIB(my.zowe(yaml)):PARMLIB(my.other.zowe(yaml))
+  3. one or more parmlib paths with PARMLIB() syntax, ex PARMLIB(my.zowe(yaml1)):PARMLIB(my.other.zowe(yaml2))
+  4. one or more of FILE and PARMLIB syntax combined, ex FILE(/my/1.yaml):FILE(/my2.yaml):PARMLIB(my.zowe(yaml1)):PARMLIB(my.other.zowe(yaml2))
  */
 const ZOWE_CONFIG_PATH = (parameterConfig && !parameterConfig.startsWith('FILE(') && !parameterConfig.startsWith('PARMLIB('))
                           ? `FILE(${parameterConfig}):FILE(${std.getenv('ZWE_zowe_runtimeDirectory')}/files/defaults.yaml)`


### PR DESCRIPTION
With #4285 we can use different parmlib members. Just updating the comment for others.