### PR TITLE
Deprecated samples not used by generate

### DIFF
--- a/files/SZWEEXEC/ZWEGEN00
+++ b/files/SZWEEXEC/ZWEGEN00
@@ -180,15 +180,11 @@ if FreeByDD('zweto') > 0 then do
   ExitWithRC(8)
 end
 
-
-/* members which are not JCL */
-x = DeleteDataSet(jclCopy'(ZWEGENER)')
-x = DeleteDataSet(jclCopy'(ZWESIP00)')
-x = DeleteDataSet(jclCopy'(ZWESIPRG)')
-x = DeleteDataSet(jclCopy'(ZWESISCH)')
-x = DeleteDataSet(jclCopy'(ZWESECKG)')
-x = DeleteDataSet(jclCopy'(ZWEINSTL)')
-
+/* members not processed */
+excludeList = "ZWEKRING ZWENOKYR ZWEGENER ZWESIP00 ZWESIPRG ZWESISCH ZWESECKG"
+do el = 1 to words(excludeList)
+  ret = DeleteDataSet(jclCopy'('word(excludeList, el)')')
+end
 
 /*
 ================================================================================

--- a/files/SZWESAMP/ZWEKRING
+++ b/files/SZWESAMP/ZWEKRING
@@ -16,6 +16,9 @@
 //*
 //*********************************************************************
 //* ATTENTION!
+//*
+//* This sample is DEPRECATED.
+//*
 //* Configure certificate for Zowe
 //* Select one of three options which is the most suitable for your
 //* environment and follow the appropriate action

--- a/files/SZWESAMP/ZWENOKYR
+++ b/files/SZWESAMP/ZWENOKYR
@@ -14,6 +14,10 @@
 //* Zowe Open Source Project
 //* This JCL can be used to remove key ring and certificates for Zowe
 //*
+//*********************************************************************
+//* ATTENTION!
+//*
+//* This sample is DEPRECATED.
 //*
 //* CAUTION: This is neither a JCL procedure nor a complete job.
 //* Before using this JCL, you will have to make the following


### PR DESCRIPTION
## Changes
* `ZWEKRING` and `ZWENOKYR` are excluded from processing by `zwe init generate`
  * Those samples are not maintained - `zowe.setup.dataset.jcllib` is expected to contain ready to execute JCLs
  * Deprecated comment added
* `ZWEINSTL` is included now
 