### PR TITLE
Add default sysmessages

### DIFF
--- a/example-zowe.yaml
+++ b/example-zowe.yaml
@@ -351,6 +351,11 @@ zowe:
     - "ZWED0031I"
   #   # ZSS ready
     - "ZWES1013I"
+  #   # Launcher status messages, such as shutdown received and requests for status
+    - "ZWEL0010I"
+    - "ZWEL0011I"
+    - "ZWEL0013I"
+    - "ZWEL0014I"
 
   #   # Not limited to Zowe message IDs, you can specify your own string for example:
   #   - "ERROR"

--- a/files/defaults.yaml
+++ b/files/defaults.yaml
@@ -142,6 +142,33 @@ zowe:
   # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   # To determine whether to trim ths syslog message inorder to print from message-id, disabled by default
   sysMessageTrim: false
+  sysMessages:
+  #   # Zowe starting
+    - "ZWEL0021I"
+  #   # Zowe started
+    - "ZWEL0018I"
+    - "ZWEL0006I"
+  #   # Zowe ready to use
+    - "ZWES1601I"
+  #   # Zowe stopping
+    - "ZWEL0008I"
+  #   # Zowe stopped
+    - "ZWEL0022I"
+  #   # Zowe components starting
+    - "ZWEL0001I"
+  #   # Zowe components stopped
+    - "ZWEL0002I"
+  #   # API ML components ready
+    - "ZWEAM000I"
+  #   # App server ready
+    - "ZWED0031I"
+  #   # ZSS ready
+    - "ZWES1013I"
+  #   # Launcher status messages, such as shutdown received and requests for status
+    - "ZWEL0010I"
+    - "ZWEL0011I"
+    - "ZWEL0013I"
+    - "ZWEL0014I"
 
 #-------------------------------------------------------------------------------
 # Zowe components default configurations


### PR DESCRIPTION
Prior, sysmessages we recommend were only in example-zowe.yaml
This adds them to defaults.yaml so that users of old versions of zowe will benefit from this new default behavior.

Also, this PR adds additional sysmessages that seem useful to see in the syslog, about launcher queries.