### PR TITLE
Add zis-test and bind-test to utilities folder

### DIFF
--- a/.github/workflows/build-packaging.yml
+++ b/.github/workflows/build-packaging.yml
@@ -276,7 +276,7 @@ jobs:
         with:
           manifest-file-path: ${{ github.workspace }}/manifest.json
           default-target-path: .pax/binaryDependencies/
-          expected-count: 28
+          expected-count: 30
       
       # this step is not doing a publish, we are just utilizing this actions to get the PUBLISH_TARGET_PATH, 
       # and it will be used in the next step: [Download 3] Download SMPE build log

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -257,6 +257,21 @@ pax -ppx -rf "${getesm}"
 rm "${getesm}"
 cd "${BASE_DIR}"
 
+bind_test=$(find "${ZOWE_ROOT_DIR}/files" -type f \( -name "bind-test*.pax" \) | head -n 1)
+echo "[$SCRIPT_NAME] extract bind-test $bind_test"
+cd "${ZOWE_ROOT_DIR}/bin/utils"
+pax -ppx -rf "${bind_test}"
+rm "${bind_test}"
+cd "${BASE_DIR}"
+
+zis_test=$(find "${ZOWE_ROOT_DIR}/files" -type f \( -name "zis-test*.pax" \) | head -n 1)
+echo "[$SCRIPT_NAME] extract zis-test $zis_test"
+cd "${ZOWE_ROOT_DIR}/bin/utils"
+pax -ppx -rf "${zis_test}"
+rm "${zis_test}"
+cd "${BASE_DIR}"
+
+
 configmgr=$(find "${ZOWE_ROOT_DIR}/files" -type f \( -name "configmgr-3*.pax" \) | head -n 1)
 echo "[$SCRIPT_NAME] extract configmgr $configmgr"
 cd "${ZOWE_ROOT_DIR}/bin/utils"

--- a/bin/README.md
+++ b/bin/README.md
@@ -58,6 +58,9 @@ Please be aware of using functions marked as `@experimental`. These functions ma
 - `bin/utils/curl.js`: This node.js script works similar to popular Linux tool `curl`. It can make HTTP/HTTPS request and display response.
 - `bin/utils/getesm`: Executable to get the name of External Security Manager
 - `bin/utils/certificate-analyser.jar`: Java based tool to verify the certificates. See [README](https://github.com/zowe/api-layer/blob/v3.x.x/certificate-analyser/README.md) for more information.
+- `bin/utils/configmr`: A tool to read YAML configuration files present in files or parmlib datasets, validate them against a json-schema, evaluate any `${{ }}` templates within, and return a verified, unified configuration. See [Using the configmgr](https://docs.zowe.org/stable/user-guide/configmgr-using/) for more information.
+- `bin/utils/bind-test`: Can be used to check if a user can bind to a socket. Useful for verifying network configuration and troubleshooting. Usage: `_BPX_JOBNAME=<jobname> bind-test --host <hostname> --port <port>`
+- `bin/utils/zis-test`: Can be used to check if a ZIS is running. Useful for verifying ZIS is running before running code that depends upon it. Usage: `zis-test --zis <crossMemoryServerName>`
 
 Please be aware of using utilities marked as `@experimental`. These utilities may be changed or improved in the future, and they may not be stable enough for extenders to use if they target to support multiple versions of Zowe.
 

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -105,6 +105,14 @@
       "version": "^3.0.0-V3.X-STAGING",
       "artifact": "*.pax"
     },
+    "org.zowe.bind-test": {
+      "version": "^3.0.0-V3.X-STAGING",
+      "artifact": "*.pax"
+    },
+    "org.zowe.zis-test": {
+      "version": "^3.0.0-V3.X-STAGING",
+      "artifact": "*.pax"
+    },
     "org.zowe.configmgr": {
       "version": "^3.0.0-V3.X-STAGING",
       "artifact": "*.pax"


### PR DESCRIPTION
This PR adds the bind-test and zis-test utilities to the bin/utils folder.
They are not used by zowe-install-packaging directly, but will be in the future such as in https://github.com/zowe/zowe-install-packaging/pull/4276

zis-test is currently used in zss and thus needs to be put into the packaging now.