### PR TITLE
Update ZWEGENER to support different members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to the Zowe Installer will be documented in this file.
 
 ## `3.3.0`
-- Enhancment: Updated the `zowe-yaml-schema.json` and `defaults.yaml` to support new configuration parameter `zowe.sysMessageTrim` and set default value. This parameter will be used to trim syslog messages and print only from the sys-message-id. (#4294)
+- Enhancement: Support different parmlib members when using JCL `ZWEGENER` [#4332](https://github.com/zowe/zowe-install-packaging/pull/4332)
+- Enhancement: Updated the `zowe-yaml-schema.json` and `defaults.yaml` to support new configuration parameter `zowe.sysMessageTrim` and set default value. This parameter will be used to trim syslog messages and print only from the sys-message-id. [#4294](https://github.com/zowe/zowe-install-packaging/pull/4294)
 
 ## `3.2.0`
 - Enhancement: `zwe support` command collecting more environment details [#4147](https://github.com/zowe/zowe-install-packaging/pull/4147)
@@ -15,7 +16,7 @@ All notable changes to the Zowe Installer will be documented in this file.
 - Bugfix: When `--log-dir` parameter for `zwe` command is a file, there might be an error "InternalError: stack overflow". [#4064](https://github.com/zowe/zowe-install-packaging/pull/4064)
 - Enhancement: command `zwe init` does not require NodeJS [#4088](https://github.com/zowe/zowe-install-packaging/pull/4088)
 - Enhancement: command `zwe install` does not require NodeJS [#4069](https://github.com/zowe/zowe-install-packaging/pull/4069)
-- Enhancement: new javascript funtion `getStatvfs()` to obtain information about the file sysytem [#3994](https://github.com/zowe/zowe-install-packaging/pull/3994)
+- Enhancement: new javascript function `getStatvfs()` to obtain information about the file system [#3994](https://github.com/zowe/zowe-install-packaging/pull/3994)
 - Enhancement: command `zwe diagnose` in javascript only [#4061](https://github.com/zowe/zowe-install-packaging/pull/4061)
 - Enhancement: schema validation update for `zowe.job.name` and `zowe.job.prefix` [#4060](https://github.com/zowe/zowe-install-packaging/pull/4060)
 

--- a/files/SZWEEXEC/ZWEGEN00
+++ b/files/SZWEEXEC/ZWEGEN00
@@ -101,6 +101,9 @@ CFG.zwe.header.time = TIME()
 ================================================================================
     Create a data set with attributes like the original jcl library and copy
     all the members of esm jcl.
+    FIXME:
+      1) check if zowe.setup.dataset.prefix is defined
+      2) check if jcllib != prefix.SZWESAMP
 ================================================================================
 */
 

--- a/files/SZWEEXEC/ZWEGEN00
+++ b/files/SZWEEXEC/ZWEGEN00
@@ -103,7 +103,7 @@ CFG.zwe.header.time = TIME()
     all the members of esm jcl.
     FIXME:
       1) check if zowe.setup.dataset.prefix is defined
-      2) check if jcllib != prefix.SZWESAMP
+      2) check that jcllib != prefix.SZWESAMP
 ================================================================================
 */
 

--- a/files/SZWEEXEC/ZWEGEN00
+++ b/files/SZWEEXEC/ZWEGEN00
@@ -449,9 +449,6 @@ do j = 1 to !contentToRead.0
         type = WORD(!contentToRead.j, 1)
         location = WORD(!contentToRead.j, 2)
         element = type'('location')'
-        if COMPARE(type, 'PARMLIB') = 0 then do
-          element = 'PARMLIB('location'(ZWEYAML))'
-        end
         if j = 1 then do
           cmd = 'LINE 'currentline' = "CONFIG='element
           if !contentToRead.0 > 1 then do
@@ -534,15 +531,6 @@ Validate:
     return 1
   end
   say 'ConfigMgr loaded your schemas.'
-
-  say 'ConfigMgr is about to set the member name for parameter library.'
-  status = ZWECFG31('setParmlibMemberName', 'MYCFG', 'ZWEYAML')
-  if status > 0 then do
-    say 'ConfigMgr could not set member name for parameter library.'
-    say 'status = 'status
-    return 1
-  end
-  say 'ConfigMgr set the parameter library member name.'
 
   say 'ConfigMgr is about to process your configuration.'
   status = ZWECFG31('setConfigPath', 'MYCFG', ARG(2))

--- a/files/SZWESAMP/ZWEGENER
+++ b/files/SZWESAMP/ZWEGENER
@@ -65,11 +65,10 @@ FILE {zowe.runtimeDirectory}/schemas/server-common.json
 $$
 //*
 //* The DD below must include one or more FILE or PARMLIB
-//* Entries. The lower entries have their values
-//* Overridden by the higher entries.
-//* PARMLIB member must be named "ZWEYAML"
+//* entries. The lower entries have their values
+//* overridden by the higher entries.
 //*
-//* Ex. PARMLIB MY.ZOWE.CUSTOM.PARMLIB
+//* Ex. PARMLIB MY.ZOWE.CUSTOM.PARMLIB(YAML)
 //*     FILE /some/other/zowe.yaml
 //MYCONFIG DD   *,DLM=$$
 FILE <full path to zowe.yaml file>


### PR DESCRIPTION
Missing in #4285:

* `ZWEGEN00`
  * Do not add `ZWEYAML` when creating `CONFIG` for `ZWESLSTC`
  * No need to set `ZWEYAML` as a member name
* `ZWEGENER`
  * Small comment update

`ZWEGEN00` is then set with the names as needed, for example:
```jcl
//MYCONFIG DD   *,DLM=$$                  
PARMLIB ZOWE.PR#4107.TMP(DEFAULT) 
PARMLIB ZOWE.PR#4107.TMP(NODE)    
$$                                        
```

Started task `ZWESLSTC` with generated `CONFIG` then:
```jcl
//STDENV   DD  *                                    
_CEE_ENVFILE_CONTINUATION=\                         
_CEE_RUNOPTS=HEAPPOOLS(OFF),HEAPPOOLS64(OFF)        
_EDC_UMASK_DFLT=0002                                
CONFIG=PARMLIB(ZOWE.PR#4107.TMP(DEFAULT)):\ 
PARMLIB(ZOWE.PR#4107.TMP(NODE))             
/*
```