### PR TITLE
scorecard workflow for pinned dependencies, workflow tokens

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -6,6 +6,7 @@ on:
       - 'v*.x/rc'
       - 'v*.x/master'
     types: [opened, synchronize, labeled, unlabeled]
+  workflow_dispatch:
   schedule:
     # Weekly on Saturdays.
     - cron:  '30 1 * * 6'

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,67 @@
+name: OSSF Scorecard
+on:
+  pull_request:
+    branches: 
+      - 'v*.x/staging'
+      - 'v*.x/rc'
+      - 'v*.x/master'
+    types: [opened, synchronize, labeled, unlabeled]
+  schedule:
+    # Weekly on Saturdays.
+    - cron:  '30 1 * * 6'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for Code scanning upload
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Scorecard team runs a weekly scan of public GitHub repos,
+          # see https://github.com/ossf/scorecard#public-data.
+          # Setting `publish_results: true` helps us scale by leveraging your workflow to
+          # extract the results instead of relying on our own infrastructure to run scans.
+          # And it's free for you!
+          publish_results: false
+
+      - name: "Filter analysis results to enabled checks"
+        env:
+          SCORECARD_ENABLED_CHECKS: Pinned-Dependencies
+        run: | 
+          ENABLED_CHECKS_IN_JSON=$(echo $SCORECARD_ENABLED_CHECKS | jq -cR 'split(",")')
+          
+          # Filter SARIF File and only keep enabled checks
+          cat results.sarif | jq '.runs[].results |= map(select(.ruleId as $id | '$ENABLED_CHECKS_IN_JSON' | all($id == .)))' > filteredResults.sarif
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: filteredResults.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: "Filter analysis results to enabled checks"
         env:
-          SCORECARD_ENABLED_CHECKS: Pinned-Dependencies
+          SCORECARD_ENABLED_CHECKS: TokenPermissionsID,PinnedDependenciesID
         run: | 
           ENABLED_CHECKS_IN_JSON=$(echo $SCORECARD_ENABLED_CHECKS | jq -cR 'split(",")')
           

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -56,7 +56,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
-          path: filteredResults.sarif
+          path: |
+            results.sarif
+            filteredResults.sarif
           retention-days: 5
 
       # Upload the results to GitHub's code scanning dashboard (optional).
@@ -64,4 +66,4 @@ jobs:
       - name: "Upload to code-scanning"
         uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
         with:
-          sarif_file: results.sarif
+          sarif_file: filteredResults.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -47,7 +47,7 @@ jobs:
           ENABLED_CHECKS_IN_JSON=$(echo $SCORECARD_ENABLED_CHECKS | jq -cR 'split(",")')
           
           # Filter SARIF File and only keep enabled checks
-          cat results.sarif | jq '.runs[].results |= map(select(.ruleId as $id | '$ENABLED_CHECKS_IN_JSON' | all($id == .)))' > filteredResults.sarif
+          cat results.sarif | jq '.runs[].results |= map(select(.ruleId as $id | '$ENABLED_CHECKS_IN_JSON' | index($id)))' > filteredResults.sarif
 
       # Upload the results as artifacts (optional). Commenting out will disable
       # uploads of run results in SARIF format to the repository Actions tab.


### PR DESCRIPTION
Creates a new workflow which is a modified version of OSSF's default scorecard actions. Scorecard actions by default cannot limit their analysis to a subset of all available tools, so the workaround here is to cull unwanted results out of the resulting `sarif` file before it's uploaded to Github. **Inspired by**: issue 1098 in OSSF Scorecards. The limited analysis is driven by a desire to focus on particular classes of problems without overwhelming our ability to review security reports. On a related note, I've opted to disable result uploads to the OSSF database, since we aren't addressing all points of analysis yet.
