### PR TITLE
Replace SDSF Job Status with `zowex`

### DIFF
--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -276,7 +276,7 @@ jobs:
         with:
           manifest-file-path: ${{ github.workspace }}/manifest.json
           default-target-path: .pax/binaryDependencies/
-          expected-count: 28
+          expected-count: 29
       
       # this step is not doing a publish, we are just utilizing this actions to get the PUBLISH_TARGET_PATH, 
       # and it will be used in the next step: [Download 3] Download SMPE build log

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -228,6 +228,18 @@ chmod +x "${ZOWE_ROOT_DIR}"/bin/zwe
 chmod +x "${ZOWE_ROOT_DIR}"/bin/utils/*.sh
 chmod +x "${ZOWE_ROOT_DIR}"/bin/utils/*.rex
 
+echo "[$SCRIPT_NAME] extract zowex ..."
+zowex_components=$(find "${ZOWE_ROOT_DIR}/files" -type f \( -name "zowe-server-*.pax.Z" \) | head -n 1)
+cd "${ZOWE_ROOT_DIR}/bin/utils"
+pax -ppx -rf "${zowex_components}"
+rm -rf "${ZOWE_ROOT_DIR}"/bin/utils/zowe-server-*
+
+echo "[$SCRIPT_NAME] change zowex to be executable ..."
+chmod +x "${ZOWE_ROOT_DIR}"/bin/utils/zowex
+
+echo "[$SCRIPT_NAME] disable zoweax and zowed for the moment ..."
+chmod -x "${ZOWE_ROOT_DIR}"/bin/utils/zoweax "${ZOWE_ROOT_DIR}"/bin/utils/zowed
+
 echo "[$SCRIPT_NAME] change keyring-util to be executable ..."
 chmod +x "${ZOWE_ROOT_DIR}"/bin/utils/keyring-util/keyring-util
 

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -230,15 +230,16 @@ chmod +x "${ZOWE_ROOT_DIR}"/bin/utils/*.rex
 
 echo "[$SCRIPT_NAME] extract zowex ..."
 zowex_components=$(find "${ZOWE_ROOT_DIR}/files" -type f \( -name "zowe-server-*.pax.Z" \) | head -n 1)
-cd "${ZOWE_ROOT_DIR}/bin/utils"
+mkdir -p "${ZOWE_ROOT_DIR}/bin/utils/zowe-server"
+cd "${ZOWE_ROOT_DIR}/bin/utils/zowe-server"
 pax -ppx -rf "${zowex_components}"
-rm -rf "${ZOWE_ROOT_DIR}"/bin/utils/zowe-server-*
 
-echo "[$SCRIPT_NAME] change zowex to be executable ..."
-chmod +x "${ZOWE_ROOT_DIR}"/bin/utils/zowex
-
-echo "[$SCRIPT_NAME] disable zoweax and zowed for the moment ..."
-chmod -x "${ZOWE_ROOT_DIR}"/bin/utils/zoweax "${ZOWE_ROOT_DIR}"/bin/utils/zowed
+echo "[$SCRIPT_NAME] place zowex in bin/utils and change zowex to be executable ..."
+# If we want zowed and zoweax, copy them now
+cp "${ZOWE_ROOT_DIR}/bin/utils/zowe-server/zowex" "${ZOWE_ROOT_DIR}/bin/utils/zowex"
+chmod +x "${ZOWE_ROOT_DIR}/bin/utils/zowex"
+cd "${ZOWE_ROOT_DIR}/bin/utils"
+rm -rf "${ZOWE_ROOT_DIR}/bin/utils/zowe-server"
 
 echo "[$SCRIPT_NAME] change keyring-util to be executable ..."
 chmod +x "${ZOWE_ROOT_DIR}"/bin/utils/keyring-util/keyring-util

--- a/.pax/prepare-workspace.sh
+++ b/.pax/prepare-workspace.sh
@@ -172,6 +172,7 @@ rsync -rv \
   --exclude '*.png' \
   --exclude '*.tgz' \
   --exclude '*.tar.gz' \
+  --exclude '*.pax.Z' \
   --exclude '*.pax' \
   --exclude '*.jar' \
   --exclude '*.class' \
@@ -191,6 +192,7 @@ cd "${PAX_BINARY_DEPENDENCIES}"
 for zlux_dep in zlux-editor tn3270-ng2 vt-ng2 sample-react-app sample-iframe-app sample-angular-app explorer-ip ; do
   mv ${zlux_dep}-*.pax        "${CONTENT_DIR}/files/zlux/${zlux_dep}.pax"
 done
+mv *.pax.Z "${CONTENT_DIR}/files/"
 mv *.pax "${CONTENT_DIR}/files/"
 mv *.zip "${CONTENT_DIR}/files/"
 mv certificate-analyser-* "${CONTENT_DIR}/files/"

--- a/bin/README.md
+++ b/bin/README.md
@@ -54,10 +54,11 @@ Please be aware of using functions marked as `@experimental`. These functions ma
 
 `bin/utils` directory holds several utility tools used by Zowe, and you can take advantage of them too.
 
-- `bin/utils/opercmd.rex`: To issue operator command on z/OS. This script can only run on z/OS.
+- `bin/utils/opercmd.rex`: To issue operator command on z/OS. This script can only run on z/OS and requires SDSF.
 - `bin/utils/curl.js`: This node.js script works similar to popular Linux tool `curl`. It can make HTTP/HTTPS request and display response.
-- `bin/utils/getesm`: Executable to get the name of External Security Manager
+- `bin/utils/getesm`: Executable to get the name of External Security Manager.
 - `bin/utils/certificate-analyser.jar`: Java based tool to verify the certificates. See [README](https://github.com/zowe/api-layer/blob/v3.x.x/certificate-analyser/README.md) for more information.
+- `bin/utils/zowex`: Zowe Native Protocol CLI for various tasks (console, jobs, datasets, ...), use `zowex --help` for more information.
 
 Please be aware of using utilities marked as `@experimental`. These utilities may be changed or improved in the future, and they may not be stable enough for extenders to use if they target to support multiple versions of Zowe.
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -58,7 +58,7 @@ Please be aware of using functions marked as `@experimental`. These functions ma
 - `bin/utils/curl.js`: This node.js script works similar to popular Linux tool `curl`. It can make HTTP/HTTPS request and display response.
 - `bin/utils/getesm`: Executable to get the name of External Security Manager.
 - `bin/utils/certificate-analyser.jar`: Java based tool to verify the certificates. See [README](https://github.com/zowe/api-layer/blob/v3.x.x/certificate-analyser/README.md) for more information.
-- `bin/utils/zowex`: Zowe Native Protocol CLI for various tasks (console, jobs, datasets, ...), use `zowex --help` for more information.
+- `@experimental`: `bin/utils/zowex`: Zowe Native Protocol CLI for various tasks (console, jobs, datasets, ...), use `zowex --help` for more information.
 
 Please be aware of using utilities marked as `@experimental`. These utilities may be changed or improved in the future, and they may not be stable enough for extenders to use if they target to support multiple versions of Zowe.
 

--- a/bin/commands/init/generate/index.ts
+++ b/bin/commands/init/generate/index.ts
@@ -20,7 +20,7 @@ import * as zosJes from '../../../libs/zos-jes';
 
 export function execute(dryRun?: boolean) {
   common.requireZoweYaml();
-  const ZOWE_CONFIG=config.getZoweConfig();
+  const ZOWE_CONFIG = config.getZoweConfig();
 
   // zowe.setup.dataset defined in defaults
   const prefix = ZOWE_CONFIG.zowe.setup.dataset.prefix;
@@ -42,9 +42,9 @@ export function execute(dryRun?: boolean) {
   // zowe.setup.jcl.header defined in defaults
   const jclHeader = ZOWE_CONFIG.zowe.setup.jcl.header;
   if (Array.isArray(jclHeader)) {
-      jclHeaderJoined = jclHeader.join("\n");
+    jclHeaderJoined = jclHeader.join("\n");
   } else {
-      jclHeaderJoined = jclHeader.toString();
+    jclHeaderJoined = jclHeader.toString();
   }
 
   const tempFile = fs.createTmpFile();
@@ -65,7 +65,7 @@ export function execute(dryRun?: boolean) {
   let originalConfig = std.getenv('ZWE_PRIVATE_CONFIG_ORIG');
   let startingConfig = originalConfig;
   if ((originalConfig.indexOf('FILE(') == -1) && (originalConfig.indexOf('PARMLIB(') == -1)) {
-    startingConfig = 'FILE('+originalConfig+')';
+    startingConfig = 'FILE(' + originalConfig + ')';
   }
 
   // we are guaranteed to have FILE() or PARMLIB() formatted config concatenated with ':'
@@ -76,14 +76,14 @@ export function execute(dryRun?: boolean) {
   for (let i = 0; i < parts.length; i++) {
     let part = parts[i].trim();
     if (part.startsWith('FILE(')) {
-      let filename = part.substring(part.indexOf('(')+1, part.indexOf(')'));
+      let filename = part.substring(part.indexOf('(') + 1, part.indexOf(')'));
       configLines.push('FILE ' + fs.convertToAbsolutePath(filename).replace(/[$]/g, '$$$$'));
     } else if (part.startsWith('PARMLIB(')) {
       const isValidParmlib = common.isValidZoweYamlParmlib(part);
       if (!isValidParmlib.ok) {
         common.printErrorAndExit(isValidParmlib.error.message, undefined, isValidParmlib.error.code);
       }
-      const parmlib = part.substring(part.indexOf('(')+1, part.lastIndexOf(')'));
+      const parmlib = part.substring(part.indexOf('(') + 1, part.lastIndexOf(')'));
       configLines.push(`PARMLIB ${parmlib}`);
     }
   }
@@ -108,7 +108,7 @@ export function execute(dryRun?: boolean) {
     if (result.rc == 0) {
       common.printMessage("Zowe JCL generated successfully");
     } else {
-      common.printMessage(`Zowe JCL generated with errors, check job log. Job completion code=${result.jobcccode}, Job completion text=${result.jobcctext}`);
+      common.printMessage(`Zowe JCL generated with errors, check job log. Job completion code=${result.jobcccode}.`);
     }
   }
   os.remove(tempFile);

--- a/bin/commands/install/index.ts
+++ b/bin/commands/install/index.ts
@@ -49,8 +49,8 @@ export function execute(): void {
     jclHeaderJoined = jclHeaderCfg.toString();
   }
 
-  const ZWEINSTL=`${runtime}/files/SZWESAMP/ZWEINSTL`;
-  const DATASETS = [ 'SZWEAUTH', 'SZWEEXEC', 'SZWELOAD', 'SZWESAMP' ];
+  const ZWEINSTL = `${runtime}/files/SZWESAMP/ZWEINSTL`;
+  const DATASETS = ['SZWEAUTH', 'SZWEEXEC', 'SZWELOAD', 'SZWESAMP'];
   const allowOverwrite = std.getenv("ZWE_CLI_PARAMETER_ALLOW_OVERWRITE") == 'true';
   const dryRun = std.getenv("ZWE_CLI_PARAMETER_DRY_RUN") == 'true';
   const existingDatasets: string[] = [];
@@ -115,7 +115,7 @@ export function execute(): void {
       common.printMessage("- Type \"zwe init <sub-command> --help\" (for example, \"zwe init stc --help\") to get more information.\n\n");
       common.printMessage("Zowe JCL generated successfully");
     } else {
-      common.printMessage(`Zowe JCL submitted with errors, check job log. Job completion code=${result.jobcccode}, Job completion text=${result.jobcctext}`);
+      common.printMessage(`Zowe JCL submitted with errors, check job log. Job completion code=${result.jobcccode}.`);
     }
   }
 

--- a/bin/libs/zos-jes.ts
+++ b/bin/libs/zos-jes.ts
@@ -167,7 +167,7 @@ export function waitForJob(jobid: string): { jobcccode?: string, jobid?: string,
     }
   }
   common.printTrace(`  * Job status check done at ${new Date().toString()}.`);
-  if (jobcccode) {
+  if (jobcccode.length > 0) {
     common.printDebug(`  * Job (${jobname}) exits with code ${jobcccode}.`);
     if (Number(jobcccode) === 0) {
       return { jobcccode, jobname, rc: 0 };

--- a/bin/libs/zos-jes.ts
+++ b/bin/libs/zos-jes.ts
@@ -231,8 +231,6 @@ export function printAndHandleJcl(jclLocationOrContent: string, jobName: string,
         }
         common.printErrorAndExit(`Error ZWEL0162E: Failed to find job ${jobId} result.`, undefined, 162);
       }
-
-      jobHasFailures = true
       if (continueOnFailure) {
         common.printError(`Warning ZWEL0164W: Job ${jobname}(${jobId}) ends with code ${jobcccode}.`);
       } else {

--- a/bin/libs/zos-jes.ts
+++ b/bin/libs/zos-jes.ts
@@ -18,7 +18,7 @@ import * as common from './common';
 import * as stringlib from './string';
 import * as shell from './shell';
 
-export function submitJob(jclFileOrContent: string, printJobDebug:boolean=true, jclIsContent?:boolean): string|undefined {
+export function submitJob(jclFileOrContent: string, printJobDebug: boolean = true, jclIsContent?: boolean): string | undefined {
   if (printJobDebug) {
     common.printDebug(`- submit job ${jclFileOrContent}`);
 
@@ -39,7 +39,7 @@ export function submitJob(jclFileOrContent: string, printJobDebug:boolean=true, 
       common.printTrace(jclFileOrContent);
     }
   }
-  
+
   let cleanupFile = false;
   let jclFile: string = jclFileOrContent;
 
@@ -56,17 +56,17 @@ export function submitJob(jclFileOrContent: string, printJobDebug:boolean=true, 
   // cat seems to work more reliably. sometimes, submit by itself just says it cannot find a real dataset.
   const result = shell.execOutSync('sh', '-c', `cat "${stringlib.escapeDollar(jclFile)}" | submit 2>&1`);
   // expected: JOB JOB????? submitted from path '...'
-  const code=result.rc;
+  const code = result.rc;
 
   if (cleanupFile) {
     os.remove(jclFile);
   }
 
-  if (code==0) {
-    let jobidlines = result.out.split('\n').filter(line=>line.indexOf('submitted')!=-1);
+  if (code == 0) {
+    let jobidlines = result.out.split('\n').filter(line => line.indexOf('submitted') != -1);
     let jobid = jobidlines.length > 0 ? jobidlines[0].split(' ')[1] : undefined;
     if (!jobid) {
-      jobidlines = result.out.split('\n').filter(line=>line.indexOf('$HASP')!=-1);
+      jobidlines = result.out.split('\n').filter(line => line.indexOf('$HASP') != -1);
       jobid = jobidlines.length > 0 ? jobidlines[0].split(' ')[1] : undefined;
     }
     if (!jobid) {
@@ -98,95 +98,90 @@ export function submitJob(jclFileOrContent: string, printJobDebug:boolean=true, 
   }
 }
 
-export function waitForJob(jobid: string): {jobcctext?: string, jobcccode?: string, jobid?: string, jobname?: string, rc: number} {
-  let jobstatus;
-  let jobname;
-  let jobcctext;
-  let jobcccode;    
-  let is_jes3;
+/**
+ * Returns job name, completion code, and status. If we cannot retrieve the completion code, it is set to -1. 
+ * Callers should check both cc and status, as cc can be -1 when the job is in OUTPUT state (job cancelled).
+ * 
+ * @param jobId 
+ * @returns 
+ */
+function getJobStatus(jobId: string): { status: string, cc: string, name: string } {
+  const getStatusCmd = std.getenv('ZWE_zowe_runtimeDirectory') + `/bin/utils/zowex job vs ${jobId}`;
+  common.printDebug(`-- Running ${getStatusCmd}`);
+  const result = shell.execOutSync('sh', '-c', `${getStatusCmd} 2>&1 && echo '.'`);
+  let status = 'UNKNOWN';
+  let compCode = '';
+  let jobName = 'UNKNOWN';
+  result.out?.split('\n').forEach((line) => {
+    if (line.includes(jobId)) {
+      /*     
+      cout << job.jobid << " " << left << setw(10) << job.retcode << " " << job.jobname << " " << job.status << endl;
+
+      Sample outputs (only one such line returned with `zowex job vs`)
+      JOB05609 CANCELED   LONGJOB  OUTPUT
+      JOB05602 CC 0000    SOMEJB OUTPUT
+      TSU05611            USER1  ACTIVE
+      JOB05486            IEFBR14$ INPUT
+      */
+      const columns = line.split(/\s+/).reverse();
+      status = columns[0];
+      jobName = columns[1];
+      if (columns[2] !== jobId) {
+        compCode = columns[2];
+      }
+    }
+  })
+  return { status: status, cc: compCode, name: jobName };
+
+}
+
+export function waitForJob(jobid: string): { jobcccode?: string, jobid?: string, jobname?: string, rc: number } {
+  let jobstatus = '';
+  let jobname = '';
+  let jobcccode = '';
 
   common.printDebug(`- Wait for job ${jobid} completed, starting at ${new Date().toString()}.`);
   // wait for job to finish
   const timesSec = [1, 5, 10, 20, 30, 60, 100, 300, 500];
   for (let i = 0; i < timesSec.length; i++) {
-    jobcctext = undefined;
-    jobcccode = undefined;
-    jobname = undefined;
-    is_jes3 = false;
     const secs = timesSec[i];
     common.printTrace(`  * Wait for ${secs} seconds`);
-    os.sleep(secs*1000); 
-    
-    let result=zoslib.operatorCommand(`$D ${jobid},CC`);
-    // if it's JES3, we receive this:
-    // ...             ISF031I CONSOLE IBMUSER ACTIVATED
-    // ...            -$D JOB00132,CC
-    // ...  IBMUSER7   IEE305I $D       COMMAND INVALID
-    is_jes3=result.out ? result.out.match(new RegExp('\$D \+COMMAND INVALID')) : false;
-    if (is_jes3) {
-      common.printDebug(`  * JES3 identified`);
-      const show_jobid=jobid.substring(3);
-      result=zoslib.operatorCommand(`*I J=${show_jobid}`);
-      // $I J= gives ...
-      // ...            -*I J=00132
-      // ...  JES3       IAT8674 JOB BPXAS    (JOB00132) P=15 CL=A        OUTSERV(PENDING WTR)
-      // ...  JES3       IAT8699 INQUIRY ON JOB STATUS COMPLETE,       1 JOB  DISPLAYED
-      try {
-        jobname=result.out.split('\n').filter(line=>line.indexOf('IAT8674') != -1)[0].replace(new RegExp('^.*IAT8674 *JOB *', 'g'), '').split(' ')[0];
-      } catch (e) {
-
+    os.sleep(secs * 1000);
+    try {
+      const jobStatus = getJobStatus(jobid);
+      jobname = jobStatus.name;
+      jobstatus = jobStatus.status;
+      jobcccode = jobStatus.cc;
+      common.printTrace(`  * Job (${jobname}) status is ${jobstatus},RC=${jobcccode}`);
+      if (jobname.length === 0) {
+        throw new Error(`Couldn't find job for job id ${jobid}`);
       }
-      break;
-    } else {
-      // $DJ gives ...
-      // ... $HASP890 JOB(JOB1)      CC=(COMPLETED,RC=0)  <-- accept this value
-      // ... $HASP890 JOB(GIMUNZIP)  CC=()  <-- reject this value
-      try {
-        const hasplines = result.out.split('\n').filter(line => line.indexOf('$HASP890') != -1);
-        if (hasplines && hasplines.length > 0) {
-          const jobline = hasplines[0];
-          const nameIndex = jobline.indexOf('JOB(');
-          const ccIndex = jobline.indexOf('CC=(');
-          jobname = jobline.substring(nameIndex+4, jobline.indexOf(')', nameIndex));
-          const cc = jobline.substring(ccIndex+4, jobline.indexOf(')', ccIndex)).split(',');
-          jobcctext = cc[0];
-          if (cc.length > 1) {
-            const equalSplit = cc[1].split('=');
-            if (equalSplit.length > 1) {
-              jobcccode = equalSplit[1];
-            }
-          }
-          common.printTrace(`  * Job (${jobname}) status is ${jobcctext},RC=${jobcccode}`);
-          if ((jobcctext && jobcctext.length > 0) || (jobcccode && jobcccode.length > 0)) {
-            // job have CC state
-            break;
-          }
-        }
-      } catch (e) {
+      if (jobcccode.length > 0) {
+        // job have CC state
         break;
       }
+
+    } catch (e) {
+      common.printTrace(`. * Error trying to get job status: ${e}`);
+      break;
     }
   }
   common.printTrace(`  * Job status check done at ${new Date().toString()}.`);
-
-  if (jobcctext || jobcccode) {
-    common.printDebug(`  * Job (${jobname}) exits with code ${jobcccode} (${jobcctext}).`);
-    if (jobcccode == "0") {
-      return {jobcctext, jobcccode, jobname, rc: 0};
+  if (jobcccode) {
+    common.printDebug(`  * Job (${jobname}) exits with code ${jobcccode}.`);
+    if (Number(jobcccode) === 0) {
+      return { jobcccode, jobname, rc: 0 };
     } else {
-      // ${jobcccode} could be greater than 255
-      return {jobcctext, jobcccode, jobname, rc: 2};
+      // ${jobcccode} could be greater than 255 or text like "CANCELLED"
+      return { jobcccode, jobname, rc: 2 };
     }
-  } else if (is_jes3) {
-    common.printTrace(`  * Cannot determine job complete code. Please check job log manually.`);
-    return {jobcctext, jobcccode, jobname, rc: 0};
   } else {
-    common.printError(`  * Job (${jobname? jobname : jobid}) doesn't finish within max waiting period.`);
-    return {jobcctext, jobcccode, jobname, rc: 1};
+    common.printError(`  * Job (${jobname.length > 0 ? jobname : jobid}) doesn't finish within max waiting period.`);
+    return { jobcccode, jobname, rc: 1 };
   }
 }
 
-export function printAndHandleJcl(jclLocationOrContent: string, jobName: string, jcllib: string, prefix: string, removeJclOnFinish?: boolean, continueOnFailure?: boolean, jclIsContent?: boolean){
+export function printAndHandleJcl(jclLocationOrContent: string, jobName: string, jcllib: string, prefix: string, removeJclOnFinish?: boolean, continueOnFailure?: boolean, jclIsContent?: boolean) {
   const jclContents = jclIsContent ? jclLocationOrContent : shell.execOutSync('sh', '-c', `cat "${stringlib.escapeDollar(jclLocationOrContent)}" 2>&1`).out;
 
   let jobHasFailures = false;
@@ -201,27 +196,27 @@ export function printAndHandleJcl(jclLocationOrContent: string, jobName: string,
 
   let removeRc: number;
 
-  let jobId: string|undefined;
+  let jobId: string | undefined;
   if (!std.getenv('ZWE_CLI_PARAMETER_DRY_RUN') && !std.getenv('ZWE_CLI_PARAMETER_SECURITY_DRY_RUN')) {
     common.printMessage(`Submitting Job ${jobName}`);
-    jobId=submitJob(jclLocationOrContent, false, jclIsContent);
+    jobId = submitJob(jclLocationOrContent, false, jclIsContent);
     if (!jobId) {
-      jobHasFailures=true;
+      jobHasFailures = true;
       if (continueOnFailure) {
         common.printError(`Warning ZWEL0160W: Failed to run JCL ${jcllib}(${jobName})`);
-        jobId=undefined;
+        jobId = undefined;
       } else {
         if (removeJclOnFinish) {
           removeRc = os.remove(jclLocationOrContent);
         }
-          common.printErrorAndExit(`Error ZWEL0161E: Failed to run JCL ${jcllib}(${jobName}).`, undefined, 161);
+        common.printErrorAndExit(`Error ZWEL0161E: Failed to run JCL ${jcllib}(${jobName}).`, undefined, 161);
       }
     }
     common.printDebug(`- job id ${jobId}`);
 
-    let {jobcctext, jobcccode, jobname, rc} = waitForJob(jobId);
+    let { jobcccode, jobname, rc } = waitForJob(jobId);
     if (rc) {
-      jobHasFailures=true;
+      jobHasFailures = true;
       if (continueOnFailure) {
         common.printError(`Warning ZWEL0158W: Failed to find job ${jobId} result.`);
       } else {
@@ -230,15 +225,15 @@ export function printAndHandleJcl(jclLocationOrContent: string, jobName: string,
         }
         common.printErrorAndExit(`Error ZWEL0162E: Failed to find job ${jobId} result.`, undefined, 162);
       }
-    
-      jobHasFailures=true
+
+      jobHasFailures = true
       if (continueOnFailure) {
-        common.printError(`Warning ZWEL0164W: Job ${jobname}(${jobId}) ends with code ${jobcccode} (${jobcctext}).`);
+        common.printError(`Warning ZWEL0164W: Job ${jobname}(${jobId}) ends with code ${jobcccode}.`);
       } else {
         if (removeJclOnFinish) {
           removeRc = os.remove(jclLocationOrContent);
         }
-        common.printErrorAndExit(`Error ZWEL0163E: Job ${jobname}(${jobId}) ends with code ${jobcccode} (${jobcctext}).`, undefined, 163);
+        common.printErrorAndExit(`Error ZWEL0163E: Job ${jobname}(${jobId}) ends with code ${jobcccode}.`, undefined, 163);
       }
     }
     if (removeJclOnFinish) {

--- a/bin/libs/zos-jes.ts
+++ b/bin/libs/zos-jes.ts
@@ -106,7 +106,7 @@ export function submitJob(jclFileOrContent: string, printJobDebug: boolean = tru
  * @returns 
  */
 function getJobStatus(jobId: string): { status: string, cc: string, name: string } {
-  const getStatusCmd = std.getenv('ZWE_zowe_runtimeDirectory') + `/bin/utils/zowex job vs ${jobId}`;
+  const getStatusCmd = std.getenv('ZWE_zowe_runtimeDirectory') + `/bin/utils/zowex job vs ${jobId} --rfc`;
   common.printDebug(`-- Running ${getStatusCmd}`);
   const result = shell.execOutSync('sh', '-c', `${getStatusCmd} 2>&1 && echo '.'`);
   let status = 'UNKNOWN';
@@ -115,20 +115,20 @@ function getJobStatus(jobId: string): { status: string, cc: string, name: string
   result.out?.split('\n').forEach((line) => {
     if (line.includes(jobId)) {
       /*     
-      cout << job.jobid << " " << left << setw(10) << job.retcode << " " << job.jobname << " " << job.status << endl;
-
       Sample outputs (only one such line returned with `zowex job vs`)
-      JOB05609 CANCELED   LONGJOB  OUTPUT
-      JOB05602 CC 0000    SOMEJB OUTPUT
-      TSU05611            USER1  ACTIVE
-      JOB05486            IEFBR14$ INPUT
+      JOB05625,CC 0000,IEFBR14$,OUTPUT,J0005625SVSCJES2E131FBE0.......:
+      JOB05624,CC 0000,IEFBR14$,OUTPUT,J0005624SVSCJES2E131FBDF.......:
+      TSU05611,ABEND 222,USERABC,OUTPUT,T0005611SVSCJES2E131F631.......:
+      JOB05609,CANCELED,LONGJOB,OUTPUT,J0005609SVSCJES2E131ED16.......:
+      JOB05607,CANCELED,LONGJOB,OUTPUT,J0005607SVSCJES2E131ED14.......:
+      JOB05602,CC 0000,ATLJ0000,OUTPUT,J0005602SVSCJES2E131ED0F.......:
+      JOB05586,CC 0000,ATLJ0000,OUTPUT,J0005586SVSCJES2E131ECF4.......:
+      TSU05815,,USERABC,ACTIVE,T0005815SVSCJES2E132110A.......:
       */
-      const columns = line.split(/\s+/).reverse();
-      status = columns[0];
-      jobName = columns[1];
-      if (columns[2] !== jobId) {
-        compCode = columns[2];
-      }
+      const columns = line.split(',').reverse(); //TODO: commas should be safe, not legal jobname/correlator? how about user id?
+      status = columns[1];
+      jobName = columns[2];
+      compCode = columns[3];
     }
   })
   return { status: status, cc: compCode, name: jobName };
@@ -169,6 +169,12 @@ export function waitForJob(jobid: string): { jobcccode?: string, jobid?: string,
   common.printTrace(`  * Job status check done at ${new Date().toString()}.`);
   if (jobcccode.length > 0) {
     common.printDebug(`  * Job (${jobname}) exits with code ${jobcccode}.`);
+
+    if (jobcccode.startsWith('CC')) {
+      // Format: 'CC 0000'. We drop the CC from all responses
+      jobcccode = jobcccode.split(/\s+/)[1];
+    }
+
     if (Number(jobcccode) === 0) {
       return { jobcccode, jobname, rc: 0 };
     } else {

--- a/bin/libs/zos-jes.ts
+++ b/bin/libs/zos-jes.ts
@@ -111,7 +111,7 @@ function getJobStatus(jobId: string): { status: string, cc: string, name: string
   const result = shell.execOutSync('sh', '-c', `${getStatusCmd} 2>&1 && echo '.'`);
   let status = 'UNKNOWN';
   let compCode = '';
-  let jobName = 'UNKNOWN';
+  let jobName = '';
   result.out?.split('\n').forEach((line) => {
     if (line.includes(jobId)) {
       /*     

--- a/bin/libs/zos-jes.ts
+++ b/bin/libs/zos-jes.ts
@@ -99,8 +99,7 @@ export function submitJob(jclFileOrContent: string, printJobDebug: boolean = tru
 }
 
 /**
- * Returns job name, completion code, and status. If we cannot retrieve the completion code, it is set to -1. 
- * Callers should check both cc and status, as cc can be -1 when the job is in OUTPUT state (job cancelled).
+ * Returns job name, completion code, and status. If we cannot retrieve the completion code, it is set to the empty string. 
  * 
  * @param jobId 
  * @returns 
@@ -112,25 +111,27 @@ function getJobStatus(jobId: string): { status: string, cc: string, name: string
   let status = 'UNKNOWN';
   let compCode = '';
   let jobName = '';
-  result.out?.split('\n').forEach((line) => {
-    if (line.includes(jobId)) {
-      /*     
-      Sample outputs (only one such line returned with `zowex job vs`)
-      JOB05625,CC 0000,IEFBR14$,OUTPUT,J0005625SVSCJES2E131FBE0.......:
-      JOB05624,CC 0000,IEFBR14$,OUTPUT,J0005624SVSCJES2E131FBDF.......:
-      TSU05611,ABEND 222,USERABC,OUTPUT,T0005611SVSCJES2E131F631.......:
-      JOB05609,CANCELED,LONGJOB,OUTPUT,J0005609SVSCJES2E131ED16.......:
-      JOB05607,CANCELED,LONGJOB,OUTPUT,J0005607SVSCJES2E131ED14.......:
-      JOB05602,CC 0000,ATLJ0000,OUTPUT,J0005602SVSCJES2E131ED0F.......:
-      JOB05586,CC 0000,ATLJ0000,OUTPUT,J0005586SVSCJES2E131ECF4.......:
-      TSU05815,,USERABC,ACTIVE,T0005815SVSCJES2E132110A.......:
-      */
-      const columns = line.split(',').reverse(); //TODO: commas should be safe, not legal jobname/correlator? how about user id?
-      status = columns[1];
-      jobName = columns[2];
-      compCode = columns[3];
-    }
-  })
+  if (result.rc == 0) { // job not found rc=255, empty job rc=1
+    result.out?.split('\n').forEach((line) => {
+      if (line.includes(jobId)) {
+        /*     
+        Sample outputs (only one such line returned with `zowex job vs`)
+        JOB05625,CC 0000,IEFBR14$,OUTPUT,J0005625SVSCJES2E131FBE0.......:
+        JOB05624,CC 0000,IEFBR14$,OUTPUT,J0005624SVSCJES2E131FBDF.......:
+        TSU05611,ABEND 222,USERABC,OUTPUT,T0005611SVSCJES2E131F631.......:
+        JOB05609,CANCELED,LONGJOB,OUTPUT,J0005609SVSCJES2E131ED16.......:
+        JOB05607,CANCELED,LONGJOB,OUTPUT,J0005607SVSCJES2E131ED14.......:
+        JOB05602,CC 0000,ATLJ0000,OUTPUT,J0005602SVSCJES2E131ED0F.......:
+        JOB05586,CC 0000,ATLJ0000,OUTPUT,J0005586SVSCJES2E131ECF4.......:
+        TSU05815,,USERABC,ACTIVE,T0005815SVSCJES2E132110A.......:
+        */
+        const columns = line.split(',').reverse(); //TODO: commas should be safe, not legal jobname/correlator? how about user id?
+        status = columns[1];
+        jobName = columns[2];
+        compCode = columns[3];
+      }
+    })
+  }
   return { status: status, cc: compCode, name: jobName };
 
 }

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -12,7 +12,7 @@
   },
   "binaryDependencies": {
     "org.zowe.zowe-native-proto-tmp.server": {
-      "version": "0.0.1",
+      "version": "^0.0.1",
       "artifact": "*.pax.Z"
     },
     "org.zowe.zlux.zlux-core": {

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -12,7 +12,8 @@
   },
   "binaryDependencies": {
     "org.zowe.zowe-native-proto-tmp.server": {
-      "version": "^0.0.1",
+      "repository": "libs-snapshot-local",
+      "version": "0.0.1",
       "artifact": "*.pax.Z"
     },
     "org.zowe.zlux.zlux-core": {

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -11,8 +11,8 @@
     "timestamp": "{BUILD_TIMESTAMP}"
   },
   "binaryDependencies": {
-    "org.zowe.zowe-native-proto.Server": {
-      "version": "Nightly",
+    "org.zowe.zowe-native-proto-tmp.server": {
+      "version": "0.0.1",
       "artifact": "*.pax.Z"
     },
     "org.zowe.zlux.zlux-core": {

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -11,10 +11,9 @@
     "timestamp": "{BUILD_TIMESTAMP}"
   },
   "binaryDependencies": {
-    "org.zowe.zowe-native-proto-tmp.server": {
-      "repository": "libs-snapshot-local",
-      "version": "0.0.1",
-      "artifact": "*.pax.Z"
+    "org.zowe.zowe-native-proto": {
+      "version": "0.1.3",
+      "artifact": "zowe-server-*.pax.Z"
     },
     "org.zowe.zlux.zlux-core": {
       "version": "^3.0.0-V3.X-STAGING-ZLUX-CORE",

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -11,6 +11,10 @@
     "timestamp": "{BUILD_TIMESTAMP}"
   },
   "binaryDependencies": {
+    "org.zowe.zowe-native-proto.Server": {
+      "version": "Nightly",
+      "artifact": "*.pax.Z"
+    },
     "org.zowe.zlux.zlux-core": {
       "version": "^3.0.0-V3.X-STAGING-ZLUX-CORE",
       "artifact": "*.pax"
@@ -132,7 +136,14 @@
     }
   },
   "sourceDependencies": [
-   {
+    {
+     "componentGroup": "Zowex Native Tools",
+     "entries": [{
+        "repository": "zowe-native-proto",
+        "tag": "main",
+        "destinations": ["Zowe PAX"]
+     }]
+    }, {
       "componentGroup": "Zowe API Mediation Layer",
       "entries": [{
         "repository": "api-layer",

--- a/tests/zwe-remote-integration/jest.config.ts
+++ b/tests/zwe-remote-integration/jest.config.ts
@@ -35,7 +35,7 @@ const config: Config = {
       },
     ],
   ],
-  testTimeout: 120000,
+  testTimeout: 160000,
   transform: {
     '^.+\\.(t|j)sx?$': ['ts-jest', { isolatedModules: true }],
   },

--- a/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/generate.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/generate.test.ts.snap
@@ -1091,3 +1091,228 @@ noverbose -
 JCL not submitted, command run with "--dry-run" flag.
 To perform command, re-run command without "--dry-run" flag, or submit the JCL directly."
 `;
+
+exports[`init-generate FLAKY interrupt generate commands 1`] = `
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+Template JCL: TEST.DATASET.PFX.SZWESAMP(ZWEGENER)
+--- JCL content ---
+//ZWEGENER JOB
+//*
+//* This program and the accompanying materials are made available
+//* under the terms of the Eclipse Public License v2.0 which
+//* accompanies this distribution, and is available at
+//* https://www.eclipse.org/legal/epl-v20.html
+//*
+//* SPDX-License-Identifier: EPL-2.0
+//*
+//* Copyright Contributors to the Zowe Project. 2020, 2020
+//*
+//*********************************************************************
+//*
+//* This job is responsible for generating other jobs required
+//* to configure Zowe.
+//*
+//* The method of validating your configuration is using
+//* JSON Schema <https://json-schema.org>. Zowe provides
+//* the ConfigMgr to assist in this. This job will invoke
+//* the ConfigMgr to validate your current configuration
+//* before generating any jobs. If there are any values
+//* that are incorrect, you will be notified. You should
+//* fix the value and then run this job again. You can run
+//* this job as many times as you need.
+//*
+//* Configmgr documentation:
+//* https://docs.zowe.org/stable/user-guide/configmgr-using
+//*
+//* Note: Any string with braces has an associated yaml value
+//*       in one of the yaml definitions for Zowe.
+//*       You must find the value and substitute it.
+//*
+//*       {key} -> value
+//*
+//GENER    EXEC PGM=IKJEFT1B
+//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=VIO,
+//   DCB=(RECFM=FB,LRECL=80,BLKSIZE=3120,DSORG=PO),
+//   SPACE=(3120,(20,5,10))
+//*
+//* Replace TEST.DATASET.PFX with the
+//* Value as seen in zowe.yaml
+//*
+//SYSPROC  DD DSN=TEST.DATASET.PFX.SZWEEXEC,DISP=SHR
+//*
+//* Replace TEST.DATASET.PFX with the
+//* Value as seen in zowe.yaml
+//*
+//STEPLIB  DD DSN=TEST.DATASET.PFX.SZWELOAD,DISP=SHR
+//ISPPLIB  DD DSN=ISP.SISPPENU,DISP=SHR
+//ISPMLIB  DD DSN=ISP.SISPMENU,DISP=SHR
+//ISPTLIB  DD DSN=ISP.SISPTENU,DISP=SHR
+//ISPSLIB  DD DSN=ISP.SISPSENU,DISP=SHR
+//ISPLOG   DD UNIT=SYSDA,SPACE=(CYL,(10,1,1),RLSE),
+//   DCB=(RECFM=VA,LRECL=125,BLKSIZE=129)
+//*
+//* The order must be as follows.
+//*
+//* zowe-yaml-schema.json
+//* server-common.json
+//*
+//* Replace /test/dir with where your Zowe run time
+//* directory is, as seen in zowe.yaml
+//*
+//MYSCHEMA DD   *,DLM=$$
+FILE /test/dir/schemas/zowe-yaml-schema.json
+FILE /test/dir/schemas/server-common.json
+$$
+//*
+//* The DD below must include one or more FILE or PARMLIB
+//* entries. The lower entries have their values
+//* overridden by the higher entries.
+//*
+//* Ex. PARMLIB MY.ZOWE.CUSTOM.PARMLIB(YAML)
+//*     FILE /some/other/zowe.yaml
+//MYCONFIG DD   *,DLM=$$
+FILE /test/dir/zowe.test.yaml
+$$
+//CMGROUT  DD   SYSOUT=*
+//SYSPRINT DD   SYSOUT=*
+//SYSTSPRT DD   SYSOUT=*
+//*
+//* Change 'generate' to 'nogenerate' if you only
+//* want to validate your configuration. The default
+//* option, 'generate', will validate and then generate
+//* jobs based on your configuration.
+//*
+//*   - generate
+//*   - nogenerate
+//*
+//* Change 'noverbose' to 'verbose' below for
+//* advanced logging. This is not needed unless
+//* there is an error.
+//*
+//*   - verbose
+//*   - noverbose
+//*
+//SYSTSIN  DD   *
+ISPSTART CMD(%ZWEGEN00 -
+generate -
+noverbose -
+)
+--- End of JCL ---
+Submitting Job ZWEGENER
+ERROR:   * Job (JOB00000) doesn't finish within max waiting period.
+Job ZWEGENER(JOB00000) completed with RC=1
+Zowe JCL generated with errors, check job log. Job completion code=."
+`;
+
+exports[`init-generate FLAKY interrupt generate commands 2`] = `
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+Template JCL: TEST.DATASET.PFX.SZWESAMP(ZWEGENER)
+--- JCL content ---
+//ZWEGENER JOB
+//*
+//* This program and the accompanying materials are made available
+//* under the terms of the Eclipse Public License v2.0 which
+//* accompanies this distribution, and is available at
+//* https://www.eclipse.org/legal/epl-v20.html
+//*
+//* SPDX-License-Identifier: EPL-2.0
+//*
+//* Copyright Contributors to the Zowe Project. 2020, 2020
+//*
+//*********************************************************************
+//*
+//* This job is responsible for generating other jobs required
+//* to configure Zowe.
+//*
+//* The method of validating your configuration is using
+//* JSON Schema <https://json-schema.org>. Zowe provides
+//* the ConfigMgr to assist in this. This job will invoke
+//* the ConfigMgr to validate your current configuration
+//* before generating any jobs. If there are any values
+//* that are incorrect, you will be notified. You should
+//* fix the value and then run this job again. You can run
+//* this job as many times as you need.
+//*
+//* Configmgr documentation:
+//* https://docs.zowe.org/stable/user-guide/configmgr-using
+//*
+//* Note: Any string with braces has an associated yaml value
+//*       in one of the yaml definitions for Zowe.
+//*       You must find the value and substitute it.
+//*
+//*       {key} -> value
+//*
+//GENER    EXEC PGM=IKJEFT1B
+//ISPPROF  DD   DSN=,DISP=(NEW,DELETE),UNIT=VIO,
+//   DCB=(RECFM=FB,LRECL=80,BLKSIZE=3120,DSORG=PO),
+//   SPACE=(3120,(20,5,10))
+//*
+//* Replace TEST.DATASET.PFX with the
+//* Value as seen in zowe.yaml
+//*
+//SYSPROC  DD DSN=TEST.DATASET.PFX.SZWEEXEC,DISP=SHR
+//*
+//* Replace TEST.DATASET.PFX with the
+//* Value as seen in zowe.yaml
+//*
+//STEPLIB  DD DSN=TEST.DATASET.PFX.SZWELOAD,DISP=SHR
+//ISPPLIB  DD DSN=ISP.SISPPENU,DISP=SHR
+//ISPMLIB  DD DSN=ISP.SISPMENU,DISP=SHR
+//ISPTLIB  DD DSN=ISP.SISPTENU,DISP=SHR
+//ISPSLIB  DD DSN=ISP.SISPSENU,DISP=SHR
+//ISPLOG   DD UNIT=SYSDA,SPACE=(CYL,(10,1,1),RLSE),
+//   DCB=(RECFM=VA,LRECL=125,BLKSIZE=129)
+//*
+//* The order must be as follows.
+//*
+//* zowe-yaml-schema.json
+//* server-common.json
+//*
+//* Replace /test/dir with where your Zowe run time
+//* directory is, as seen in zowe.yaml
+//*
+//MYSCHEMA DD   *,DLM=$$
+FILE /test/dir/schemas/zowe-yaml-schema.json
+FILE /test/dir/schemas/server-common.json
+$$
+//*
+//* The DD below must include one or more FILE or PARMLIB
+//* entries. The lower entries have their values
+//* overridden by the higher entries.
+//*
+//* Ex. PARMLIB MY.ZOWE.CUSTOM.PARMLIB(YAML)
+//*     FILE /some/other/zowe.yaml
+//MYCONFIG DD   *,DLM=$$
+FILE /test/dir/zowe.test.yaml
+$$
+//CMGROUT  DD   SYSOUT=*
+//SYSPRINT DD   SYSOUT=*
+//SYSTSPRT DD   SYSOUT=*
+//*
+//* Change 'generate' to 'nogenerate' if you only
+//* want to validate your configuration. The default
+//* option, 'generate', will validate and then generate
+//* jobs based on your configuration.
+//*
+//*   - generate
+//*   - nogenerate
+//*
+//* Change 'noverbose' to 'verbose' below for
+//* advanced logging. This is not needed unless
+//* there is an error.
+//*
+//*   - verbose
+//*   - noverbose
+//*
+//SYSTSIN  DD   *
+ISPSTART CMD(%ZWEGEN00 -
+generate -
+noverbose -
+)
+--- End of JCL ---
+Submitting Job ZWEGENER
+Job ZWEGENER(JOB00000) completed with RC=2
+Zowe JCL generated with errors, check job log. Job completion code=CANCELED."
+`;

--- a/tests/zwe-remote-integration/src/__tests__/init/generate.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/init/generate.test.ts
@@ -16,6 +16,7 @@ import { FileType, TestFileActions, TestFile } from '../../zos/TestFileActions';
 import * as fs from 'fs-extra';
 import * as _ from 'lodash';
 import path from 'path';
+import { sleep } from '../../utils';
 
 const testSuiteName = 'init-generate';
 describe(`${testSuiteName}`, () => {
@@ -185,9 +186,45 @@ describe(`${testSuiteName}`, () => {
     });
   });
 
+  describe('FLAKY', () => {
+    it('interrupt generate commands', async () => {
+      // First case: cancel and purge
+
+      // we have ~30 seconds to cancel the running job
+      let deferredResult = testRunner.runZweTest(cfgYaml, 'init generate --allow-overwrite');
+      // wait for zwegener to be submitted
+      await sleep(6000);
+      // TODO: this can capture other ZWEGENER tasks running on the system? change jcl name before submission?
+      let jobid = await testRunner.runRaw(
+        `./bin/utils/zowex job list --rfc | awk -F, 'match($3, "ZWEGENER") && match($4, "ACTIVE") { print $1 }'`,
+      );
+      let runningJob = jobid.stdout.trim();
+      console.log(`Found running job: ${runningJob}`);
+      await testRunner.runRaw(`./bin/utils/zowex job cancel ${runningJob}`);
+      await testRunner.runRaw(`./bin/utils/zowex job delete ${runningJob}`);
+      let genResult = await deferredResult;
+      expect(genResult.cleanedStdout).toMatchSnapshot();
+
+      // Second case: cancel
+
+      deferredResult = testRunner.runZweTest(cfgYaml, 'init generate --allow-overwrite');
+      // wait for zwegener to be submitted
+      await sleep(6000);
+      // TODO: this can capture other ZWEGENER tasks running on the system? change jcl name before submission?
+      jobid = await testRunner.runRaw(
+        `./bin/utils/zowex job list --rfc | awk -F, 'match($3, "ZWEGENER") && match($4, "ACTIVE") { print $1 }'`,
+      );
+      runningJob = jobid.stdout.trim();
+      console.log(`Found running job: ${runningJob}`);
+      await testRunner.runRaw(`./bin/utils/zowex job cancel ${runningJob}`);
+      genResult = await deferredResult;
+      expect(genResult.cleanedStdout).toMatchSnapshot();
+    });
+  });
+
   describe('(LONG)', () => {
     it('jcllib updates: jcl header single line', async () => {
-      const header = `'SOMEJOB',REGION=0M`;
+      const header = `'SOMEJOB', REGION = 0M`;
       _.set(cfgYaml, 'zowe.setup.jcl.header', header);
       const result = await testRunner.runZweTest(cfgYaml, 'init generate');
       expect(result.stdout).not.toBeNull();
@@ -213,7 +250,7 @@ describe(`${testSuiteName}`, () => {
     });
 
     it('jcllib updates: jcl header multi line', async () => {
-      const jclLines = [`'SOMEJOB',`, `//   REGION=0M`, `//* atestcomment`, '//* secondtestcomment'];
+      const jclLines = [`'SOMEJOB', `, `//   REGION=0M`, `//* atestcomment`, '//* secondtestcomment'];
       _.set(cfgYaml, 'zowe.setup.jcl.header', jclLines);
       const result = await testRunner.runZweTest(cfgYaml, 'init generate');
       expect(result.stdout).not.toBeNull();

--- a/tests/zwe-remote-integration/src/globalSetup.ts
+++ b/tests/zwe-remote-integration/src/globalSetup.ts
@@ -195,6 +195,11 @@ module.exports = async () => {
       await downloadManifestDep('org.zowe.getesm');
     }
 
+    await downloadArtifact(
+      'libs-snapshot-local',
+      'org/zowe/zowe-native-proto/Server/Nightly',
+      'zowe-server-0.1.2-2025-07-15-013657.pax.Z',
+    );
     await downloadArtifact('libs-snapshot-local', 'org/zowe/vtl-cli/zowe-cli-package/1.0.7-SNAPSHOT', 'vtl.tar.gz');
 
     const downloadsDirContents = fs.readdirSync(downloadsDir);
@@ -226,7 +231,12 @@ module.exports = async () => {
 
     const vtlArchive = downloadsDirContents.find((item) => /vtl.tar.gz/g.test(item));
     if (vtlArchive == null) {
-      throw new Error('Could not locate zowe-utility-tools zip in the .build directory');
+      throw new Error('Could not locate vtl tar in the .build directory');
+    }
+
+    const zowexArchive = downloadsDirContents.find((item) => /zowe-server.*pax.Z/g.test(item));
+    if (zowexArchive == null) {
+      throw new Error('Could not locate zowex archive in the .build directory');
     }
 
     const getEsmArchive = downloadsDirContents.find((item) => /getesm.*.pax/g.test(item));
@@ -293,6 +303,11 @@ module.exports = async () => {
 
     console.log(`Uploading ${launcherPax} to ${ussWorkDir}/launcher.pax ...`);
     await files.Upload.fileToUssFile(zosmfSession, path.resolve(downloadsDir, launcherPax), `${ussWorkDir}/launcher.pax`, {
+      binary: true,
+    });
+
+    console.log(`Uploading ${zowexArchive} to ${ussWorkDir}/zowex.pax.Z ...`);
+    await files.Upload.fileToUssFile(zosmfSession, path.resolve(downloadsDir, zowexArchive), `${ussWorkDir}/zowex.pax.Z`, {
       binary: true,
     });
 
@@ -439,6 +454,10 @@ module.exports = async () => {
       await uss.runCommand(`cp -X ${pgm} "//'${REMOTE_SYSTEM_INFO.szweload}(${pgm})'"`, ussWorkDir);
       await uss.runCommand(`cp ${pgm} ${REMOTE_SYSTEM_INFO.ussTestDir}/files/SZWELOAD`, ussWorkDir);
     }
+
+    console.log(`Unpacking zowex pax and placing zowex in utils directory ... `);
+    await uss.runCommand(`pax -ppx -rf zowex.pax.Z`, ussWorkDir);
+    await uss.runCommand(`cp -f ${ussWorkDir}/zowex ${REMOTE_SYSTEM_INFO.ussTestDir}/bin/utils`);
 
     console.log(`Unpacking zss pax and placing SAMPLIB in ${REMOTE_SYSTEM_INFO.szwesamp} ...`);
     await uss.runCommand(`mkdir -p ${REMOTE_SYSTEM_INFO.ussTestDir}/components/zss`);


### PR DESCRIPTION
This PR replaces SDSF usage in the `zos-jes.ts` module with `zowex`, which uses SSI function code 80 to obtain jobs information.

Notable changes:
*  [Zowe Native Proto Server Side](https://github.com/zowe/zowe-native-proto/#architecture) is part of the PAX build and placed in `bin/utils`. `zowex` is copied over, while `zoweax` and `zowed` are not (for now). They may be used in the future.
* Job completion text is not available in the `zowex job vs` output today and is removed. This was mostly a footnote on some job submission logging.
* As a byproduct of this change, JES3 should work since it also supports SSI 80.

Todo:
* ~~Validation of PAX build~~ Includes `zowex`, CICD test failures are the known APIML ones in staging
* ~~Testing / Snapshot updates~~ No updates, log changes were in debug logs which aren't captured in tests. All `ZWE` tests passing.
* ~~Better to delete `zowed` and `zoweax`?~~ Not copied over
* ~~Edge-case test: what if a submitted job is cancelled and purged before `zowex job vs` is run?~~ Done. Marked as a FLAKY test so it won't run with CI/CD, but the snapshot is there and the behavior was correct.
* ~~CLI Squad will produce a formal release of zowe-native-proto for us. I copied a nightly build for this PR into a temporary folder on Artifactory.~~ Done