### PR TITLE
Missing JCL header

### DIFF
--- a/files/SZWESAMP/ZWEKRING
+++ b/files/SZWESAMP/ZWEKRING
@@ -1,4 +1,4 @@
-//ZWEKRING JOB
+//ZWEKRING JOB {zowe.setup.jcl.header}
 //*
 //* This program and the accompanying materials are made available
 //* under the terms of the Eclipse Public License v2.0 which

--- a/files/SZWESAMP/ZWENOKYR
+++ b/files/SZWESAMP/ZWENOKYR
@@ -1,4 +1,4 @@
-//ZWENOKYR JOB
+//ZWENOKYR JOB {zowe.setup.jcl.header}
 //*
 //* This program and the accompanying materials are made available
 //* under the terms of the Eclipse Public License v2.0 which


### PR DESCRIPTION
2 samples are missing `{zowe.setup.jcl.header}`.