### PR TITLE
Update Node versions used in tests (v3)

### DIFF
--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -191,7 +191,7 @@ BASE_DIR=$(
 ) # <something>/.pax
 
 # use node v18 to build
-export NODE_HOME=/ZOWE/node/node-v18.16.0
+export NODE_HOME=/ZOWE/node/node-v18.20.8
 export JAVA_HOME=/ZOWE/node/J17.0_64
 export PATH=$JAVA_HOME/bin:$PATH
 ZOWE_ROOT_DIR="${BASE_DIR}/content"

--- a/tests/installation/src/__tests__/extended/node-versions/node-v20.ts
+++ b/tests/installation/src/__tests__/extended/node-versions/node-v20.ts
@@ -32,7 +32,7 @@ describe(testSuiteName, () => {
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
         'zowe_custom_for_test': 'true',
-        'zos_node_home': '/ZOWE/node/node-v20.11.0',
+        'zos_node_home': '/ZOWE/node/node-v20.19.2',
         'zowe_lock_keystore': 'false',
       }
     );

--- a/tests/installation/src/__tests__/extended/node-versions/node-v22.ts
+++ b/tests/installation/src/__tests__/extended/node-versions/node-v22.ts
@@ -32,7 +32,7 @@ describe(testSuiteName, () => {
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
         'zowe_custom_for_test': 'true',
-        'zos_node_home': '/ZOWE/node/node-v22.10.0',
+        'zos_node_home': '/ZOWE/node/node-v22.16.0',
         'zowe_lock_keystore': 'false',
       }
     );


### PR DESCRIPTION
Updates Node 18, 20, and 22 to use the latest versions available on the Marist systems.

Node 18 was also updated on the user's PATH to the latest version.