### PR TITLE
`zowe.sysMessages` - min length and no null

### DIFF
--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -583,6 +583,10 @@
           "uniqueItems": true,
           "items": {
             "type": "string"
+            "minLength": 1,
+            "not": {
+              "type": "null"
+            }
           }
         },
         "sysMessageTrim": {

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -582,7 +582,7 @@
           "description": "List of Zowe message portions when matched will be additionally logged into the system's log (such as syslog on z/OS). Note: Some messages extremely early in the Zowe lifecycle may not be added to the system's log",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "type": "string",
             "minLength": 1,
             "not": {
               "type": "null"


### PR DESCRIPTION
By default it is possible to define `null` item in `zowe.sysMessages`.
This does not make sense and empty string `""` too.

This will be rejected by schema validation:

```yaml
zowe:
  sysMessages:
    -
    - ~
    - ""
    - null
```