### PR TITLE
debug nightly build

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -58,32 +58,32 @@
     },
     "org.zowe.apiml.api-catalog-package": {
       "version": "^3.0.3-SNAPSHOT",
-      "artifact": "api-catalog-*.zip",
+      "artifact": "api-catalog-3.2.15-20250616.142200*.zip",
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.discovery-package": {
       "version": "^3.0.3-SNAPSHOT",
-      "artifact": "discovery-*.zip",
+      "artifact": "discovery-3.2.15-20250616.142200*.zip",
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.gateway-package": {
       "version": "^3.0.3-SNAPSHOT",
-      "artifact": "gateway-*.zip",
+      "artifact": "gateway-3.2.15-20250616.142200*.zip",
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.caching-service-package": {
       "version": "^3.0.3-SNAPSHOT",
-      "artifact": "caching-service-*.zip",
+      "artifact": "caching-service-3.2.15-20250616.142200*.zip",
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.apiml-common-lib-package": {
       "version": "^3.0.3-SNAPSHOT",
-      "artifact": "apiml-common-lib-*.zip",
+      "artifact": "apiml-common-lib-3.2.15-20250616.142200*.zip",
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.sdk.common-java-lib-package": {
       "version": "^2.0.0-SNAPSHOT",
-      "artifact": "common-java-lib-*.zip",
+      "artifact": "common-java-lib-3.2.15-20250616.142200*.zip",
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.sdk.apiml-sample-extension-package": {
@@ -93,7 +93,7 @@
     },
     "org.zowe.apiml.zaas-package": {
       "version": "^3.0.3-SNAPSHOT",
-      "artifact": "zaas-package-*.zip",
+      "artifact": "zaas-package-3.2.15-20250616.142200*.zip",
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.sdk.certificate-analyser": {

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -58,32 +58,32 @@
     },
     "org.zowe.apiml.api-catalog-package": {
       "version": "^3.0.3-SNAPSHOT",
-      "artifact": "api-catalog-3.2.15-20250616.142200*.zip",
+      "artifact": "api-catalog-package-3.2.15-20250616.142200*.zip",
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.discovery-package": {
       "version": "^3.0.3-SNAPSHOT",
-      "artifact": "discovery-3.2.15-20250616.142200*.zip",
+      "artifact": "discovery-package-3.2.15-20250616.142200-3.zip",
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.gateway-package": {
       "version": "^3.0.3-SNAPSHOT",
-      "artifact": "gateway-3.2.15-20250616.142200*.zip",
+      "artifact": "gateway-package-3.2.15-20250616.142200*.zip",
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.caching-service-package": {
       "version": "^3.0.3-SNAPSHOT",
-      "artifact": "caching-service-3.2.15-20250616.142200*.zip",
+      "artifact": "caching-service-package-3.2.15-20250616.142200*.zip",
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.apiml-common-lib-package": {
       "version": "^3.0.3-SNAPSHOT",
-      "artifact": "apiml-common-lib-3.2.15-20250616.142200*.zip",
+      "artifact": "apiml-common-lib-package-3.2.15-20250616.142200*.zip",
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.sdk.common-java-lib-package": {
       "version": "^2.0.0-SNAPSHOT",
-      "artifact": "common-java-lib-3.2.15-20250616.142200*.zip",
+      "artifact": "common-java-lib-package-3.2.15-20250616.142200*.zip",
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.sdk.apiml-sample-extension-package": {

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -13,7 +13,7 @@
   "binaryDependencies": {
     "org.zowe.zlux.zlux-core": {
       "version": "^3.0.0-V3.X-STAGING-ZLUX-CORE",
-      "artifact": "zlux-core-3.3.0-20250617.154621.pax"
+      "artifact": "*.pax"
     },
     "org.zowe.zlux.sample-angular-app": {
       "version": "^3.0.0-V3.X-STAGING",
@@ -41,7 +41,7 @@
     },
     "org.zowe.zss": {
       "version": "^3.0.0-STAGING",
-      "artifact": "zss-3.3.0-staging-1318-20250611120903.pax"
+      "artifact": "*.pax"
     },
     "org.zowe.explorer-jes": {
       "version": "^3.0.0-SNAPSHOT"

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -83,7 +83,7 @@
     },
     "org.zowe.apiml.sdk.common-java-lib-package": {
       "version": "^2.0.0-SNAPSHOT",
-      "artifact": "common-java-lib-package-3.2.15-20250616.142200*.zip",
+      "artifact": "common-java-lib-package-2.0.7-20250529.123714-1.zip",
       "exclusions": ["*PR*.zip"]
     },
     "org.zowe.apiml.sdk.apiml-sample-extension-package": {

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -13,7 +13,7 @@
   "binaryDependencies": {
     "org.zowe.zlux.zlux-core": {
       "version": "^3.0.0-V3.X-STAGING-ZLUX-CORE",
-      "artifact": "*.pax"
+      "artifact": "zlux-core-3.3.0-20250617.154621.pax"
     },
     "org.zowe.zlux.sample-angular-app": {
       "version": "^3.0.0-V3.X-STAGING",

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -41,7 +41,7 @@
     },
     "org.zowe.zss": {
       "version": "^3.0.0-STAGING",
-      "artifact": "*.pax"
+      "artifact": "zss-3.3.0-staging-1318-20250611120903.pax"
     },
     "org.zowe.explorer-jes": {
       "version": "^3.0.0-SNAPSHOT"


### PR DESCRIPTION
error inconsistently appearing in `loginMVD`, which is direct-to-service login to web desktop. This should redirect to APIML.

The error is fixed when downgrading APIML.