### PR TITLE
Add CHANGELOG workflow automation

### DIFF
--- a/.github/workflows/changelog-updates.yml
+++ b/.github/workflows/changelog-updates.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
     branches: 
       - 'v*.x/staging'
-    types: [opened, synchronize, labeled]
+    types: [opened, synchronize, labeled, unlabeled]
 
 jobs:
   check-changelog:

--- a/.github/workflows/changelog-updates.yml
+++ b/.github/workflows/changelog-updates.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           git diff --exit-code "origin/${{ github.event.pull_request.base.ref }}" -- "CHANGELOG.md"
           if [[ "$?" -eq 0 ]]; then
-            echo "Please review the CHANGELOG and add an entry for this pull request."
+            echo "Please review the CHANGELOG and add an entry for this pull request if it contains changes users should be informed of."
             echo "If there are no changes, add the 'skip-changelog' label to this pull request."
             exit 1
           fi

--- a/.github/workflows/changelog-updates.yml
+++ b/.github/workflows/changelog-updates.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: 'Check CHANGELOG'
         run: |

--- a/.github/workflows/changelog-updates.yml
+++ b/.github/workflows/changelog-updates.yml
@@ -1,0 +1,32 @@
+# Triggers when comments are made on issues/PRs, runs when '/ci' is added to a pull request.
+name: Zowe Changelog Check
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: write
+
+on:
+  pull_request:
+    branches: 
+      - 'v*.x/staging'
+    types: [opened, synchronize]
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+
+      - name: 'Check CHANGELOG'
+        run: |
+          git diff --exit-code "origin/${{ github.event.pull_request.base.ref }}" -- "CHANGELOG.md"
+          if [[ "$?" -eq 0 ]]; then
+            echo "Please review the CHANGELOG and add an entry for this pull request."
+            echo "If there are no changes, add the 'skip-changelog' label to this pull request."
+            exit 1
+          fi
+
+

--- a/.github/workflows/changelog-updates.yml
+++ b/.github/workflows/changelog-updates.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
     branches: 
       - 'v*.x/staging'
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled]
 
 jobs:
   check-changelog:


### PR DESCRIPTION
In light of PRs like #4332, we should have an automated check which points our attention to the CHANGELOG for all pull requests against staging branches. This automated check will be mandatory moving forward, and it can be bypassed by adding a `skip-changelog` label to the pull request.