### PR TITLE
Fix more zwe test cases

### DIFF
--- a/tests/zwe-remote-integration/jest.config.ts
+++ b/tests/zwe-remote-integration/jest.config.ts
@@ -14,6 +14,7 @@ const config: Config = {
   // runner: "./dist/worker-group-runner.js",
   globalSetup: '<rootDir>/src/globalSetup.ts',
   globalTeardown: '<rootDir>/src/globalTeardown.ts',
+  setupFilesAfterEnv: ['<rootDir>/src/jest-config.ts'],
   preset: 'ts-jest',
   modulePathIgnorePatterns: ['<rootDir>/.build'],
   testRegex: '__tests__.*\\.*?\\.(spec|test)\\.ts$',

--- a/tests/zwe-remote-integration/src/__tests__/env/env.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/env/env.test.ts
@@ -12,12 +12,14 @@ import ZoweYamlType from '../../config/ZoweYamlType';
 import { RemoteTestRunner } from '../../zos/RemoteTestRunner';
 import { ZoweConfig } from '../../config/ZoweConfig';
 import * as fs from 'fs-extra';
+import { FileType, TestFile, TestFileActions } from '../../zos/TestFileActions';
 
 const testSuiteName = 'generated-env-tests';
 describe(`${testSuiteName}`, () => {
   let testRunner: RemoteTestRunner;
   let cfgYaml: ZoweYamlType;
   let defaultCfgYaml: ZoweYamlType;
+  let cleanupFiles: TestFile[] = [];
 
   beforeAll(async () => {
     testRunner = new RemoteTestRunner(testSuiteName);
@@ -27,13 +29,21 @@ describe(`${testSuiteName}`, () => {
     };
     testRunner.addCleanFn(cleanSecurityManager);
   });
-  beforeEach(() => {
+  beforeEach(async () => {
     cfgYaml = ZoweConfig.getZoweYaml();
     defaultCfgYaml = ZoweConfig.getDefaultsYaml();
+
+    await testRunner.removeUssFileOrDirForTest('components');
+    cleanupFiles.push({
+      name: `${cfgYaml.zowe.workspaceDirectory}/.env`,
+      type: FileType.USS_DIR,
+    });
   });
 
   afterEach(async () => {
     await testRunner.postTest();
+    await TestFileActions.deleteAll(cleanupFiles);
+    cleanupFiles = [];
   });
 
   afterAll(() => {

--- a/tests/zwe-remote-integration/src/__tests__/env/env.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/env/env.test.ts
@@ -32,12 +32,13 @@ describe(`${testSuiteName}`, () => {
   beforeEach(async () => {
     cfgYaml = ZoweConfig.getZoweYaml();
     defaultCfgYaml = ZoweConfig.getDefaultsYaml();
-
-    await testRunner.removeUssFileOrDirForTest('components');
-    cleanupFiles.push({
+    const workspaceEnv: TestFile = {
       name: `${cfgYaml.zowe.workspaceDirectory}/.env`,
       type: FileType.USS_DIR,
-    });
+    };
+    await TestFileActions.deleteAll([workspaceEnv]);
+    await testRunner.removeUssFileOrDirForTest('components');
+    cleanupFiles.push(workspaceEnv);
   });
 
   afterEach(async () => {

--- a/tests/zwe-remote-integration/src/__tests__/init/generate.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/init/generate.test.ts
@@ -158,7 +158,7 @@ describe(`${testSuiteName}`, () => {
     });
 
     it('BAD: missing defaults.yaml', async () => {
-      await testRunner.removeUssFileForTest('files/defaults.yaml');
+      await testRunner.removeUssFileOrDirForTest('files/defaults.yaml');
       const result = await testRunner.runZweTest(cfgYaml, 'init generate --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot(); // FIXME: the snapshot indicates processing continues when it shouldn't

--- a/tests/zwe-remote-integration/src/__tests__/launcher/launcher.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/launcher/launcher.test.ts
@@ -20,15 +20,16 @@ describe(`${testSuiteName}`, () => {
   let testRunner: RemoteTestRunner;
   let cfgYaml: ZoweYamlType;
   let defaultCfgYaml: ZoweYamlType;
-  const workspaceEnv: TestFile = {
-    name: `${cfgYaml.zowe.workspaceDirectory}/.env`,
-    type: FileType.USS_DIR,
-  };
+  let workspaceEnv: TestFile;
 
   beforeAll(async () => {
     testRunner = new RemoteTestRunner(testSuiteName);
     cfgYaml = ZoweConfig.getZoweYaml();
     defaultCfgYaml = ZoweConfig.getDefaultsYaml();
+    workspaceEnv = {
+      name: `${cfgYaml.zowe.workspaceDirectory}/.env`,
+      type: FileType.USS_DIR,
+    };
     const cleanSecurityManager = (input: string) => {
       return input.replaceAll(/TSS|ACF2|RACF/gi, 'ESMT'); // ESM TEST
     };

--- a/tests/zwe-remote-integration/src/__tests__/launcher/launcher.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/launcher/launcher.test.ts
@@ -46,6 +46,8 @@ describe(`${testSuiteName}`, () => {
     it('compare .zowe-merged.yaml created by launcher and zwe', async () => {
       const defaultsUpl = await testRunner.uploadDefaultsYaml(defaultCfgYaml);
       const zyUpl = await testRunner.uploadZoweYaml(cfgYaml);
+      // we need to remove the components dir so zowe_launcher fails and returns after creating env. otherwise test hangs.
+      await testRunner.removeUssFileOrDirForTest('components');
 
       const launcherRes = await testRunner.runRaw(` 
             export RUNTIME_DIRECTORY=${cfgYaml.zowe.runtimeDirectory} && \
@@ -56,7 +58,10 @@ describe(`${testSuiteName}`, () => {
       // this is an intentionally invalid zowe_launcher run - create env configs and then exit with an error
       expect(launcherRes.rc).toBe(8);
 
-      const launchZoweMerged = await testRunner.downloadMaskedUssFilesMatching('*.yaml', `${cfgYaml.zowe.workspaceDirectory}/.env/`);
+      const launchZoweMerged = await testRunner.downloadMaskedUssFilesMatching(
+        '.zowe-merged.yaml',
+        `${cfgYaml.zowe.workspaceDirectory}/.env/`,
+      );
       expect(launchZoweMerged.length).toBe(1);
       testRunner.collectTestFile(launchZoweMerged[0]);
 

--- a/tests/zwe-remote-integration/src/__tests__/launcher/launcher.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/launcher/launcher.test.ts
@@ -13,12 +13,17 @@ import { RemoteTestRunner } from '../../zos/RemoteTestRunner';
 import { ZoweConfig } from '../../config/ZoweConfig';
 import * as fs from 'fs-extra';
 import * as yaml from 'yaml';
+import { FileType, TestFileActions } from '../../zos/TestFileActions';
 
 const testSuiteName = 'compare-zwe-output-with-launcher';
 describe(`${testSuiteName}`, () => {
   let testRunner: RemoteTestRunner;
   let cfgYaml: ZoweYamlType;
   let defaultCfgYaml: ZoweYamlType;
+  const workspaceEnv: TestFile = {
+    name: `${cfgYaml.zowe.workspaceDirectory}/.env`,
+    type: FileType.USS_DIR,
+  };
 
   beforeAll(async () => {
     testRunner = new RemoteTestRunner(testSuiteName);
@@ -29,13 +34,15 @@ describe(`${testSuiteName}`, () => {
     };
     testRunner.addCleanFn(cleanSecurityManager);
   });
-  beforeEach(() => {
+  beforeEach(async () => {
     cfgYaml = ZoweConfig.getZoweYaml();
     defaultCfgYaml = ZoweConfig.getDefaultsYaml();
+    await TestFileActions.deleteAll([workspaceEnv]);
   });
 
   afterEach(async () => {
     await testRunner.postTest();
+    await TestFileActions.deleteAll([workspaceEnv]);
   });
 
   afterAll(() => {
@@ -71,7 +78,6 @@ describe(`${testSuiteName}`, () => {
       const zweZoweMerged = await testRunner.downloadMaskedUssFilesMatching('*.yaml', `${cfgYaml.zowe.workspaceDirectory}/.env/`);
       expect(zweZoweMerged.length).toBe(1);
       testRunner.collectTestFile(zweZoweMerged[0]);
-
       // track changes to merged yaml files generally
       const launchMergedYaml = fs.readFileSync(launchZoweMerged[0], 'utf8');
       const zweMergedYaml = fs.readFileSync(zweZoweMerged[0], 'utf8');

--- a/tests/zwe-remote-integration/src/__tests__/launcher/launcher.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/launcher/launcher.test.ts
@@ -13,7 +13,7 @@ import { RemoteTestRunner } from '../../zos/RemoteTestRunner';
 import { ZoweConfig } from '../../config/ZoweConfig';
 import * as fs from 'fs-extra';
 import * as yaml from 'yaml';
-import { FileType, TestFileActions } from '../../zos/TestFileActions';
+import { FileType, TestFile, TestFileActions } from '../../zos/TestFileActions';
 
 const testSuiteName = 'compare-zwe-output-with-launcher';
 describe(`${testSuiteName}`, () => {

--- a/tests/zwe-remote-integration/src/jest-config.ts
+++ b/tests/zwe-remote-integration/src/jest-config.ts
@@ -1,0 +1,11 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+jest.retryTimes(1, { logErrorsBeforeRetry: true });

--- a/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
+++ b/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
@@ -273,7 +273,7 @@ export class RemoteTestRunner {
     }
   }
 
-  public async removeUssFileForTest(filePath: string) {
+  public async removeUssFileOrDirForTest(filePath: string) {
     const flattenedTmpName = filePath.replaceAll('/', '_');
     await this.runRaw(`mkdir -p ${this.REMOTE_TEST_TMP_DIR}`);
     await this.runRaw(`mv ${filePath} ${this.REMOTE_TEST_TMP_DIR}/${flattenedTmpName}`);
@@ -384,7 +384,7 @@ export class RemoteTestRunner {
     const stringDefaultYaml = YAML.stringify(defaultsYaml, { nullStr: '' });
     const yamlOutputDir = this.yamlOutputTemplate.replace('{{ testInstance }}', testName);
     fs.mkdirpSync(yamlOutputDir);
-    await this.removeUssFileForTest('files/defaults.yaml');
+    await this.removeUssFileOrDirForTest('files/defaults.yaml');
     const redundantFilePath = this.writeRedundant(`${yamlOutputDir}/defaults.yaml`, stringDefaultYaml);
     await files.Upload.fileToUssFile(this.session, redundantFilePath, yamlUploadPath, {
       binary: false,


### PR DESCRIPTION
* `launcher` tests: Removes `components` before running. Adding `components` dir to remote integration environment caused the launcher test to hang.
* `.env` tests: Cleanup files created in `.env` after test runs and removes `components` before running (same as above).