### PR TITLE
Changelog Workflow update

### DIFF
--- a/.github/workflows/changelog-updates.yml
+++ b/.github/workflows/changelog-updates.yml
@@ -24,8 +24,9 @@ jobs:
 
       - name: 'Check CHANGELOG'
         run: |
-          git diff --exit-code "origin/${{ github.event.pull_request.base.ref }}" -- "CHANGELOG.md"
-          if [[ "$?" -eq 0 ]]; then
+          result=$(git diff "origin/v3.x/staging" -- "CHANGELOG.md")
+          echo "${result}"
+          if [ -z "${result}" ]; then
             echo "Please review the CHANGELOG and add an entry for this pull request if it contains changes users should be informed of."
             echo "If there are no changes, add the 'skip-changelog' label to this pull request."
             exit 1

--- a/.github/workflows/changelog-updates.yml
+++ b/.github/workflows/changelog-updates.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: 'Check CHANGELOG'
         run: |
-          result=$(git diff "origin/v3.x/staging" -- "CHANGELOG.md")
+          result=$(git diff "origin/${{ github.event.pull_request.base.ref }}" -- "CHANGELOG.md")
           echo "${result}"
           if [ -z "${result}" ]; then
             echo "Please review the CHANGELOG and add an entry for this pull request if it contains changes users should be informed of."

--- a/.github/workflows/changelog-updates.yml
+++ b/.github/workflows/changelog-updates.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: 'Check CHANGELOG'
         run: |
-          git diff --exit-code --quiet "origin/${{ github.event.pull_request.base.ref }}" -- "CHANGELOG.md"
-          if [[ "$?" -eq 0 ]]; then
+          result=$(git diff "origin/${{ github.event.pull_request.base.ref }}" -- "CHANGELOG.md")
+          if [ -z "${result}" ]; then
             echo "Please review the CHANGELOG and add an entry for this pull request if it contains changes users should be informed of."
             echo "If there are no changes, add the 'skip-changelog' label to this pull request."
             exit 1

--- a/.github/workflows/changelog-updates.yml
+++ b/.github/workflows/changelog-updates.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: 'Check CHANGELOG'
         run: |
-          result=$(git diff "origin/${{ github.event.pull_request.base.ref }}" -- "CHANGELOG.md")
-          if [ -z "${result}" ]; then
+          git diff --exit-code --quiet "origin/${{ github.event.pull_request.base.ref }}" -- "CHANGELOG.md"
+          if [[ "$?" -eq 0 ]]; then
             echo "Please review the CHANGELOG and add an entry for this pull request if it contains changes users should be informed of."
             echo "If there are no changes, add the 'skip-changelog' label to this pull request."
             exit 1

--- a/.github/workflows/changelog-updates.yml
+++ b/.github/workflows/changelog-updates.yml
@@ -25,7 +25,6 @@ jobs:
       - name: 'Check CHANGELOG'
         run: |
           result=$(git diff "origin/${{ github.event.pull_request.base.ref }}" -- "CHANGELOG.md")
-          echo "${result}"
           if [ -z "${result}" ]; then
             echo "Please review the CHANGELOG and add an entry for this pull request if it contains changes users should be informed of."
             echo "If there are no changes, add the 'skip-changelog' label to this pull request."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Zowe Installer will be documented in this file.
 
 ## `3.3.0`
+- ?
 - Enhancement: Support different parmlib members when using JCL `ZWEGENER` [#4332](https://github.com/zowe/zowe-install-packaging/pull/4332)
 - Enhancement: Updated the `zowe-yaml-schema.json` and `defaults.yaml` to support new configuration parameter `zowe.sysMessageTrim` and set default value. This parameter will be used to trim syslog messages and print only from the sys-message-id. [#4294](https://github.com/zowe/zowe-install-packaging/pull/4294)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 All notable changes to the Zowe Installer will be documented in this file.
 
 ## `3.3.0`
-- ?
 - Enhancement: Support different parmlib members when using JCL `ZWEGENER` [#4332](https://github.com/zowe/zowe-install-packaging/pull/4332)
 - Enhancement: Updated the `zowe-yaml-schema.json` and `defaults.yaml` to support new configuration parameter `zowe.sysMessageTrim` and set default value. This parameter will be used to trim syslog messages and print only from the sys-message-id. [#4294](https://github.com/zowe/zowe-install-packaging/pull/4294)
 


### PR DESCRIPTION
This [PR](https://github.com/zowe/zowe-install-packaging/pull/4337) was created with Changelog updated. But the workflows is failing:
```
Run git diff --exit-code "origin/v3.x/staging" -- "CHANGELOG.md"
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 18f8231ff..b67c2877[9](https://github.com/zowe/zowe-install-packaging/actions/runs/15254613628/job/42899141065?pr=4337#step:3:10) 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Zowe Installer will be documented in this file.
 
 ## `3.3.0`
+- Bugfix: stop processing `ZWEGENER` if `zowe.setup.dataset.prefix` or `zowe.setup.dataset.jcllib` is undefined or identical [#4337](https://github.com/zowe/zowe-install-packaging/pull/#4337)
 - Enhancement: Support different parmlib members when using JCL `ZWEGENER` [#4332](https://github.com/zowe/zowe-install-packaging/pull/4332)
 - Enhancement: Updated the `zowe-yaml-schema.json` and `defaults.yaml` to support new configuration parameter `zowe.sysMessageTrim` and set default value. This parameter will be used to trim syslog messages and print only from the sys-message-id. [#4294](https://github.com/zowe/zowe-install-packaging/pull/4294)
```

The change is detected correctly, but workflows ends with `Error: Process completed with exit code 1.`

I have no idea, if the `--exit-code` is not supported or what is going on, but it seems this PR solves it.