### PR TITLE
ZWEGEN00: check `zowe.setup.dataset.prefix` and `zowe.setup.dataset.jcllib`

### DIFF
--- a/.github/workflows/changelog-updates.yml
+++ b/.github/workflows/changelog-updates.yml
@@ -30,4 +30,5 @@ jobs:
             echo "If there are no changes, add the 'skip-changelog' label to this pull request."
             exit 1
           fi
-          exit 0
+
+

--- a/.github/workflows/changelog-updates.yml
+++ b/.github/workflows/changelog-updates.yml
@@ -30,5 +30,4 @@ jobs:
             echo "If there are no changes, add the 'skip-changelog' label to this pull request."
             exit 1
           fi
-
-
+          exit 0

--- a/.github/workflows/changelog-updates.yml
+++ b/.github/workflows/changelog-updates.yml
@@ -25,7 +25,9 @@ jobs:
       - name: 'Check CHANGELOG'
         run: |
           git diff --exit-code "origin/${{ github.event.pull_request.base.ref }}" -- "CHANGELOG.md"
-          if [[ "$?" -eq 0 ]]; then
+          saveRC="$?"
+          echo "Last rc=${saveRC}"
+          if [[ "${saveRC}" -eq 0 ]]; then
             echo "Please review the CHANGELOG and add an entry for this pull request if it contains changes users should be informed of."
             echo "If there are no changes, add the 'skip-changelog' label to this pull request."
             exit 1

--- a/.github/workflows/changelog-updates.yml
+++ b/.github/workflows/changelog-updates.yml
@@ -25,9 +25,7 @@ jobs:
       - name: 'Check CHANGELOG'
         run: |
           git diff --exit-code "origin/${{ github.event.pull_request.base.ref }}" -- "CHANGELOG.md"
-          saveRC="$?"
-          echo "Last rc=${saveRC}"
-          if [[ "${saveRC}" -eq 0 ]]; then
+          if [[ "$?" -eq 0 ]]; then
             echo "Please review the CHANGELOG and add an entry for this pull request if it contains changes users should be informed of."
             echo "If there are no changes, add the 'skip-changelog' label to this pull request."
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Zowe Installer will be documented in this file.
 
 ## `3.3.0`
+- Bugfix: stop processing `ZWEGENER` if `zowe.setup.dataset.prefix` or `zowe.setup.dataset.jcllib` is undefined or identical [#4337](https://github.com/zowe/zowe-install-packaging/pull/#4337)
 - Enhancement: Support different parmlib members when using JCL `ZWEGENER` [#4332](https://github.com/zowe/zowe-install-packaging/pull/4332)
 - Enhancement: Updated the `zowe-yaml-schema.json` and `defaults.yaml` to support new configuration parameter `zowe.sysMessageTrim` and set default value. This parameter will be used to trim syslog messages and print only from the sys-message-id. [#4294](https://github.com/zowe/zowe-install-packaging/pull/4294)
 

--- a/files/SZWEEXEC/ZWEGEN00
+++ b/files/SZWEEXEC/ZWEGEN00
@@ -406,7 +406,9 @@ say 'The edit macro was invoked on each member.'
 ================================================================================
     Add the job card to each member if filled out.
 ================================================================================
-*/
+FIXME:
+  1. Card is added to each member (STCs included)
+  2. It overwrites the first line
 
 card.0 = 0
 
@@ -450,7 +452,7 @@ if card.0 > 0 then do
   say 'The job card was added to each member.'
 end
 
-
+*/
 
 say 'Checking the ZWESLSTC CONFIG entry'
 

--- a/files/SZWEEXEC/ZWEGEN00
+++ b/files/SZWEEXEC/ZWEGEN00
@@ -27,10 +27,11 @@ parse arg operation verbosity
 operation = strip(operation)
 verbosity = strip(verbosity)
 
-VALID_OPERATIONS = '"generate" | "nogenerate"'
-VALID_VERBOSITY = '"verbose" | "noverbose"'
+VALID_OPERATIONS = 'generate nogenerate'
+VALID_VERBOSITY = 'verbose noverbose'
 
-if POS(verbosity, VALID_VERBOSITY) = 0 then do
+checkVerbosity = CheckInput(verbosity, VALID_VERBOSITY)
+if length(checkVerbosity) = 0 then do
   queue '"'verbosity'" is not a valid verbosity.'
   queue 'Valid verbosity levels are: '||VALID_VERBOSITY
   FormatError(8)
@@ -73,7 +74,8 @@ end
 ================================================================================
 */
 
-if POS(operation, VALID_OPERATIONS) = 0 then do
+checkOperatation = CheckInput(operation, VALID_OPERATIONS)
+if length(checkOperatation) = 0 then do
   queue '"'operation'" is not a valid operation.'
   queue 'Valid operations are: '||VALID_OPERATIONS
   FormatError(8)
@@ -977,13 +979,31 @@ AddToChain:
 
 /*
 ================================================================================
+  CheckInput('parmIn', 'list_of_valid_options')
+================================================================================
+*/
+CheckInput: procedure
+
+  parmIn = strip(ARG(1))
+  validOptions = ARG(2)
+  parmReturn = ''
+
+  do i = 1 to words(validOptions)
+    if word(validOptions, i) = parmIn then
+      parmReturn = parmIn
+  end
+
+  return parmReturn
+
+/*
+================================================================================
   Print('msg')
 ================================================================================
 */
 Print:
   procedure expose !verbose
 
-  if !verbose = 1 then do
+  if !verbose > 0 then do
     say ARG(1)
   end
 

--- a/files/SZWEEXEC/ZWEGEN00
+++ b/files/SZWEEXEC/ZWEGEN00
@@ -29,9 +29,9 @@ VALID_OPERATIONS = '"generate" | "nogenerate"'
 VALID_VERBOSITY = '"verbose" | "noverbose"'
 
 if POS(verbosity, VALID_VERBOSITY) = 0 then do
-  say 'Error: "'verbosity'" is not a valid verbosity.'
-  say '       Valid verbosity levels are: '||VALID_VERBOSITY
-  ExitWithRC(8)
+  queue '"'verbosity'" is not a valid verbosity.'
+  queue 'Valid verbosity levels are: '||VALID_VERBOSITY
+  FormatError(8)
 end
 !verbose = COMPARE(verbosity, 'noverbose')
 
@@ -72,9 +72,9 @@ end
 */
 
 if POS(operation, VALID_OPERATIONS) = 0 then do
-  say 'Error: "'operation'" is not a valid operation.'
-  say '       Valid operations are: '||VALID_OPERATIONS
-  ExitWithRC(8)
+  queue '"'operation'" is not a valid operation.'
+  queue 'Valid operations are: '||VALID_OPERATIONS
+  FormatError(8)
 end
 
 if COMPARE(operation, 'nogenerate') = 0 then do
@@ -101,14 +101,32 @@ CFG.zwe.header.time = TIME()
 ================================================================================
     Create a data set with attributes like the original jcl library and copy
     all the members of esm jcl.
-    FIXME:
-      1) check if zowe.setup.dataset.prefix is defined
-      2) check that jcllib != prefix.SZWESAMP
+    Note: CFG.ZOWE.SETUP.DATASET.PREFIX/JCLLIB is a valid dataset name,
+      we have to check if variable is initialized (via SYMBOL)
 ================================================================================
 */
 
+cfg_mandatory = 'zowe.setup.dataset.prefix zowe.setup.dataset.jcllib'
+UPDATE_CONFIG = 'Update the configuration and submit the JCL again.'
+
+say 'Checking required configuration keys'
+do i = 1 to words(cfg_mandatory)
+  if symbol('CFG.'||word(cfg_mandatory, i)) = 'LIT' then do
+    queue '"'word(cfg_mandatory, i)'" is not defined in configuration.'
+    queue UPDATE_CONFIG
+    FormatError(8)
+  end
+end
+
 jcl = CFG.zowe.setup.dataset.prefix'.SZWESAMP'
 jclCopy = CFG.zowe.setup.dataset.jcllib
+
+if jcl = jclCopy then do
+  queue '"zowe.setup.dataset.prefix" and "zowe.setup.dataset.jcllib"',
+      'are identical, which is not allowed.'
+  queue UPDATE_CONFIG
+  FormatError(8)
+end
 
 say 'Creating a fresh copy of 'jcl' named 'jclCopy'.'
 
@@ -736,7 +754,7 @@ CreatePartitionedDataSet:
   cmd = 'alloc'
   cmd = cmd 'da('"'"ARG(1)"'"')'
   cmd = cmd 'dsorg(po)'
-  cmd = cmd 'space(50,5)'
+  cmd = cmd 'space(60,5)'
   cmd = cmd 'tracks'
   cmd = cmd 'lrecl('ARG(2)')'
   cmd = cmd 'recfm('ARG(3)')'
@@ -968,6 +986,24 @@ Print:
   end
 
   return 0
+
+/*
+================================================================================
+  FormatError(exitCode)
+================================================================================
+*/
+FormatError:
+  exitCode = ARG(1)
+
+  do line = 1 to queued()
+    parse pull errorMessage
+    if line = 1 then
+      say 'Error: '||errorMessage
+    else
+      say '       '||errorMessage
+  end
+
+  ExitWithRC(exitCode)
 
 /*
 ================================================================================

--- a/files/SZWEEXEC/ZWEGEN00
+++ b/files/SZWEEXEC/ZWEGEN00
@@ -24,6 +24,8 @@
 */
 
 parse arg operation verbosity
+operation = strip(operation)
+verbosity = strip(verbosity)
 
 VALID_OPERATIONS = '"generate" | "nogenerate"'
 VALID_VERBOSITY = '"verbose" | "noverbose"'


### PR DESCRIPTION
Changes:
* Checks `zowe.setup.dataset.prefix` and `zowe.setup.dataset.jcllib`
* When `ZWEGENER` submitted manually, missing `zowe.setup.dataset.prefix` could cause some problems:
    * Attempt to create `CFG.ZOWE.SETUP.DATASET.PREFIX.JCLLIB` dataset, because by default a REXX variable is initialized with own name, which is unfortunately a valid dataset name
    * If user is not authorized to use HLQ `CFG`, there is just another error
    * The `jcllib` must not be set to `zowe.setup.dataset.prefix` + `.SZWESAMP`
* New function `FormatError` and `CheckInput`
* Space increased from 50 to 60

# Tests
## Input parameters

* Leading and trailing spaces removed
* Case sensitive
* No abbreviation
* Check via `CheckInput`, which could be modified to support abbreviation or case sensitivity

### Incorrect `generate` option
```jcl
//SYSTSIN  DD   *
ISPSTART CMD(%ZWEGEN00    Generate   noverbose )
```

```
Error: "Generate" is not a valid operation.
       Valid operations are: generate nogenerate
```

### Incorrect `verbose` option
```jcl
//SYSTSIN  DD   *
ISPSTART CMD(%ZWEGEN00 -
  generate   -
  verb  -
)
```
```
Error: "verb" is not a valid verbosity.
       Valid verbosity levels are: verbose noverbose
```
## Datasets
### Missing `zowe.setup.dataset.prefix`
```
Error: "zowe.setup.dataset.prefix" is not defined in configuration.  
       Update the configuration and submit the JCL again.            
```

### Missing `zowe.setup.dataset.jcllib`
```
Error: "zowe.setup.dataset.jcllib" is not defined in configuration.
       Update the configuration and submit the JCL again.          
```

### `jcllib` same as `prefix` + `.SZWESAMP`
```
Error: "zowe.setup.dataset.prefix" and "zowe.setup.dataset.jcllib" are identical, which is not allowed.
       Update the configuration and submit the JCL again.                                              
```

Otherwise, without fix:
```
Creating a fresh copy of ZOWE.PR4337.SZWESAMP named ZOWE.PR4337.SZWESAMP.         
  ISRLS358Invalid data sets       -/-Same data sets not allowed when processing 'LMCOPY' service. 
```