### PR TITLE
Schema validation: allow null/empty strings as in Zowe 3.2.0

### DIFF
--- a/bin/commands/init/generate/.help
+++ b/bin/commands/init/generate/.help
@@ -67,7 +67,7 @@ The above datasets can be run to set up a Zowe instance.
 You can also use `zwe init` or `zwe init` subcommands to have them run automatically.
 
 JCL JOB statement customization:
-- Each JOB statement is defined as `//ZWEnnnnn JOB {zowe.setup.jcl.header}`, where `nnnnn` identifies each job
+- Each JOB statement is defined as `//ZWEnnnnn JOB {zowe.setup.jcl.header}`, where `nnnnn` identifies the job
 - Default setting is empty string causing no additional JOB fields will be used - if your site or External Security Manager does not require additional fields, you can skip this
 - Otherwise you can use `zwe init generate` to set additional JOB fields
 - Note: JCL syntax is not checked by `zwe init generate` command

--- a/bin/commands/init/mvs/index.ts
+++ b/bin/commands/init/mvs/index.ts
@@ -27,9 +27,9 @@ export function execute(allowOverwrite?: boolean) {
     common.printErrorAndExit(`Error ZWEL0157E: Zowe dataset prefix (zowe.setup.dataset.prefix) is not defined in Zowe YAML configuration file.`, undefined, 157);
   }
 
-  const zssEnabled = ZOWE_CONFIG.components.zss.enabled;  // In defaults, this property is always defined
+  // For V4: if components.zss.enabled = false => no need to create parmlib
   const parmlib = ZOWE_CONFIG.zowe.setup?.dataset?.parmlib ? ZOWE_CONFIG.zowe.setup.dataset.parmlib : undefined;
-  if (zssEnabled && parmlib == undefined) {
+  if (!parmlib) {
       common.printErrorAndExit(`Error ZWEL0157E: zowe.setup.dataset.parmlib is not defined in Zowe YAML configuration file.`, undefined, 157);
   }
 

--- a/bin/commands/init/stc/index.ts
+++ b/bin/commands/init/stc/index.ts
@@ -50,12 +50,20 @@ export function execute(allowOverwrite: boolean = false) {
     return common.printErrorAndExit(`Error ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL ${prefix}.SZWESAMP(ZWEGENER) before running this command.`, undefined, 319);
   }
 
-  // zowe.setup.security.stcs.* defined in defaults
-  const security_stcs_zowe = ZOWE_CONFIG.zowe.setup.security.stcs.zowe;
-  const security_stcs_zis = ZOWE_CONFIG.zowe.setup.security.stcs.zis;
-  const security_stcsAux = ZOWE_CONFIG.zowe.setup.security.stcs.aux;
+  let stcZowe = ZOWE_CONFIG.zowe.setup.security.stcs.zowe;
+  if (!stcZowe) {
+    stcZowe = 'ZWESLSTC';
+  }
+  let stcZis = ZOWE_CONFIG.zowe.setup.security.stcs.zis;
+  if (!stcZis) {
+    stcZis = 'ZWESISTC';
+  }
+  let stcAux = ZOWE_CONFIG.zowe.setup.security.stcs.aux;
+  if (!stcAux) {
+    stcAux = 'ZWESASTC';
+  }
 
-  [security_stcs_zowe, security_stcs_zis, security_stcsAux].forEach((mb: string) => {
+  [stcZowe, stcZis, stcAux].forEach((mb: string) => {
     // STCs in target proclib
     if (zosdataset.isDatasetExists(`${proclib}(${mb})`)) {
       stcExistence = true;
@@ -79,7 +87,6 @@ export function execute(allowOverwrite: boolean = false) {
     const DEFAULT_CMS_NAME = 'ZWESIS_STD';
     // zis and crossMemoryServerName are in defaults
     const zisSuffix = ZOWE_CONFIG.zowe.setup.dataset.parmlibMembers.zis.substring(6);
-    // There is no schema validation (at this point) for crossMemoryServerName as it is in components
     // Check and take string or use defaults
     const cmsName = typeof ZOWE_CONFIG.components.zss.crossMemoryServerName === "string" ? ZOWE_CONFIG.components.zss.crossMemoryServerName.substring(0, 16) : DEFAULT_CMS_NAME;
     if (stcExistence == true) {

--- a/bin/commands/install/.help
+++ b/bin/commands/install/.help
@@ -15,9 +15,32 @@ zowe:
       prefix: IBMUSER.ZWE
 ```
 
-Expected outputs:
+- `zowe.setup.jcl.header` controls the JOB header parameters for `ZWEINSTL` JCL sample.
+Default setting is empty string causing no additional JOB fields will be used.
+Is is optional, if your site or External Security Manager does not require additional fields.
 
-- Will create these data sets under `zowe.setup.dataset.prefix` definition:
+One line, for example accounting information only:
+```yaml
+zowe:
+  setup:
+    jcl:
+      header: 123456
+```
+
+Multiple lines as an array:
+```yaml
+zowe:
+  setup:
+    jcl:
+      header:
+        - "123456,"
+        - "//       'Zowe User',"
+        - "//       NOTIFY=&SYSUID"
+```
+
+Note: the JCL syntax in not check by `zwe` command.
+
+- `zowe.setup.dataset.prefix` shows where the datasets will be installed:
   * `SZWEAUTH` contains few Zowe load modules (++PROGRAM).
   * `SZWESAMP` contains several sample configurations.
   * `SZWEEXEC` contains few utilities used by Zowe.

--- a/files/SZWEEXEC/ZWEGEN00
+++ b/files/SZWEEXEC/ZWEGEN00
@@ -279,6 +279,70 @@ say 'The 'output.0' members in 'jclCopy' have been recorded.'
 
 /*
 ================================================================================
+    Set defaults - user defined empty/null values will overwrite the defaults
+      defined in "zowe.runtimeDirectory/files/defaults.yaml".
+      It needs to be restored for such case.
+================================================================================
+*/
+
+say 'Setting the defaults values.'
+
+if isNullEmpty(CFG.zowe.setup.dataset.authLoadlib) then do
+  CFG.zowe.setup.dataset.authLoadlib = CFG.zowe.setup.dataset.prefix'.SZWEAUTH'
+  dbgTxt = 'zowe.setup.dataset.authLoadlib = '
+  call Print dbgTxt||CFG.zowe.setup.dataset.authLoadlib
+end
+
+if isNullEmpty(CFG.zowe.setup.security.groups.admin) then do
+  CFG.zowe.setup.security.groups.admin = 'ZWEADMIN'
+  dbgTxt = 'zowe.setup.security.groups.admin = '
+  call Print dbgTxt||CFG.zowe.setup.security.groups.admin
+end
+
+if isNullEmpty(CFG.zowe.setup.security.groups.stc) then do
+  CFG.zowe.setup.security.groups.stc = 'ZWEADMIN'
+  dbgTxt = 'zowe.setup.security.groups.stc = '
+  call Print dbgTxt||CFG.zowe.setup.security.groups.stc
+end
+
+if isNullEmpty(CFG.zowe.setup.security.groups.sysProg) then do
+  CFG.zowe.setup.security.groups.sysProg = 'ZWEADMIN'
+  dbgTxt = 'zowe.setup.security.groups.sysProg = '
+  call Print dbgTxt||CFG.zowe.setup.security.groups.sysProg
+end
+
+if isNullEmpty(CFG.zowe.setup.security.users.zowe) then do
+  CFG.zowe.setup.security.users.zowe = 'ZWESVUSR'
+  dbgTxt = 'zowe.setup.security.users.zowe = '
+  call Print dbgTxt||CFG.zowe.setup.security.users.zowe
+end
+
+if isNullEmpty(CFG.zowe.setup.security.users.zis) then do
+  CFG.zowe.setup.security.users.zis = 'ZWESIUSR'
+  dbgTxt = 'zowe.setup.security.users.zis = '
+  call Print dbgTxt||CFG.zowe.setup.security.users.zis
+end
+
+if isNullEmpty(CFG.zowe.setup.security.stcs.zowe) then do
+  CFG.zowe.setup.security.stcs.zowe = 'ZWESLSTC'
+  dbgTxt = 'zowe.setup.security.stcs.zowe = '
+  call Print dbgTxt||CFG.zowe.setup.security.stcs.zowe
+end
+
+if isNullEmpty(CFG.zowe.setup.security.stcs.zis) then do
+  CFG.zowe.setup.security.stcs.zis = 'ZWESISTC'
+  dbgTxt = 'zowe.setup.security.stcs.zis = '
+  call Print dbgTxt||CFG.zowe.setup.security.stcs.zis
+end
+
+if isNullEmpty(CFG.zowe.setup.security.stcs.aux) then do
+  CFG.zowe.setup.security.stcs.aux = 'ZWESASTC'
+  dbgTxt = 'zowe.setup.security.stcs.aux = '
+  call Print dbgTxt||CFG.zowe.setup.security.stcs.aux
+end
+
+/*
+================================================================================
     Read each member record by record and store the substitutions required
     for use later when the edit macro is invoked.
 ================================================================================
@@ -1021,6 +1085,22 @@ CheckInput: procedure
   end
 
   return parmReturn
+
+/*
+================================================================================
+  isNullEmpty(yamlKey)
+    Note: This check is not able to determine,
+          if '<NULL>' is text or was originally YAML null value!
+================================================================================
+*/
+isNullEmpty: procedure
+
+  yamlKey = ARG(1)
+
+  if yamlKey = '' | yamlKey = '<NULL>' then
+    return 1
+
+  return 0
 
 /*
 ================================================================================

--- a/files/SZWEEXEC/ZWEGEN00
+++ b/files/SZWEEXEC/ZWEGEN00
@@ -281,7 +281,7 @@ say 'The 'output.0' members in 'jclCopy' have been recorded.'
 ================================================================================
 */
 
-say 'Setting the defaults values.'
+say 'Setting the default values.'
 
 if isNullEmpty(CFG.zowe.setup.dataset.authLoadlib) then do
   CFG.zowe.setup.dataset.authLoadlib = CFG.zowe.setup.dataset.prefix'.SZWEAUTH'

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -21,15 +21,39 @@
               "description": "MVS data set related configurations",
               "properties": {
                 "prefix": {
-                  "$ref": "/schemas/v2/server-common#zoweDatasetPrefix",
+                  "oneOf": [
+                    {
+                      "$ref": "/schemas/v2/server-common#zoweDatasetPrefix"
+                    },
+                    {
+                      "type": "string",
+                      "maxLength": 0
+                    }
+                  ],
                   "description": "Where Zowe MVS data sets will be installed"
                 },
                 "proclib": {
-                  "$ref": "/schemas/v2/server-common#zoweDataset",
+                  "oneOf": [
+                    {
+                      "$ref": "/schemas/v2/server-common#zoweDataset"
+                    },
+                    {
+                      "type": "string",
+                      "maxLength": 0
+                    }
+                  ],
                   "description": "PROCLIB where Zowe STCs will be copied over"
                 },
                 "parmlib": {
-                  "$ref": "/schemas/v2/server-common#zoweDataset",
+                  "oneOf": [
+                    {
+                      "$ref": "/schemas/v2/server-common#zoweDataset"
+                    },
+                    {
+                      "type": "string",
+                      "maxLength": 0
+                    }
+                  ],
                   "description": "Zowe PARMLIB"
                 },
                 "parmlibMembers": {
@@ -44,21 +68,53 @@
                   }
                 },
                 "jcllib": {
-                  "$ref": "/schemas/v2/server-common#zoweDataset",
+                  "oneOf": [
+                    {
+                      "$ref": "/schemas/v2/server-common#zoweDataset"
+                    },
+                    {
+                      "type": "string",
+                      "maxLength": 0
+                    }
+                  ],
                   "description": "JCL library where Zowe will store temporary JCLs during initialization"
                 },
                 "loadlib": {
-                  "$ref": "/schemas/v2/server-common#zoweDataset",
+                  "oneOf": [
+                    {
+                      "$ref": "/schemas/v2/server-common#zoweDataset"
+                    },
+                    {
+                      "type": "string",
+                      "maxLength": 0
+                    }
+                  ],
                   "description": "States the dataset where Zowe executable utilities are located",
                   "default": "<hlq>.SZWELOAD"
                 },
                 "authLoadlib": {
-                  "$ref": "/schemas/v2/server-common#zoweDataset",
+                  "oneOf": [
+                    {
+                      "$ref": "/schemas/v2/server-common#zoweDataset"
+                    },
+                    {
+                      "type": "string",
+                      "maxLength": 0
+                    }
+                  ],
                   "description": "The dataset that contains any Zowe core code that needs to run APF-authorized, such as ZIS",
                   "default": "<hlq>.SZWEAUTH"
                 },
                 "authPluginLib": {
-                  "$ref": "/schemas/v2/server-common#zoweDataset",
+                  "oneOf": [
+                    {
+                      "$ref": "/schemas/v2/server-common#zoweDataset"
+                    },
+                    {
+                      "type": "string",
+                      "maxLength": 0
+                    }
+                  ],
                   "description": "APF authorized LOADLIB for Zowe ZIS Plugins"
                 }
               }
@@ -103,17 +159,41 @@
                   "description": "security group name",
                   "properties": {
                     "admin": {
-                      "$ref": "/schemas/v2/server-common#zoweUser",
+                      "oneOf": [
+                        {
+                          "$ref": "/schemas/v2/server-common#zoweUser"
+                        },
+                        {
+                          "type": "string",
+                          "maxLength": 0
+                        }
+                      ],
                       "description": "Zowe admin user group",
                       "default": "ZWEADMIN"
                     },
                     "stc": {
-                      "$ref": "/schemas/v2/server-common#zoweUser",
+                      "oneOf": [
+                        {
+                          "$ref": "/schemas/v2/server-common#zoweUser"
+                        },
+                        {
+                          "type": "string",
+                          "maxLength": 0
+                        }
+                      ],
                       "description": "Zowe STC group",
                       "default": "ZWEADMIN"
                     },
                     "sysProg": {
-                      "$ref": "/schemas/v2/server-common#zoweUser",
+                      "oneOf": [
+                        {
+                          "$ref": "/schemas/v2/server-common#zoweUser"
+                        },
+                        {
+                          "type": "string",
+                          "maxLength": 0
+                        }
+                      ],
                       "description": "Zowe SysProg group",
                       "default": "ZWEADMIN"
                     }
@@ -125,12 +205,28 @@
                   "description": "security user name",
                   "properties": {
                     "zowe": {
-                      "$ref": "/schemas/v2/server-common#zoweUser",
+                      "oneOf": [
+                        {
+                          "$ref": "/schemas/v2/server-common#zoweUser"
+                        },
+                        {
+                          "type": "string",
+                          "maxLength": 0
+                        }
+                      ],
                       "description": "Zowe runtime user name of main service",
                       "default": "ZWESVUSR"
                     },
                     "zis": {
-                      "$ref": "/schemas/v2/server-common#zoweUser",
+                      "oneOf": [
+                        {
+                          "$ref": "/schemas/v2/server-common#zoweUser"
+                        },
+                        {
+                          "type": "string",
+                          "maxLength": 0
+                        }
+                      ],
                       "description": "Zowe runtime user name of ZIS",
                       "default": "ZWESIUSR"
                     }

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -238,17 +238,41 @@
                   "description": "STC names",
                   "properties": {
                     "zowe": {
-                      "$ref": "/schemas/v2/server-common#zoweDatasetMember",
+                      "oneOf": [
+                        {
+                          "$ref": "/schemas/v2/server-common#zoweDatasetMember"
+                        },
+                        {
+                          "type": "string",
+                          "maxLength": 0
+                        }
+                      ],
                       "description": "STC name of main service",
                       "default": "ZWESLSTC"
                     },
                     "zis": {
-                      "$ref": "/schemas/v2/server-common#zoweDatasetMember",
+                      "oneOf": [
+                        {
+                          "$ref": "/schemas/v2/server-common#zoweDatasetMember"
+                        },
+                        {
+                          "type": "string",
+                          "maxLength": 0
+                        }
+                      ],
                       "description": "STC name of ZIS",
                       "default": "ZWESISTC"
                     },
                     "aux": {
-                      "$ref": "/schemas/v2/server-common#zoweDatasetMember",
+                      "oneOf": [
+                        {
+                          "$ref": "/schemas/v2/server-common#zoweDatasetMember"
+                        },
+                        {
+                          "type": "string",
+                          "maxLength": 0
+                        }
+                      ],
                       "description": "STC name of Auxiliary Service",
                       "default": "ZWESASTC"
                     }

--- a/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/apfauth.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/apfauth.test.ts.snap
@@ -10,25 +10,19 @@ ERROR: ZWEL0143E Cannot find data set member 'BAD.DS.PREFIX.NOEXIST.SZWESAMP(ZWE
 `;
 
 exports[`init-apfauth (LONG) apf empty ds prefix 1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/prefix
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/prefix
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/prefix"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> APF authorize load libraries
+ERROR: ZWEL0157E: Zowe dataset prefix (zowe.setup.dataset.prefix) is not defined in Zowe YAML configuration file."
 `;
 
 exports[`init-apfauth (LONG) apf empty jcllib 1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/jcllib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/jcllib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/jcllib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> APF authorize load libraries
+ERROR: ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL TEST.DATASET.PFX.SZWESAMP(ZWEGENER) before running this command."
 `;
 
 exports[`init-apfauth (SHORT) apf bad authLoadLib 1`] = `
@@ -48,25 +42,65 @@ ERROR: ZWEL0324E: The dataset specified in 'zowe.setup.dataset.authPluginLib' do
 `;
 
 exports[`init-apfauth (SHORT) apf empty jcllib post-generate 1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/jcllib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/jcllib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/jcllib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> APF authorize load libraries
+ERROR: ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL TEST.DATASET.PFX.SZWESAMP(ZWEGENER) before running this command."
 `;
 
 exports[`init-apfauth (SHORT) apf empty pluginlib 1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/authPluginLib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/authPluginLib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/authPluginLib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> APF authorize load libraries
+ZWEL0159I: zowe.setup.dataset.authPluginLib is not defined in Zowe YAML configuration file. Skipping.
+Template JCL: TEST.DATASET.PFX.SZWESAMP(ZWEIAPF2) , Executable JCL: TEST.DATASET.PFX.JCLLIB(ZWEIAPF2)
+--- JCL Content ---
+//ZWEIAPF2 JOB
+//*
+//* This program and the accompanying materials are made available
+//* under the terms of the Eclipse Public License v2.0 which
+//* accompanies this distribution, and is available at
+//* https://www.eclipse.org/legal/epl-v20.html
+//*
+//* SPDX-License-Identifier: EPL-2.0
+//*
+//* Copyright Contributors to the Zowe Project. 2020, 2020
+//*
+//*********************************************************************
+//*
+//*  This JCL is used to set APF for the two datasets of Zowe
+//*  which need it. You can issue this, or use another
+//*  way to accomplish the task.
+//*
+//*  The following variables are derived from the zowe YAML config:
+//*  LOADLIB: the dataset that holds the APF portion of Zowe.
+//*    If not set, zowe.setup.dataset.prefix + SZWEAUTH is used.
+//*  PLUGLIB: the dataset that holds the extensions for ZIS.
+//*    If not set, no PLUGLIB authorization is done.
+//*
+//*  Note: if you plan NOT to use Zowe Cross Memory Server at all,
+//*    you can skip this step.
+//*
+//*********************************************************************
+//*
+//APFAUTH EXEC PGM=BPXBATCH
+//BPXPRINT DD SYSOUT=*
+//STDOUT   DD SYSOUT=*
+//STDERR   DD SYSOUT=*
+//STDPARM DD *
+SH cd '/test/dir' &&
+cd bin/utils &&
+LOADLIB='TEST.DATASET.PFX.SZWELOAD' &&
+LOADLOC="VOLUME=TSTVOL" &&
+./opercmd.rex "SETPROG APF,ADD,DSN=$LOADLIB,$LOADLOC"
+//*
+--- End of JCL ---
+JCL not submitted, command run with "--dry-run" flag.
+To perform command, re-run command without "--dry-run" flag, or submit the JCL directly
+>> Command run successfully.
+>> Zowe load libraries are APF authorized successfully."
 `;
 
 exports[`init-apfauth (SHORT) apf empty pluginlib 2`] = `

--- a/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/mvs.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/mvs.test.ts.snap
@@ -13,14 +13,15 @@ Skipped writing to a dataset. To write, you must use --allow-overwrite.
 `;
 
 exports[`init-mvs (SHORT) authLoadLib negatives 2`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/authLoadlib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/authLoadlib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/authLoadlib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Initialize Zowe custom data sets
+Create data sets if they do not exist
+Warning ZWEL0301W: TEST.DATASET.PFX.PARMLIB already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+Warning ZWEL0301W: TEST.DATASET.PFX.ZWESAPL already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+Skipped writing to a dataset. To write, you must use --allow-overwrite.
+>> Zowe custom data sets are initialized successfully."
 `;
 
 exports[`init-mvs (SHORT) authLoadLib negatives 3`] = `
@@ -714,14 +715,15 @@ Skipped writing to a dataset. To write, you must use --allow-overwrite.
 `;
 
 exports[`init-mvs (SHORT) authPluginLib negatives  2`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/authPluginLib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/authPluginLib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/authPluginLib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Initialize Zowe custom data sets
+Create data sets if they do not exist
+Warning ZWEL0301W: TEST.DATASET.PFX.PARMLIB already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+Warning ZWEL0301W: TEST.DATASET.PFX.SZWELOAD already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+Skipped writing to a dataset. To write, you must use --allow-overwrite.
+>> Zowe custom data sets are initialized successfully."
 `;
 
 exports[`init-mvs (SHORT) authPluginLib negatives  3`] = `
@@ -1198,14 +1200,11 @@ ERROR: Error ZWEL0157E: Zowe dataset prefix (zowe.setup.dataset.prefix) is not d
 `;
 
 exports[`init-mvs (SHORT) bad ds prefix post-generate 2`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/prefix
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/prefix
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/prefix"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Initialize Zowe custom data sets
+ERROR: Error ZWEL0157E: Zowe dataset prefix (zowe.setup.dataset.prefix) is not defined in Zowe YAML configuration file."
 `;
 
 exports[`init-mvs (SHORT) jcllib fails verification 1`] = `
@@ -1217,14 +1216,11 @@ ERROR: Error ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Ru
 `;
 
 exports[`init-mvs (SHORT) jcllib fails verification 2`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/jcllib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/jcllib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/jcllib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Initialize Zowe custom data sets
+ERROR: Error ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL TEST.DATASET.PFX.SZWESAMP(ZWEGENER) before running this command."
 `;
 
 exports[`init-mvs (SHORT) parmlib negatives  1`] = `
@@ -1236,14 +1232,11 @@ ERROR: Error ZWEL0157E: zowe.setup.dataset.parmlib is not defined in Zowe YAML c
 `;
 
 exports[`init-mvs (SHORT) parmlib negatives  2`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/parmlib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/parmlib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/parmlib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Initialize Zowe custom data sets
+ERROR: Error ZWEL0157E: zowe.setup.dataset.parmlib is not defined in Zowe YAML configuration file."
 `;
 
 exports[`init-mvs (SHORT) parmlib negatives  3`] = `

--- a/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/mvs.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/mvs.test.ts.snap
@@ -1,14 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`init-mvs (SHORT) authLoadLib negatives 1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/authLoadlib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/authLoadlib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/authLoadlib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Initialize Zowe custom data sets
+Create data sets if they do not exist
+Warning ZWEL0301W: TEST.DATASET.PFX.PARMLIB already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+Warning ZWEL0301W: TEST.DATASET.PFX.ZWESAPL already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+Skipped writing to a dataset. To write, you must use --allow-overwrite.
+>> Zowe custom data sets are initialized successfully."
 `;
 
 exports[`init-mvs (SHORT) authLoadLib negatives 2`] = `
@@ -701,14 +702,15 @@ To perform command, re-run command without "--dry-run" flag, or submit the JCL d
 `;
 
 exports[`init-mvs (SHORT) authPluginLib negatives  1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/authPluginLib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/authPluginLib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/authPluginLib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Initialize Zowe custom data sets
+Create data sets if they do not exist
+Warning ZWEL0301W: TEST.DATASET.PFX.PARMLIB already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+Warning ZWEL0301W: TEST.DATASET.PFX.SZWELOAD already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+Skipped writing to a dataset. To write, you must use --allow-overwrite.
+>> Zowe custom data sets are initialized successfully."
 `;
 
 exports[`init-mvs (SHORT) authPluginLib negatives  2`] = `
@@ -1188,14 +1190,11 @@ To perform command, re-run command without "--dry-run" flag, or submit the JCL d
 `;
 
 exports[`init-mvs (SHORT) bad ds prefix post-generate 1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/prefix
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/prefix
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/prefix"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Initialize Zowe custom data sets
+ERROR: Error ZWEL0157E: Zowe dataset prefix (zowe.setup.dataset.prefix) is not defined in Zowe YAML configuration file."
 `;
 
 exports[`init-mvs (SHORT) bad ds prefix post-generate 2`] = `
@@ -1210,14 +1209,11 @@ Validity Exceptions(s) with object at
 `;
 
 exports[`init-mvs (SHORT) jcllib fails verification 1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/jcllib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/jcllib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/jcllib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Initialize Zowe custom data sets
+ERROR: Error ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL TEST.DATASET.PFX.SZWESAMP(ZWEGENER) before running this command."
 `;
 
 exports[`init-mvs (SHORT) jcllib fails verification 2`] = `
@@ -1232,14 +1228,11 @@ Validity Exceptions(s) with object at
 `;
 
 exports[`init-mvs (SHORT) parmlib negatives  1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/parmlib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/parmlib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/parmlib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Initialize Zowe custom data sets
+ERROR: Error ZWEL0157E: zowe.setup.dataset.parmlib is not defined in Zowe YAML configuration file."
 `;
 
 exports[`init-mvs (SHORT) parmlib negatives  2`] = `

--- a/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/stc.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/stc.test.ts.snap
@@ -772,15 +772,61 @@ To perform command, re-run command without "--dry-run" flag, or submit the JCL d
 `;
 
 exports[`init-stc (SHORT) invalid stc configurations 2`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/security
-        Validity Exceptions(s) with object at /zowe/setup/security/stcs
-          Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
-            string too short (len=0) '' 0 < MIN=1 at /zowe/setup/security/stcs/aux
-            string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/aux"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Install Zowe main started task
+Template JCL: TEST.DATASET.PFX.SZWESAMP(ZWEISTC) , Executable JCL: TEST.DATASET.PFX.JCLLIB(ZWEISTC)
+--- JCL Content ---
+//ZWEISTC JOB
+//*
+//* This program and the accompanying materials are made available
+//* under the terms of the Eclipse Public License v2.0 which
+//* accompanies this distribution, and is available at
+//* https://www.eclipse.org/legal/epl-v20.html
+//*
+//* SPDX-License-Identifier: EPL-2.0
+//*
+//* Copyright Contributors to the Zowe Project. 2020, 2020
+//*
+//*********************************************************************
+//*
+//* This job is used to add proclib members
+//* Used to start a Zowe "instance"
+//* Instances represent a configuration of Zowe, different from the
+//* "runtime" datasets that are created upon install of Zowe / SMPE.
+//*
+//* If you plan NOT to use Zowe Cross Memory Server, consider to
+//* copy Zowe Launcher STC only (ZWESLSTC).
+//*
+//*********************************************************************
+//*
+//MCOPY EXEC PGM=IKJEFT01
+//SYSTSPRT DD SYSOUT=A
+//  SET PROCLIB=TEST.DATASET.PFX.TEST.PROCLIB
+//STCZOWE DD DISP=SHR,
+// DSN=&PROCLIB.(ZWESLSTC)
+//STCZIS DD DISP=SHR,
+// DSN=&PROCLIB.(ZWESISTC)
+//STCAUX DD DISP=SHR,
+// DSN=&PROCLIB.(ZWESASTC)
+//*
+//SYSTSIN DD *
+REPRO +
+INDATASET('TEST.DATASET.PFX.JCLLIB(ZWESLSTC)') +
+OUTFILE(STCZOWE)
+REPRO +
+INDATASET('TEST.DATASET.PFX.JCLLIB(ZWESISTC)') +
+OUTFILE(STCZIS)
+REPRO +
+INDATASET('TEST.DATASET.PFX.JCLLIB(ZWESASTC)') +
+OUTFILE(STCAUX)
+//*
+--- End of JCL ---
+JCL not submitted, command run with "--dry-run" flag.
+To perform command, re-run command without "--dry-run" flag, or submit the JCL directly
+>> Command run successfully.
+>> Zowe main started tasks are installed successfully."
 `;
 
 exports[`init-stc (SHORT) invalid stc configurations 3`] = `
@@ -790,9 +836,13 @@ Validity Exceptions(s) with object at
     Validity Exceptions(s) with object at /zowe/setup
       Validity Exceptions(s) with object at /zowe/setup/security
         Validity Exceptions(s) with object at /zowe/setup/security/stcs
-          Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
-            string too long (len=10) 'TOOLONGTOO' 10 > MAX=8 at /zowe/setup/security/stcs/aux
-            string pattern match fail s='TOOLONGTOO', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/aux"
+          Schema at '/zowe/setup/security/stcs/aux' invalid
+            not oneOf schemas at '/zowe/setup/security/stcs/aux' are valid, 0 are
+              Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
+                string too long (len=10) 'TOOLONGTOO' 10 > MAX=8 at /zowe/setup/security/stcs/aux
+                string pattern match fail s='TOOLONGTOO', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/aux
+              Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
+                string too long (len=10) 'TOOLONGTOO' 10 > MAX=0 at /zowe/setup/security/stcs/aux"
 `;
 
 exports[`init-stc (SHORT) invalid stc configurations 4`] = `
@@ -802,12 +852,13 @@ Validity Exceptions(s) with object at
     Validity Exceptions(s) with object at /zowe/setup
       Validity Exceptions(s) with object at /zowe/setup/security
         Validity Exceptions(s) with object at /zowe/setup/security/stcs
-          Validity Exceptions(s) with string at /zowe/setup/security/stcs/zis
-            string too short (len=0) '' 0 < MIN=1 at /zowe/setup/security/stcs/zis
-            string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/zis
-          Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
-            string too long (len=10) 'TOOLONGTOO' 10 > MAX=8 at /zowe/setup/security/stcs/aux
-            string pattern match fail s='TOOLONGTOO', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/aux"
+          Schema at '/zowe/setup/security/stcs/aux' invalid
+            not oneOf schemas at '/zowe/setup/security/stcs/aux' are valid, 0 are
+              Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
+                string too long (len=10) 'TOOLONGTOO' 10 > MAX=8 at /zowe/setup/security/stcs/aux
+                string pattern match fail s='TOOLONGTOO', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/aux
+              Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
+                string too long (len=10) 'TOOLONGTOO' 10 > MAX=0 at /zowe/setup/security/stcs/aux"
 `;
 
 exports[`init-stc (SHORT) invalid stc configurations 5`] = `
@@ -817,12 +868,13 @@ Validity Exceptions(s) with object at
     Validity Exceptions(s) with object at /zowe/setup
       Validity Exceptions(s) with object at /zowe/setup/security
         Validity Exceptions(s) with object at /zowe/setup/security/stcs
-          Validity Exceptions(s) with string at /zowe/setup/security/stcs/zis
-            string too short (len=0) '' 0 < MIN=1 at /zowe/setup/security/stcs/zis
-            string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/zis
-          Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
-            string too long (len=10) 'TOOLONGTOO' 10 > MAX=8 at /zowe/setup/security/stcs/aux
-            string pattern match fail s='TOOLONGTOO', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/aux"
+          Schema at '/zowe/setup/security/stcs/aux' invalid
+            not oneOf schemas at '/zowe/setup/security/stcs/aux' are valid, 0 are
+              Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
+                string too long (len=10) 'TOOLONGTOO' 10 > MAX=8 at /zowe/setup/security/stcs/aux
+                string pattern match fail s='TOOLONGTOO', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/aux
+              Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
+                string too long (len=10) 'TOOLONGTOO' 10 > MAX=0 at /zowe/setup/security/stcs/aux"
 `;
 
 exports[`init-stc (SHORT) invalid stc configurations 6`] = `
@@ -832,15 +884,13 @@ Validity Exceptions(s) with object at
     Validity Exceptions(s) with object at /zowe/setup
       Validity Exceptions(s) with object at /zowe/setup/security
         Validity Exceptions(s) with object at /zowe/setup/security/stcs
-          Validity Exceptions(s) with string at /zowe/setup/security/stcs/zowe
-            string too short (len=0) '' 0 < MIN=1 at /zowe/setup/security/stcs/zowe
-            string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/zowe
-          Validity Exceptions(s) with string at /zowe/setup/security/stcs/zis
-            string too short (len=0) '' 0 < MIN=1 at /zowe/setup/security/stcs/zis
-            string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/zis
-          Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
-            string too long (len=10) 'TOOLONGTOO' 10 > MAX=8 at /zowe/setup/security/stcs/aux
-            string pattern match fail s='TOOLONGTOO', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/aux"
+          Schema at '/zowe/setup/security/stcs/aux' invalid
+            not oneOf schemas at '/zowe/setup/security/stcs/aux' are valid, 0 are
+              Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
+                string too long (len=10) 'TOOLONGTOO' 10 > MAX=8 at /zowe/setup/security/stcs/aux
+                string pattern match fail s='TOOLONGTOO', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/aux
+              Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
+                string too long (len=10) 'TOOLONGTOO' 10 > MAX=0 at /zowe/setup/security/stcs/aux"
 `;
 
 exports[`init-stc (SHORT) invalid stc configurations 7`] = `
@@ -850,15 +900,13 @@ Validity Exceptions(s) with object at
     Validity Exceptions(s) with object at /zowe/setup
       Validity Exceptions(s) with object at /zowe/setup/security
         Validity Exceptions(s) with object at /zowe/setup/security/stcs
-          Validity Exceptions(s) with string at /zowe/setup/security/stcs/zowe
-            string too short (len=0) '' 0 < MIN=1 at /zowe/setup/security/stcs/zowe
-            string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/zowe
-          Validity Exceptions(s) with string at /zowe/setup/security/stcs/zis
-            string too short (len=0) '' 0 < MIN=1 at /zowe/setup/security/stcs/zis
-            string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/zis
-          Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
-            string too long (len=10) 'TOOLONGTOO' 10 > MAX=8 at /zowe/setup/security/stcs/aux
-            string pattern match fail s='TOOLONGTOO', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/aux"
+          Schema at '/zowe/setup/security/stcs/aux' invalid
+            not oneOf schemas at '/zowe/setup/security/stcs/aux' are valid, 0 are
+              Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
+                string too long (len=10) 'TOOLONGTOO' 10 > MAX=8 at /zowe/setup/security/stcs/aux
+                string pattern match fail s='TOOLONGTOO', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/aux
+              Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
+                string too long (len=10) 'TOOLONGTOO' 10 > MAX=0 at /zowe/setup/security/stcs/aux"
 `;
 
 exports[`init-stc (SHORT) valid config empty proclib 1`] = `
@@ -928,14 +976,11 @@ ERROR: Error ZWEL0157E: Zowe dataset prefix (zowe.setup.dataset.prefix) is not d
 `;
 
 exports[`init-stc (SHORT) wrong ds prefix 2`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/prefix
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/prefix
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/prefix"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Install Zowe main started task
+ERROR: Error ZWEL0157E: Zowe dataset prefix (zowe.setup.dataset.prefix) is not defined in Zowe YAML configuration file."
 `;
 
 exports[`init-stc (SHORT) wrong jcllib 1`] = `
@@ -947,14 +992,11 @@ ERROR: Error ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Ru
 `;
 
 exports[`init-stc (SHORT) wrong jcllib 2`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/jcllib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/jcllib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/jcllib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Install Zowe main started task
+ERROR: Error ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL TEST.DATASET.PFX.SZWESAMP(ZWEGENER) before running this command."
 `;
 
 exports[`init-stc (SHORT) wrong proclib 1`] = `
@@ -966,14 +1008,11 @@ ERROR: Error ZWEL0157E: PROCLIB (zowe.setup.dataset.proclib) is not defined in Z
 `;
 
 exports[`init-stc (SHORT) wrong proclib 2`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/proclib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/proclib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/proclib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Install Zowe main started task
+ERROR: Error ZWEL0157E: PROCLIB (zowe.setup.dataset.proclib) is not defined in Zowe YAML configuration file."
 `;
 
 exports[`init-stc (SHORT) wrong proclib 3`] = `
@@ -982,8 +1021,12 @@ Validity Exceptions(s) with object at
   Validity Exceptions(s) with object at /zowe
     Validity Exceptions(s) with object at /zowe/setup
       Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/proclib
-          string pattern match fail s='INVALID.PROCLIB.DEFINITION1', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/proclib"
+        Schema at '/zowe/setup/dataset/proclib' invalid
+          not oneOf schemas at '/zowe/setup/dataset/proclib' are valid, 0 are
+            Validity Exceptions(s) with string at /zowe/setup/dataset/proclib
+              string pattern match fail s='INVALID.PROCLIB.DEFINITION1', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/proclib
+            Validity Exceptions(s) with string at /zowe/setup/dataset/proclib
+              string too long (len=27) 'INVALID.PROCLIB.DEFINITION1' 27 > MAX=0 at /zowe/setup/dataset/proclib"
 `;
 
 exports[`init-stc (SHORT) zis stc exists 1`] = `

--- a/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/stc.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/stc.test.ts.snap
@@ -551,15 +551,61 @@ To perform command, re-run command without "--dry-run" flag, or submit the JCL d
 `;
 
 exports[`init-stc (SHORT) invalid stc configurations 1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/security
-        Validity Exceptions(s) with object at /zowe/setup/security/stcs
-          Validity Exceptions(s) with string at /zowe/setup/security/stcs/aux
-            string too short (len=0) '' 0 < MIN=1 at /zowe/setup/security/stcs/aux
-            string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@]){0,7}$', at /zowe/setup/security/stcs/aux"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Install Zowe main started task
+Template JCL: TEST.DATASET.PFX.SZWESAMP(ZWEISTC) , Executable JCL: TEST.DATASET.PFX.JCLLIB(ZWEISTC)
+--- JCL Content ---
+//ZWEISTC JOB
+//*
+//* This program and the accompanying materials are made available
+//* under the terms of the Eclipse Public License v2.0 which
+//* accompanies this distribution, and is available at
+//* https://www.eclipse.org/legal/epl-v20.html
+//*
+//* SPDX-License-Identifier: EPL-2.0
+//*
+//* Copyright Contributors to the Zowe Project. 2020, 2020
+//*
+//*********************************************************************
+//*
+//* This job is used to add proclib members
+//* Used to start a Zowe "instance"
+//* Instances represent a configuration of Zowe, different from the
+//* "runtime" datasets that are created upon install of Zowe / SMPE.
+//*
+//* If you plan NOT to use Zowe Cross Memory Server, consider to
+//* copy Zowe Launcher STC only (ZWESLSTC).
+//*
+//*********************************************************************
+//*
+//MCOPY EXEC PGM=IKJEFT01
+//SYSTSPRT DD SYSOUT=A
+//  SET PROCLIB=TEST.DATASET.PFX.TEST.PROCLIB
+//STCZOWE DD DISP=SHR,
+// DSN=&PROCLIB.(ZWESLSTC)
+//STCZIS DD DISP=SHR,
+// DSN=&PROCLIB.(ZWESISTC)
+//STCAUX DD DISP=SHR,
+// DSN=&PROCLIB.(ZWESASTC)
+//*
+//SYSTSIN DD *
+REPRO +
+INDATASET('TEST.DATASET.PFX.JCLLIB(ZWESLSTC)') +
+OUTFILE(STCZOWE)
+REPRO +
+INDATASET('TEST.DATASET.PFX.JCLLIB(ZWESISTC)') +
+OUTFILE(STCZIS)
+REPRO +
+INDATASET('TEST.DATASET.PFX.JCLLIB(ZWESASTC)') +
+OUTFILE(STCAUX)
+//*
+--- End of JCL ---
+JCL not submitted, command run with "--dry-run" flag.
+To perform command, re-run command without "--dry-run" flag, or submit the JCL directly
+>> Command run successfully.
+>> Zowe main started tasks are installed successfully."
 `;
 
 exports[`init-stc (SHORT) invalid stc configurations 2`] = `
@@ -711,14 +757,11 @@ To perform command, re-run command without "--dry-run" flag, or submit the JCL d
 `;
 
 exports[`init-stc (SHORT) wrong ds prefix 1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/prefix
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/prefix
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/prefix"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Install Zowe main started task
+ERROR: Error ZWEL0157E: Zowe dataset prefix (zowe.setup.dataset.prefix) is not defined in Zowe YAML configuration file."
 `;
 
 exports[`init-stc (SHORT) wrong ds prefix 2`] = `
@@ -733,14 +776,11 @@ Validity Exceptions(s) with object at
 `;
 
 exports[`init-stc (SHORT) wrong jcllib 1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/jcllib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/jcllib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/jcllib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Install Zowe main started task
+ERROR: Error ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL TEST.DATASET.PFX.SZWESAMP(ZWEGENER) before running this command."
 `;
 
 exports[`init-stc (SHORT) wrong jcllib 2`] = `
@@ -755,14 +795,11 @@ Validity Exceptions(s) with object at
 `;
 
 exports[`init-stc (SHORT) wrong proclib 1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/proclib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/proclib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/proclib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Install Zowe main started task
+ERROR: Error ZWEL0157E: PROCLIB (zowe.setup.dataset.proclib) is not defined in Zowe YAML configuration file."
 `;
 
 exports[`init-stc (SHORT) wrong proclib 2`] = `

--- a/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/vsam.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/vsam.test.ts.snap
@@ -427,15 +427,15 @@ ERROR: Warning ZWEL0304W: Zowe Caching Service is not configured to use VSAM. Co
 `;
 
 exports[`init-vsam (SHORT) skip undefined caching service 1`] = `
-"failed to evaluate ' components.gateway?.zowe?.network?.server?.tls?.attls == true ? 'http' : zowe.network?.server?.tls?.attls == true ? 'http' : 'https' ', status=-1
+"TypeError: cannot read property 'gateway' of null
+    at <eval> (<embedded>)
+failed to evaluate ' components.gateway?.zowe?.network?.server?.tls?.attls == true ? 'http' : zowe.network?.server?.tls?.attls == true ? 'http' : 'https' ', status=-1
 Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
 Validity Exceptions(s) with object at
   Validity Exceptions(s) with object at /zowe
     Validity Exceptions(s) with object at /zowe/network
       type 'object' not permitted at /zowe/network/proxyType; expecting type 'string'
-  string cannot be null for /components
-TypeError: cannot read property 'gateway' of null
-    at <eval> (<embedded>)"
+  string cannot be null for /components"
 `;
 
 exports[`init-vsam (SHORT) unset ds prefix 1`] = `
@@ -447,14 +447,11 @@ ERROR: Error ZWEL0157E: Zowe dataset prefix (zowe.setup.dataset.prefix) is not d
 `;
 
 exports[`init-vsam (SHORT) unset ds prefix 2`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/prefix
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/prefix
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/prefix"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Initialize Zowe custom data sets
+ERROR: Error ZWEL0157E: Zowe dataset prefix (zowe.setup.dataset.prefix) is not defined in Zowe YAML configuration file."
 `;
 
 exports[`init-vsam (SHORT) unset jcllib 1`] = `
@@ -466,14 +463,11 @@ ERROR: Error ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Ru
 `;
 
 exports[`init-vsam (SHORT) unset jcllib 2`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/jcllib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/jcllib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/jcllib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Initialize Zowe custom data sets
+ERROR: Error ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL TEST.DATASET.PFX.SZWESAMP(ZWEGENER) before running this command."
 `;
 
 exports[`init-vsam (SHORT) unset vsam mode 1`] = `

--- a/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/vsam.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/vsam.test.ts.snap
@@ -427,26 +427,23 @@ ERROR: Warning ZWEL0304W: Zowe Caching Service is not configured to use VSAM. Co
 `;
 
 exports[`init-vsam (SHORT) skip undefined caching service 1`] = `
-"TypeError: cannot read property 'gateway' of null
-    at <eval> (<embedded>)
-failed to evaluate ' components.gateway?.zowe?.network?.server?.tls?.attls == true ? 'http' : zowe.network?.server?.tls?.attls == true ? 'http' : 'https' ', status=-1
+"failed to evaluate ' components.gateway?.zowe?.network?.server?.tls?.attls == true ? 'http' : zowe.network?.server?.tls?.attls == true ? 'http' : 'https' ', status=-1
 Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
 Validity Exceptions(s) with object at
   Validity Exceptions(s) with object at /zowe
     Validity Exceptions(s) with object at /zowe/network
       type 'object' not permitted at /zowe/network/proxyType; expecting type 'string'
-  string cannot be null for /components"
+  string cannot be null for /components
+TypeError: cannot read property 'gateway' of null
+    at <eval> (<embedded>)"
 `;
 
 exports[`init-vsam (SHORT) unset ds prefix 1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/prefix
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/prefix
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/prefix"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Initialize Zowe custom data sets
+ERROR: Error ZWEL0157E: Zowe dataset prefix (zowe.setup.dataset.prefix) is not defined in Zowe YAML configuration file."
 `;
 
 exports[`init-vsam (SHORT) unset ds prefix 2`] = `
@@ -461,14 +458,11 @@ Validity Exceptions(s) with object at
 `;
 
 exports[`init-vsam (SHORT) unset jcllib 1`] = `
-"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
-Validity Exceptions(s) with object at
-  Validity Exceptions(s) with object at /zowe
-    Validity Exceptions(s) with object at /zowe/setup
-      Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/jcllib
-          string too short (len=0) '' 0 < MIN=3 at /zowe/setup/dataset/jcllib
-          string pattern match fail s='', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/jcllib"
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Initialize Zowe custom data sets
+ERROR: Error ZWEL0319E: zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL TEST.DATASET.PFX.SZWESAMP(ZWEGENER) before running this command."
 `;
 
 exports[`init-vsam (SHORT) unset jcllib 2`] = `

--- a/tests/zwe-remote-integration/src/__tests__/init/apfauth.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/init/apfauth.test.ts
@@ -54,7 +54,7 @@ describe(`${testSuiteName}`, () => {
       const result = await testRunner.runZweTest(cfgYaml, 'init apfauth --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(63);
     });
 
     it('apf empty ds prefix', async () => {
@@ -62,7 +62,7 @@ describe(`${testSuiteName}`, () => {
       const result = await testRunner.runZweTest(cfgYaml, 'init apfauth --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(157);
     });
 
     it('apf bad ds prefix', async () => {
@@ -89,7 +89,7 @@ describe(`${testSuiteName}`, () => {
       const result = await testRunner.runZweTest(cfgYaml, 'init apfauth --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(63);
     });
 
     it('apf empty pluginlib', async () => {
@@ -97,7 +97,7 @@ describe(`${testSuiteName}`, () => {
       let result = await testRunner.runZweTest(cfgYaml, 'init apfauth --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(0);
 
       delete cfgYaml.zowe.setup.dataset.authPluginLib;
       result = await testRunner.runZweTest(cfgYaml, 'init apfauth --dry-run');

--- a/tests/zwe-remote-integration/src/__tests__/init/generate.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/init/generate.test.ts
@@ -224,7 +224,7 @@ describe(`${testSuiteName}`, () => {
 
   describe('(LONG)', () => {
     it('jcllib updates: jcl header single line', async () => {
-      const header = `'SOMEJOB', REGION = 0M`;
+      const header = `'SOMEJOB', REGION=0M`;
       _.set(cfgYaml, 'zowe.setup.jcl.header', header);
       const result = await testRunner.runZweTest(cfgYaml, 'init generate');
       expect(result.stdout).not.toBeNull();

--- a/tests/zwe-remote-integration/src/__tests__/init/mvs.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/init/mvs.test.ts
@@ -82,13 +82,13 @@ describe(`${testSuiteName}`, () => {
       let result = await testRunner.runZweTest(cfgYaml, 'init mvs --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(157);
 
       cfgYaml.zowe.setup.dataset.prefix = '';
       result = await testRunner.runZweTest(cfgYaml, 'init mvs --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(157);
     });
 
     it('jcllib fails verification', async () => {
@@ -96,13 +96,13 @@ describe(`${testSuiteName}`, () => {
       let result = await testRunner.runZweTest(cfgYaml, 'init mvs --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(63);
 
       cfgYaml.zowe.setup.dataset.jcllib = '';
       result = await testRunner.runZweTest(cfgYaml, 'init mvs --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(63);
     });
 
     it('authLoadLib negatives', async () => {
@@ -110,13 +110,13 @@ describe(`${testSuiteName}`, () => {
       let result = await testRunner.runZweTest(cfgYaml, 'init mvs --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(0);
 
       cfgYaml.zowe.setup.dataset.authLoadlib = '';
       result = await testRunner.runZweTest(cfgYaml, 'init mvs --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(0);
 
       cfgYaml.zowe.setup.dataset.authLoadlib = 'DOES.NOT.EXIST.ALL';
       result = await testRunner.runZweTest(cfgYaml, 'init mvs --dry-run');
@@ -161,13 +161,13 @@ describe(`${testSuiteName}`, () => {
       let result = await testRunner.runZweTest(cfgYaml, 'init mvs --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(157);
 
       cfgYaml.zowe.setup.dataset.parmlib = '';
       result = await testRunner.runZweTest(cfgYaml, 'init mvs --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(157);
 
       cfgYaml.zowe.setup.dataset.parmlib = 'DOES.NOT.EXIST.ALL';
       result = await testRunner.runZweTest(cfgYaml, 'init mvs --dry-run');
@@ -200,13 +200,13 @@ describe(`${testSuiteName}`, () => {
       let result = await testRunner.runZweTest(cfgYaml, 'init mvs --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(0);
 
       cfgYaml.zowe.setup.dataset.authPluginLib = '';
       result = await testRunner.runZweTest(cfgYaml, 'init mvs --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(0);
 
       cfgYaml.zowe.setup.dataset.authPluginLib = 'DOES.NOT.EXIST.ALL';
       result = await testRunner.runZweTest(cfgYaml, 'init mvs --dry-run');

--- a/tests/zwe-remote-integration/src/__tests__/init/stc.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/init/stc.test.ts
@@ -112,13 +112,13 @@ describe(`${testSuiteName}`, () => {
       let result = await testRunner.runZweTest(cfgYaml, 'init stc --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(157);
 
       cfgYaml.zowe.setup.dataset.prefix = '';
       result = await testRunner.runZweTest(cfgYaml, 'init stc --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(157);
     });
 
     it('wrong proclib', async () => {
@@ -126,13 +126,13 @@ describe(`${testSuiteName}`, () => {
       let result = await testRunner.runZweTest(cfgYaml, 'init stc --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(157);
 
       cfgYaml.zowe.setup.dataset.proclib = '';
       result = await testRunner.runZweTest(cfgYaml, 'init stc --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(157);
 
       cfgYaml.zowe.setup.dataset.proclib = 'INVALID.PROCLIB.DEFINITION1';
       result = await testRunner.runZweTest(cfgYaml, 'init stc --dry-run');
@@ -146,13 +146,13 @@ describe(`${testSuiteName}`, () => {
       let result = await testRunner.runZweTest(cfgYaml, 'init stc --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(63);
 
       cfgYaml.zowe.setup.dataset.jcllib = '';
       result = await testRunner.runZweTest(cfgYaml, 'init stc --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(63);
     });
 
     it('invalid stc configurations', async () => {
@@ -160,13 +160,13 @@ describe(`${testSuiteName}`, () => {
       let result = await testRunner.runZweTest(cfgYaml, 'init stc --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(0);
 
       cfgYaml.zowe.setup.security.stcs.aux = '';
       result = await testRunner.runZweTest(cfgYaml, 'init stc --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(0);
 
       cfgYaml.zowe.setup.security.stcs.aux = 'TOOLONGTOO';
       result = await testRunner.runZweTest(cfgYaml, 'init stc --dry-run');

--- a/tests/zwe-remote-integration/src/__tests__/init/vsam.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/init/vsam.test.ts
@@ -104,13 +104,13 @@ describe(`${testSuiteName}`, () => {
       let result = await testRunner.runZweTest(cfgYaml, 'init vsam --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(157);
 
       cfgYaml.zowe.setup.dataset.prefix = '';
       result = await testRunner.runZweTest(cfgYaml, 'init vsam --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(157);
     });
 
     it('unset jcllib', async () => {
@@ -118,13 +118,13 @@ describe(`${testSuiteName}`, () => {
       let result = await testRunner.runZweTest(cfgYaml, 'init vsam --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(63);
 
       cfgYaml.zowe.setup.dataset.jcllib = '';
       result = await testRunner.runZweTest(cfgYaml, 'init vsam --dry-run');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(1);
+      expect(result.rc).toBe(63);
     });
 
     it('invalid NONRLS configurations', async () => {

--- a/tests/zwe-remote-integration/src/__tests__/install/__snapshots__/install.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/install/__snapshots__/install.test.ts.snap
@@ -1789,8 +1789,12 @@ Validity Exceptions(s) with object at
   Validity Exceptions(s) with object at /zowe
     Validity Exceptions(s) with object at /zowe/setup
       Validity Exceptions(s) with object at /zowe/setup/dataset
-        Validity Exceptions(s) with string at /zowe/setup/dataset/prefix
-          string pattern match fail s='INVALID.DSN.LENGTH123123', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/prefix"
+        Schema at '/zowe/setup/dataset/prefix' invalid
+          not oneOf schemas at '/zowe/setup/dataset/prefix' are valid, 0 are
+            Validity Exceptions(s) with string at /zowe/setup/dataset/prefix
+              string pattern match fail s='INVALID.DSN.LENGTH123123', pat='^([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}(\\.([A-Z\\$\\#\\@]){1}([A-Z0-9\\$\\#\\@\\-]){0,7}){0,11}$', at /zowe/setup/dataset/prefix
+            Validity Exceptions(s) with string at /zowe/setup/dataset/prefix
+              string too long (len=24) 'INVALID.DSN.LENGTH123123' 24 > MAX=0 at /zowe/setup/dataset/prefix"
 `;
 
 exports[`zwe-install (SHORT) zwe install invalid dataset name 2`] = `

--- a/tests/zwe-remote-integration/src/__tests__/install/__snapshots__/install.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/install/__snapshots__/install.test.ts.snap
@@ -518,82 +518,12 @@ exports[`zwe-install (LONG) install with edge-case prefix names 7`] = `
 Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
 -------------------------------------------------------------------------------
 >> Install Zowe MVS data sets
-Template JCL: /test/dir/files/SZWESAMP/ZWEINSTL
---- JCL content ---
-//ZWEINSTL JOB
-//*
-//* This program and the accompanying materials are made available
-//* under the terms of the Eclipse Public License v2.0 which
-//* accompanies this distribution, and is available at
-//* https://www.eclipse.org/legal/epl-v20.html
-//*
-//* SPDX-License-Identifier: EPL-2.0
-//*
-//* Copyright Contributors to the Zowe Project. 2020, 2020
-//*
-//*********************************************************************
-//*
-//* This job is used to create the MVS data sets under the
-//* zowe.setup.dataset.prefix definition:
-//*   - SZWEAUTH - Zowe load modules (++PROGRAM)
-//*   - SZWESAMP - sample configurations
-//*   - SZWEEXEC - utilities used by Zowe
-//*   - SZWELOAD - config manager for REXX
-//*
-//* The following step will copy required members.
-//*
-//*********************************************************************
-//MKPDSE EXEC PGM=IKJEFT01,DYNAMNBR=4
-//SYSTSPRT DD SYSOUT=A
-//SYSTSIN DD *
-ALLOC NEW DA('TEST.DATASET.PFX.PR#4282.$1-#-@.SZWESAMP') +
-dsntype(library) dsorg(po) recfm(f b) lrecl(80) +
-unit(sysallda) space(30,15) tracks
-ALLOC NEW DA('TEST.DATASET.PFX.PR#4282.$1-#-@.SZWEEXEC') +
-dsntype(library) dsorg(po) recfm(f b) lrecl(80) +
-unit(sysallda) space(15,15) tracks
-ALLOC NEW DA('TEST.DATASET.PFX.PR#4282.$1-#-@.SZWEAUTH') +
-dsntype(library) dsorg(po) recfm(u) lrecl(0) +
-blksize(32760) unit(sysallda) space(195,15) tracks
-ALLOC NEW DA('TEST.DATASET.PFX.PR#4282.$1-#-@.SZWELOAD') +
-dsntype(library) dsorg(po) recfm(u) lrecl(0) +
-blksize(32760) unit(sysallda) space(150,15) tracks
-//*
-//*
-//AUTHCPY EXEC PGM=BPXBATCH
-//BPXPRINT DD SYSOUT=*
-//STDOUT   DD SYSOUT=*
-//STDERR   DD SYSOUT=*
-//STDPARM DD *
-SH cd '/test/dir' &&
-ZWE_TMP_PREFIX='TEST.DATASET.PFX.PR#4282.$1-#-@' &&
-cd files/SZWESAMP &&
-cp * "//'$ZWE_TMP_PREFIX.SZWESAMP'" &&
-cd ../SZWEEXEC &&
-cp * "//'$ZWE_TMP_PREFIX.SZWEEXEC'" &&
-cd ../SZWELOAD &&
-cp * "//'$ZWE_TMP_PREFIX.SZWELOAD'" &&
-cd ../../components/launcher/bin &&
-cp zowe_launcher
-   "//'$ZWE_TMP_PREFIX.SZWEAUTH(ZWELNCH)'" &&
-cd ../samplib/ &&
-cp * "//'$ZWE_TMP_PREFIX.SZWESAMP'" &&
-cd ../../zss/SAMPLIB &&
-cp ZWESASTC ZWESIP00 ZWESISCH ZWESISTC
-   "//'$ZWE_TMP_PREFIX.SZWESAMP'" &&
-cd ../LOADLIB &&
-cp * "//'$ZWE_TMP_PREFIX.SZWEAUTH'"
-/*
---- End of JCL ---
-Submitting Job ZWEINSTL
-Job ZWEINSTL(JOB00000) completed with RC=0
+Warning ZWEL0301W: TEST.DATASET.PFX.PR#4282.$1-#-@.SZWEAUTH already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+Warning ZWEL0301W: TEST.DATASET.PFX.PR#4282.$1-#-@.SZWEEXEC already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+Warning ZWEL0301W: TEST.DATASET.PFX.PR#4282.$1-#-@.SZWELOAD already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+Warning ZWEL0301W: TEST.DATASET.PFX.PR#4282.$1-#-@.SZWESAMP already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
 -------------------------------------------------------------------------------
->> Zowe MVS data sets are installed successfully.
-Zowe installation completed. In order to use Zowe, you need to run "zwe init" command to initialize Zowe instance.
-- Type "zwe init --help" to get more information.
-You can also run individual init sub-commands: generate, mvs, certificate, security, vsam, apfauth, and stc.
-- Type "zwe init <sub-command> --help" (for example, "zwe init stc --help") to get more information.
-Zowe JCL generated successfully"
+>> Zowe MVS data sets installation skipped."
 `;
 
 exports[`zwe-install (LONG) install with edge-case prefix names 8`] = `
@@ -689,6 +619,94 @@ exports[`zwe-install (LONG) install, re-install and fail, overwrite and succeed 
 Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
 -------------------------------------------------------------------------------
 >> Install Zowe MVS data sets
+Warning ZWEL0300W: TEST.DATASET.PFX.PR#4282.$1-#-@.SZWEAUTH already exists. Members in this data set will be overwritten.
+Warning ZWEL0300W: TEST.DATASET.PFX.PR#4282.$1-#-@.SZWEEXEC already exists. Members in this data set will be overwritten.
+Warning ZWEL0300W: TEST.DATASET.PFX.PR#4282.$1-#-@.SZWELOAD already exists. Members in this data set will be overwritten.
+Warning ZWEL0300W: TEST.DATASET.PFX.PR#4282.$1-#-@.SZWESAMP already exists. Members in this data set will be overwritten.
+Template JCL: /test/dir/files/SZWESAMP/ZWEINSTL
+--- JCL content ---
+//ZWEINSTL JOB
+//*
+//* This program and the accompanying materials are made available
+//* under the terms of the Eclipse Public License v2.0 which
+//* accompanies this distribution, and is available at
+//* https://www.eclipse.org/legal/epl-v20.html
+//*
+//* SPDX-License-Identifier: EPL-2.0
+//*
+//* Copyright Contributors to the Zowe Project. 2020, 2020
+//*
+//*********************************************************************
+//*
+//* This job is used to create the MVS data sets under the
+//* zowe.setup.dataset.prefix definition:
+//*   - SZWEAUTH - Zowe load modules (++PROGRAM)
+//*   - SZWESAMP - sample configurations
+//*   - SZWEEXEC - utilities used by Zowe
+//*   - SZWELOAD - config manager for REXX
+//*
+//* The following step will copy required members.
+//*
+//*********************************************************************
+//MKPDSE EXEC PGM=IKJEFT01,DYNAMNBR=4
+//SYSTSPRT DD SYSOUT=A
+//SYSTSIN DD *
+ALLOC NEW DA('TEST.DATASET.PFX.PR#4282.$1-#-@.SZWESAMP') +
+dsntype(library) dsorg(po) recfm(f b) lrecl(80) +
+unit(sysallda) space(30,15) tracks
+ALLOC NEW DA('TEST.DATASET.PFX.PR#4282.$1-#-@.SZWEEXEC') +
+dsntype(library) dsorg(po) recfm(f b) lrecl(80) +
+unit(sysallda) space(15,15) tracks
+ALLOC NEW DA('TEST.DATASET.PFX.PR#4282.$1-#-@.SZWEAUTH') +
+dsntype(library) dsorg(po) recfm(u) lrecl(0) +
+blksize(32760) unit(sysallda) space(195,15) tracks
+ALLOC NEW DA('TEST.DATASET.PFX.PR#4282.$1-#-@.SZWELOAD') +
+dsntype(library) dsorg(po) recfm(u) lrecl(0) +
+blksize(32760) unit(sysallda) space(150,15) tracks
+//*
+//*
+//AUTHCPY EXEC PGM=BPXBATCH
+//BPXPRINT DD SYSOUT=*
+//STDOUT   DD SYSOUT=*
+//STDERR   DD SYSOUT=*
+//STDPARM DD *
+SH cd '/test/dir' &&
+ZWE_TMP_PREFIX='TEST.DATASET.PFX.PR#4282.$1-#-@' &&
+cd files/SZWESAMP &&
+cp * "//'$ZWE_TMP_PREFIX.SZWESAMP'" &&
+cd ../SZWEEXEC &&
+cp * "//'$ZWE_TMP_PREFIX.SZWEEXEC'" &&
+cd ../SZWELOAD &&
+cp * "//'$ZWE_TMP_PREFIX.SZWELOAD'" &&
+cd ../../components/launcher/bin &&
+cp zowe_launcher
+   "//'$ZWE_TMP_PREFIX.SZWEAUTH(ZWELNCH)'" &&
+cd ../samplib/ &&
+cp * "//'$ZWE_TMP_PREFIX.SZWESAMP'" &&
+cd ../../zss/SAMPLIB &&
+cp ZWESASTC ZWESIP00 ZWESISCH ZWESISTC
+   "//'$ZWE_TMP_PREFIX.SZWESAMP'" &&
+cd ../LOADLIB &&
+cp * "//'$ZWE_TMP_PREFIX.SZWEAUTH'"
+/*
+--- End of JCL ---
+Deleting existing datasets.
+Submitting Job ZWEINSTL
+Job ZWEINSTL(JOB00000) completed with RC=0
+-------------------------------------------------------------------------------
+>> Zowe MVS data sets are installed successfully.
+Zowe installation completed. In order to use Zowe, you need to run "zwe init" command to initialize Zowe instance.
+- Type "zwe init --help" to get more information.
+You can also run individual init sub-commands: generate, mvs, certificate, security, vsam, apfauth, and stc.
+- Type "zwe init <sub-command> --help" (for example, "zwe init stc --help") to get more information.
+Zowe JCL generated successfully"
+`;
+
+exports[`zwe-install (LONG) install, re-install and fail, overwrite and succeed 2`] = `
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Install Zowe MVS data sets
 Template JCL: /test/dir/files/SZWESAMP/ZWEINSTL
 --- JCL content ---
 //ZWEINSTL JOB
@@ -767,19 +785,6 @@ You can also run individual init sub-commands: generate, mvs, certificate, secur
 Zowe JCL generated successfully"
 `;
 
-exports[`zwe-install (LONG) install, re-install and fail, overwrite and succeed 2`] = `
-"Temporary directory '/tmp/.zweenv-0000' created.
-Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
--------------------------------------------------------------------------------
->> Install Zowe MVS data sets
-Warning ZWEL0301W: TEST.DATASET.PFX.INST.TEST.SZWEAUTH already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
-Warning ZWEL0301W: TEST.DATASET.PFX.INST.TEST.SZWEEXEC already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
-Warning ZWEL0301W: TEST.DATASET.PFX.INST.TEST.SZWELOAD already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
-Warning ZWEL0301W: TEST.DATASET.PFX.INST.TEST.SZWESAMP already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
--------------------------------------------------------------------------------
->> Zowe MVS data sets installation skipped."
-`;
-
 exports[`zwe-install (LONG) install, re-install and fail, overwrite and succeed 3`] = `
 "Temporary directory '/tmp/.zweenv-0000' created.
 Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
@@ -794,6 +799,19 @@ Warning ZWEL0301W: TEST.DATASET.PFX.INST.TEST.SZWESAMP already exists and will n
 `;
 
 exports[`zwe-install (LONG) install, re-install and fail, overwrite and succeed 4`] = `
+"Temporary directory '/tmp/.zweenv-0000' created.
+Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
+-------------------------------------------------------------------------------
+>> Install Zowe MVS data sets
+Warning ZWEL0301W: TEST.DATASET.PFX.INST.TEST.SZWEAUTH already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+Warning ZWEL0301W: TEST.DATASET.PFX.INST.TEST.SZWEEXEC already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+Warning ZWEL0301W: TEST.DATASET.PFX.INST.TEST.SZWELOAD already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+Warning ZWEL0301W: TEST.DATASET.PFX.INST.TEST.SZWESAMP already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
+-------------------------------------------------------------------------------
+>> Zowe MVS data sets installation skipped."
+`;
+
+exports[`zwe-install (LONG) install, re-install and fail, overwrite and succeed 5`] = `
 "Temporary directory '/tmp/.zweenv-0000' created.
 Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
 -------------------------------------------------------------------------------
@@ -1745,8 +1763,28 @@ Description
         dataset:
           prefix: IBMUSER.ZWE
     \`\`\`
-    Expected outputs:
-    - Will create these data sets under \`zowe.setup.dataset.prefix\` definition:
+    - \`zowe.setup.jcl.header\` controls the JOB header parameters for \`ZWEINSTL\` JCL sample.
+    Default setting is empty string causing no additional JOB fields will be used.
+    Is is optional, if your site or External Security Manager does not require additional fields.
+    One line, for example accounting information only:
+    \`\`\`
+    zowe:
+      setup:
+        jcl:
+          header: 123456
+    \`\`\`
+    Multiple lines as an array:
+    \`\`\`
+    zowe:
+      setup:
+        jcl:
+          header:
+            - "123456,"
+            - "//       'Zowe User',"
+            - "//       NOTIFY=&SYSUID"
+    \`\`\`
+    Note: the JCL syntax in not check by \`zwe\` command.
+    - \`zowe.setup.dataset.prefix\` shows where the datasets will be installed:
       * \`SZWEAUTH\` contains few Zowe load modules (++PROGRAM).
       * \`SZWESAMP\` contains several sample configurations.
       * \`SZWEEXEC\` contains few utilities used by Zowe.

--- a/tests/zwe-remote-integration/src/__tests__/install/install.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/install/install.test.ts
@@ -63,11 +63,11 @@ describe(`${testSuiteName}`, () => {
         expect(result.rc).toBe(0);
 
         const cleanupDs: TestFile[] = installDatasets.map((ds) => {
-          return { name: `${cfgYaml.zowe.setup.dataset.prefix}.${ds}`, type: FileType.DS_NON_CLUSTER };
+          return { name: `${test}.${ds}`, type: FileType.DS_NON_CLUSTER };
         });
         await TestFileActions.deleteAll(cleanupDs);
       }
-    }, 300000);
+    }, 500000);
 
     it('install, re-install and fail, overwrite and succeed', async () => {
       _.set(cfgYaml, 'zowe.setup.dataset.prefix', `${cfgYaml.zowe.setup.dataset.prefix}.INST.TEST`);

--- a/tests/zwe-remote-integration/src/config/ZoweYamlType.ts
+++ b/tests/zwe-remote-integration/src/config/ZoweYamlType.ts
@@ -156,15 +156,39 @@ const zoweSchema = zoweYamlSchema as {
               description: 'MVS data set related configurations';
               properties: {
                 prefix: {
-                  $ref: '/schemas/v2/server-common#zoweDatasetPrefix';
+                  oneOf: [
+                    {
+                      $ref: '/schemas/v2/server-common#zoweDatasetPrefix';
+                    },
+                    {
+                      type: 'string';
+                      maxLength: 0;
+                    },
+                  ];
                   description: 'Where Zowe MVS data sets will be installed';
                 };
                 proclib: {
-                  $ref: '/schemas/v2/server-common#zoweDataset';
+                  oneOf: [
+                    {
+                      $ref: '/schemas/v2/server-common#zoweDataset';
+                    },
+                    {
+                      type: 'string';
+                      maxLength: 0;
+                    },
+                  ];
                   description: 'PROCLIB where Zowe STCs will be copied over';
                 };
                 parmlib: {
-                  $ref: '/schemas/v2/server-common#zoweDataset';
+                  oneOf: [
+                    {
+                      $ref: '/schemas/v2/server-common#zoweDataset';
+                    },
+                    {
+                      type: 'string';
+                      maxLength: 0;
+                    },
+                  ];
                   description: 'Zowe PARMLIB';
                 };
                 parmlibMembers: {
@@ -179,21 +203,53 @@ const zoweSchema = zoweYamlSchema as {
                   };
                 };
                 jcllib: {
-                  $ref: '/schemas/v2/server-common#zoweDataset';
+                  oneOf: [
+                    {
+                      $ref: '/schemas/v2/server-common#zoweDataset';
+                    },
+                    {
+                      type: 'string';
+                      maxLength: 0;
+                    },
+                  ];
                   description: 'JCL library where Zowe will store temporary JCLs during initialization';
                 };
                 loadlib: {
-                  $ref: '/schemas/v2/server-common#zoweDataset';
+                  oneOf: [
+                    {
+                      $ref: '/schemas/v2/server-common#zoweDataset';
+                    },
+                    {
+                      type: 'string';
+                      maxLength: 0;
+                    },
+                  ];
                   description: 'States the dataset where Zowe executable utilities are located';
                   default: '<hlq>.SZWELOAD';
                 };
                 authLoadlib: {
-                  $ref: '/schemas/v2/server-common#zoweDataset';
+                  oneOf: [
+                    {
+                      $ref: '/schemas/v2/server-common#zoweDataset';
+                    },
+                    {
+                      type: 'string';
+                      maxLength: 0;
+                    },
+                  ];
                   description: 'The dataset that contains any Zowe core code that needs to run APF-authorized, such as ZIS';
                   default: '<hlq>.SZWEAUTH';
                 };
                 authPluginLib: {
-                  $ref: '/schemas/v2/server-common#zoweDataset';
+                  oneOf: [
+                    {
+                      $ref: '/schemas/v2/server-common#zoweDataset';
+                    },
+                    {
+                      type: 'string';
+                      maxLength: 0;
+                    },
+                  ];
                   description: 'APF authorized LOADLIB for Zowe ZIS Plugins';
                 };
               };
@@ -235,17 +291,41 @@ const zoweSchema = zoweYamlSchema as {
                   description: 'security group name';
                   properties: {
                     admin: {
-                      $ref: '/schemas/v2/server-common#zoweUser';
+                      oneOf: [
+                        {
+                          $ref: '/schemas/v2/server-common#zoweUser';
+                        },
+                        {
+                          type: 'string';
+                          maxLength: 0;
+                        },
+                      ];
                       description: 'Zowe admin user group';
                       default: 'ZWEADMIN';
                     };
                     stc: {
-                      $ref: '/schemas/v2/server-common#zoweUser';
+                      oneOf: [
+                        {
+                          $ref: '/schemas/v2/server-common#zoweUser';
+                        },
+                        {
+                          type: 'string';
+                          maxLength: 0;
+                        },
+                      ];
                       description: 'Zowe STC group';
                       default: 'ZWEADMIN';
                     };
                     sysProg: {
-                      $ref: '/schemas/v2/server-common#zoweUser';
+                      oneOf: [
+                        {
+                          $ref: '/schemas/v2/server-common#zoweUser';
+                        },
+                        {
+                          type: 'string';
+                          maxLength: 0;
+                        },
+                      ];
                       description: 'Zowe SysProg group';
                       default: 'ZWEADMIN';
                     };
@@ -257,12 +337,28 @@ const zoweSchema = zoweYamlSchema as {
                   description: 'security user name';
                   properties: {
                     zowe: {
-                      $ref: '/schemas/v2/server-common#zoweUser';
+                      oneOf: [
+                        {
+                          $ref: '/schemas/v2/server-common#zoweUser';
+                        },
+                        {
+                          type: 'string';
+                          maxLength: 0;
+                        },
+                      ];
                       description: 'Zowe runtime user name of main service';
                       default: 'ZWESVUSR';
                     };
                     zis: {
-                      $ref: '/schemas/v2/server-common#zoweUser';
+                      oneOf: [
+                        {
+                          $ref: '/schemas/v2/server-common#zoweUser';
+                        },
+                        {
+                          type: 'string';
+                          maxLength: 0;
+                        },
+                      ];
                       description: 'Zowe runtime user name of ZIS';
                       default: 'ZWESIUSR';
                     };
@@ -274,17 +370,41 @@ const zoweSchema = zoweYamlSchema as {
                   description: 'STC names';
                   properties: {
                     zowe: {
-                      $ref: '/schemas/v2/server-common#zoweDatasetMember';
+                      oneOf: [
+                        {
+                          $ref: '/schemas/v2/server-common#zoweDatasetMember';
+                        },
+                        {
+                          type: 'string';
+                          maxLength: 0;
+                        },
+                      ];
                       description: 'STC name of main service';
                       default: 'ZWESLSTC';
                     };
                     zis: {
-                      $ref: '/schemas/v2/server-common#zoweDatasetMember';
+                      oneOf: [
+                        {
+                          $ref: '/schemas/v2/server-common#zoweDatasetMember';
+                        },
+                        {
+                          type: 'string';
+                          maxLength: 0;
+                        },
+                      ];
                       description: 'STC name of ZIS';
                       default: 'ZWESISTC';
                     };
                     aux: {
-                      $ref: '/schemas/v2/server-common#zoweDatasetMember';
+                      oneOf: [
+                        {
+                          $ref: '/schemas/v2/server-common#zoweDatasetMember';
+                        },
+                        {
+                          type: 'string';
+                          maxLength: 0;
+                        },
+                      ];
                       description: 'STC name of Auxiliary Service';
                       default: 'ZWESASTC';
                     };

--- a/tests/zwe-remote-integration/src/jest-config.ts
+++ b/tests/zwe-remote-integration/src/jest-config.ts
@@ -8,4 +8,7 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-jest.retryTimes(1, { logErrorsBeforeRetry: true });
+// only set retry when we're not updating snapshots...retries + updates causes problems with duplicate snapshots written out
+if (!process.argv.includes('-u') && !process.argv.includes('--updateSnapshot')) {
+  jest.retryTimes(1, { logErrorsBeforeRetry: true });
+}


### PR DESCRIPTION
Schema changes in #4107 caused this is not valid configuration:
```yaml
zowe:
  setup:
    dataset:
      prefix: 
      parmlib: 
      jcllib: 
      authLoadlib: 
      authPluginLib: 
    security:
      groups:
        admin:
        stc:
        sysProg: 
      users:
        zowe:
        zis: 
      stcs:
        zowe: 
        zis: 
        aux: 
```

It is a braking change, schema must be updated to accept empty or null values for all keys in this example. The main reason is, that the startup process is checking entire configuration, included `zowe.setup.*`. Before the #4107 that example was fine for starting the launcher.