### PR TITLE
Add certificate analyser to the build

### DIFF
--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -274,7 +274,7 @@ jobs:
         with:
           manifest-file-path: ${{ github.workspace }}/manifest.json
           default-target-path: .pax/binaryDependencies/
-          expected-count: 27
+          expected-count: 28
       
       # this step is not doing a publish, we are just utilizing this actions to get the PUBLISH_TARGET_PATH, 
       # and it will be used in the next step: [Download 3] Download SMPE build log

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -272,6 +272,12 @@ pax -ppx -rf "${configmgr_rexx}"
 rm "${configmgr_rexx}"
 cd "${BASE_DIR}"
 
+certificate_analyser=$(find "${ZOWE_ROOT_DIR}/files" -type f \( -name "certificate-analyser*.jar" \) | head -n 1)
+echo "[$SCRIPT_NAME] move certificate_analyser $certificate_analyser"
+mkdir -p "${ZOWE_ROOT_DIR}/bin/utils"
+mv "${certificate_analyser}" "${ZOWE_ROOT_DIR}/bin/utils/certificate-analyser.jar"
+
+
 echo "[$SCRIPT_NAME] create dummy zowe.yaml for install"
 cat <<EOT >>"${BASE_DIR}/zowe.yaml"
 zowe:

--- a/.pax/prepare-workspace.sh
+++ b/.pax/prepare-workspace.sh
@@ -193,6 +193,7 @@ for zlux_dep in zlux-editor tn3270-ng2 vt-ng2 sample-react-app sample-iframe-app
 done
 mv *.pax "${CONTENT_DIR}/files/"
 mv *.zip "${CONTENT_DIR}/files/"
+mv certificate-analyser-* "${CONTENT_DIR}/files/"
 # PAX_BINARY_DEPENDENCIES should be empty now
 if [ -n "$(ls -1)" ]; then
   echo "[$SCRIPT_NAME] Error: binaryDependencies directory is not clean"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Zowe Installer will be documented in this file.
 
 ## `3.3.0`
+- Enhancement: Add a utility "certificate-analyser.jar" to the folder zowe/bin/utils. This tool can be used to verify correct certificates for use by zowe, as well as correct connectivity to servers Zowe communicates with such as z/OSMF. It will be used by Zowe under specific circumstances to verify that network setup is correct. [#???](https://github.com/zowe/zowe-install-packaging/pull/???)
 - Enhancement: Support different parmlib members when using JCL `ZWEGENER` [#4332](https://github.com/zowe/zowe-install-packaging/pull/4332)
 - Enhancement: Updated the `zowe-yaml-schema.json` and `defaults.yaml` to support new configuration parameter `zowe.sysMessageTrim` and set default value. This parameter will be used to trim syslog messages and print only from the sys-message-id. [#4294](https://github.com/zowe/zowe-install-packaging/pull/4294)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zowe Installer will be documented in this file.
 
 ## `3.3.0`
-- Enhancement: Add a utility "certificate-analyser.jar" to the folder zowe/bin/utils. This tool can be used to verify correct certificates for use by zowe, as well as correct connectivity to servers Zowe communicates with such as z/OSMF. It will be used by Zowe under specific circumstances to verify that network setup is correct. [#???](https://github.com/zowe/zowe-install-packaging/pull/???)
+- Enhancement: Add a utility "certificate-analyser.jar" to the folder zowe/bin/utils. This tool can be used to verify correct certificates for use by zowe, as well as correct connectivity to servers Zowe communicates with such as z/OSMF. It will be used by Zowe under specific circumstances to verify that network setup is correct. [#4354](https://github.com/zowe/zowe-install-packaging/pull/4354)
 - Enhancement: Support different parmlib members when using JCL `ZWEGENER` [#4332](https://github.com/zowe/zowe-install-packaging/pull/4332)
 - Enhancement: Updated the `zowe-yaml-schema.json` and `defaults.yaml` to support new configuration parameter `zowe.sysMessageTrim` and set default value. This parameter will be used to trim syslog messages and print only from the sys-message-id. [#4294](https://github.com/zowe/zowe-install-packaging/pull/4294)
 

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -96,9 +96,9 @@
       "artifact": "zaas-package-*.zip",
       "exclusions": ["*PR*.zip"]
     },
-    "org.zowe.apiml.sdk.certificate-analyzer": {
+    "org.zowe.apiml.sdk.certificate-analyser": {
       "version": "^3.0.3-SNAPSHOT",
-      "artifact": "certificate-analyzer-*.jar",
+      "artifact": "certificate-analyser-*.jar",
       "exclusions": ["*PR*.jar"]
     },
     "org.zowe.getesm": {

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -96,6 +96,11 @@
       "artifact": "zaas-package-*.zip",
       "exclusions": ["*PR*.zip"]
     },
+    "org.zowe.apiml.sdk.certificate-analyzer": {
+      "version": "^3.0.3-SNAPSHOT",
+      "artifact": "certificate-analyzer-*.jar",
+      "exclusions": ["*PR*.jar]
+    },
     "org.zowe.getesm": {
       "version": "^3.0.0-V3.X-STAGING",
       "artifact": "*.pax"

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -99,7 +99,7 @@
     "org.zowe.apiml.sdk.certificate-analyzer": {
       "version": "^3.0.3-SNAPSHOT",
       "artifact": "certificate-analyzer-*.jar",
-      "exclusions": ["*PR*.jar]
+      "exclusions": ["*PR*.jar"]
     },
     "org.zowe.getesm": {
       "version": "^3.0.0-V3.X-STAGING",


### PR DESCRIPTION
This PR just adds the certificate-analyser jar ( https://zowe.jfrog.io/artifactory/libs-snapshot-local/org/zowe/apiml/sdk/certificate-analyser/ )
It's not yet used, but in future PRs we can start to leverage it.