### PR TITLE
update gener tests with UNIT=VIO and correct JCL headers

### DIFF
--- a/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/generate.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/generate.test.ts.snap
@@ -269,7 +269,7 @@ Template JCL: TEST.DATASET.PFX.SZWESAMP(ZWEGENER)
 //*       {key} -> value
 //*
 //GENER    EXEC PGM=IKJEFT1B
-//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=,
+//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=VIO,
 //   DCB=(RECFM=FB,LRECL=80,BLKSIZE=3120,DSORG=PO),
 //   SPACE=(3120,(20,5,10))
 //*
@@ -386,9 +386,9 @@ Zowe will remove it on success, but if zwe exits with a non-zero code manual cle
 Template JCL: TEST.DATASET.PFX.SZWESAMP(ZWEGENER)
 --- JCL content ---
 //ZWEGENER JOB 'SOMEJOB'
-(0000000000)
-LONGFIELD1,LONGFIELD2,LONGFIELD3,ANOTHER,FIELD,GOING,WAY,PAST,EIGHTY,CHARACTERS
-SYSAFF=SYS1
+//    (0000000000)
+//    LONGFIELD1,LONGFIELD2,LONGFIELD3,ANOTHER,FIELD,GOING,WAY,PAST,EIGHTY,CHAR
+//    SYSAFF=SYS1
 //*
 //* This program and the accompanying materials are made available
 //* under the terms of the Eclipse Public License v2.0 which
@@ -423,7 +423,7 @@ SYSAFF=SYS1
 //*       {key} -> value
 //*
 //GENER    EXEC PGM=IKJEFT1B
-//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=,
+//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=VIO,
 //   DCB=(RECFM=FB,LRECL=80,BLKSIZE=3120,DSORG=PO),
 //   SPACE=(3120,(20,5,10))
 //*
@@ -501,9 +501,9 @@ Zowe will remove it on success, but if zwe exits with a non-zero code manual cle
 Template JCL: TEST.DATASET.PFX.SZWESAMP(ZWEGENER)
 --- JCL content ---
 //ZWEGENER JOB LONGFIELD1,LONGFIELD2,LONGFIELD3,ANOTHER,FIELD,GOING,WAY,PAST,EIGHTY,CHARACTERS
-(0000000000)
-SOMEJOB
-SYSAFF=SYS1
+//    (0000000000)
+//    SOMEJOB
+//    SYSAFF=SYS1
 //*
 //* This program and the accompanying materials are made available
 //* under the terms of the Eclipse Public License v2.0 which
@@ -538,7 +538,7 @@ SYSAFF=SYS1
 //*       {key} -> value
 //*
 //GENER    EXEC PGM=IKJEFT1B
-//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=,
+//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=VIO,
 //   DCB=(RECFM=FB,LRECL=80,BLKSIZE=3120,DSORG=PO),
 //   SPACE=(3120,(20,5,10))
 //*
@@ -653,7 +653,7 @@ Template JCL: TEST.DATASET.PFX.SZWESAMP(ZWEGENER)
 //*       {key} -> value
 //*
 //GENER    EXEC PGM=IKJEFT1B
-//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=,
+//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=VIO,
 //   DCB=(RECFM=FB,LRECL=80,BLKSIZE=3120,DSORG=PO),
 //   SPACE=(3120,(20,5,10))
 //*
@@ -765,7 +765,7 @@ Template JCL: TEST.DATASET.PFX.SZWESAMP(ZWEGENER)
 //*       {key} -> value
 //*
 //GENER    EXEC PGM=IKJEFT1B
-//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=,
+//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=VIO,
 //   DCB=(RECFM=FB,LRECL=80,BLKSIZE=3120,DSORG=PO),
 //   SPACE=(3120,(20,5,10))
 //*
@@ -909,7 +909,7 @@ Template JCL: TEST.DATASET.PFX.SZWESAMP(ZWEGENER)
 //*       {key} -> value
 //*
 //GENER    EXEC PGM=IKJEFT1B
-//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=,
+//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=VIO,
 //   DCB=(RECFM=FB,LRECL=80,BLKSIZE=3120,DSORG=PO),
 //   SPACE=(3120,(20,5,10))
 //*
@@ -1021,7 +1021,7 @@ Template JCL: TEST.DATASET.PFX.SZWESAMP(ZWEGENER)
 //*       {key} -> value
 //*
 //GENER    EXEC PGM=IKJEFT1B
-//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=,
+//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=VIO,
 //   DCB=(RECFM=FB,LRECL=80,BLKSIZE=3120,DSORG=PO),
 //   SPACE=(3120,(20,5,10))
 //*

--- a/tests/zwe-remote-integration/src/__tests__/init/generate.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/init/generate.test.ts
@@ -91,7 +91,7 @@ describe(`${testSuiteName}`, () => {
       expect(result.rc).toBe(1);
 
       // this is technically not valid JCL, but fits in 80 chars
-      jclLines = [`'SOMEJOB'`, `(0000000000)`, longString.slice(0, 79), 'SYSAFF=SYS1'];
+      jclLines = [`'SOMEJOB'`, `//    (0000000000)`, ('//    ' + longString).slice(0, 79), '//    SYSAFF=SYS1'];
       _.set(cfgYaml, 'zowe.setup.jcl.header', jclLines);
       result = await testRunner.runZweTest(cfgYaml, 'init generate --dry-run');
       expect(result.stdout).not.toBeNull();
@@ -99,7 +99,7 @@ describe(`${testSuiteName}`, () => {
       expect(result.rc).toBe(0);
 
       // with idx 0, the slice is invalid for first line. this is currently allowed by schema.
-      jclLines = [longString.slice(0, 79), `(0000000000)`, 'SOMEJOB', 'SYSAFF=SYS1'];
+      jclLines = [longString.slice(0, 79), `//    (0000000000)`, '//    SOMEJOB', '//    SYSAFF=SYS1'];
       _.set(cfgYaml, 'zowe.setup.jcl.header', jclLines);
       result = await testRunner.runZweTest(cfgYaml, 'init generate --dry-run');
       expect(result.stdout).not.toBeNull();
@@ -127,7 +127,7 @@ describe(`${testSuiteName}`, () => {
 
       // error - 81 char line
       // eslint-disable-next-line
-      _.set(cfgYaml, 'zowe.setup.jcl.header', longString.slice(0, 80- ('//ABCABCDE JOB '.length-1) ));
+      _.set(cfgYaml, 'zowe.setup.jcl.header', longString.slice(0, 80 - ('//ABCABCDE JOB '.length - 1)));
       result = await testRunner.runZweTest(cfgYaml, 'init generate --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
@@ -135,7 +135,7 @@ describe(`${testSuiteName}`, () => {
 
       // OK - 80 char line
       // eslint-disable-next-line
-      _.set(cfgYaml, 'zowe.setup.jcl.header', longString.slice(0, 80-'//ABCABCDE JOB '.length));
+      _.set(cfgYaml, 'zowe.setup.jcl.header', longString.slice(0, 80 - '//ABCABCDE JOB '.length));
       result = await testRunner.runZweTest(cfgYaml, 'init generate --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();


### PR DESCRIPTION
Missed small updates to `zwe init generate` tests in other PRs.