### PR TITLE
Backward compat for apiml modulith by declaring apiml components enabled when they are not

### DIFF
--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -39,6 +39,8 @@ const containerComponentId = std.getenv('ZWE_PRIVATE_CONTAINER_COMPONENT_ID');
 const zosmfHost = std.getenv('ZOSMF_HOST');
 const zosmfPort = Number(std.getenv('ZOSMF_PORT'));
 
+const INDIVIDUAL_APIML_COMPONENTS = ['gateway', 'discovery', 'api-catalog', 'caching-service', 'zaas'];
+
 
 const user = std.getenv('USER');
 
@@ -199,8 +201,17 @@ function validateComponents(enabledComponents:string[]): any {
   // reset error counter
   let privateErrors = 0;
   std.setenv('ZWE_PRIVATE_ERRORS_FOUND','0');
-  enabledComponents.forEach((componentId: string)=> {
+
+  let apimlModulithEnabled = enabledComponents.includes('apiml');
+  for (let i = 0; i < enabledComponents.length; i++) {
+    let componentId = enabledComponents[i];
     common.printFormattedTrace("ZWELS", "zwe-internal-start-prepare,validate_components", `- checking ${componentId}`);
+    
+    if (apimlModulithEnabled && INDIVIDUAL_APIML_COMPONENTS.includes(componentId)) {
+      common.printFormattedTrace("ZWELS", "zwe-internal-start-prepare,validate_components", `- skipping ${componentId} because apiml modulith enabled`);
+      continue;
+    }
+
     const componentDir = component.findComponentDirectory(componentId);
     common.printFormattedTrace("ZWELS", "zwe-internal-start-prepare,validate_components", `- in directory ${componentDir}`);
     if (componentDir) {
@@ -243,7 +254,7 @@ function validateComponents(enabledComponents:string[]): any {
         }
       }
     }
-  });
+  }
 
   std.setenv('ZWE_PRIVATE_ERRORS_FOUND', ''+privateErrors);
   varlib.checkRuntimeValidationResult("zwe-internal-start-prepare,validate_components");
@@ -260,11 +271,18 @@ function configureComponents(componentEnvironments?: any, enabledComponents?:str
   const zwePrivateWorkspaceEnvDir = std.getenv('ZWE_PRIVATE_WORKSPACE_ENV_DIR');
   const zweCliParameterHaInstance = std.getenv('ZWE_CLI_PARAMETER_HA_INSTANCE');
 
-
-  enabledComponents.forEach((componentId: string)=> {
+  let apimlModulithEnabled = enabledComponents.includes('apiml');
+  for (let i = 0; i < enabledComponents.length; i++) {
+    let componentId = enabledComponents[i];
     common.printFormattedTrace("ZWELS", "zwe-internal-start-prepare,configure_components", `- checking ${componentId}`);
+
+    if (apimlModulithEnabled && INDIVIDUAL_APIML_COMPONENTS.includes(componentId)) {
+      common.printFormattedTrace("ZWELS", "zwe-internal-start-prepare,configure_components", `- skipping ${componentId} because apiml modulith enabled`);
+      continue;
+    }
+
     const componentDir = component.findComponentDirectory(componentId);
-    common.printFormattedTrace("ZWELS", "zwe-internal-start-prepare,validate_components", `- in directory ${componentDir}`);
+    common.printFormattedTrace("ZWELS", "zwe-internal-start-prepare,configure_components", `- in directory ${componentDir}`);
     if (componentDir) {
       const manifestPath = component.getManifestPath(componentDir);
       const manifest = component.getManifest(componentDir);
@@ -395,7 +413,7 @@ function configureComponents(componentEnvironments?: any, enabledComponents?:str
         }
       }
     }
-  });
+  }
 
   common.printFormattedDebug("ZWELS", "zwe-internal-start-prepare,configure_components", "component configurations are successful");
 }

--- a/bin/libs/component.ts
+++ b/bin/libs/component.ts
@@ -44,12 +44,23 @@ const MANIFEST_SCHEMAS = `${runtimeDirectory}/schemas/manifest-schema.json:${COM
 const PLUGIN_DEF_SCHEMA_ID = "https://zowe.org/schemas/v2/appfw-plugin-definition";
 const PLUGIN_DEF_SCHEMAS = `${runtimeDirectory}/components/app-server/schemas/plugindefinition-schema.json`;
 
-
+// This intentionally lies about individual apiml components for backward compatibility.
+// If the apiml modulith is enabled, all are considered enabled.
 export function getEnabledComponents() {
   let haInstance = configUtils.sanitizeHaInstanceId();
   let haConfig = configmgr.loadZoweConfig(haInstance);
   let components = Object.keys(haConfig.components);
   let enabled: string[] = [];
+  let apimlModulithEnabled = haConfig.components.apiml.enabled == true;
+  let individualApimlComponents = ['gateway', 'discovery', 'api-catalog', 'caching-service', 'zaas'];
+  
+  if (apimlModulithEnabled) {
+    enabled = enabled.concat(individualApimlComponents);
+    
+    //do not process individual apiml components further
+    components = components.filter(name => !individualApimlComponents.includes(name));
+  }
+  
   components.forEach((key) => {
     if (haConfig.components[key].enabled == true) {
       enabled.push(key);

--- a/bin/libs/config.ts
+++ b/bin/libs/config.ts
@@ -35,52 +35,6 @@ const cliParameterConfig:string = function() {
     return (value as string);
 }();
 
-function isApimlEnabled(): boolean {
-  const config = configmgr.getZoweConfig();
-  const defaultEnabledComponents = component.getEnabledComponents();
-  const componentEnabled = config.components['apiml']?.enabled;
-  return componentEnabled 
-  && !config.components['gateway'].enabled
-  && !config.components['discovery'].enabled
-  && !config.components['caching-service'].enabled
-  && !config.components['api-catalog'].enabled
-  && !config.components['zaas'].enabled
-  && !config.components['apiml'].port == config.components['gateway'].port
-}
-
-function enableApiml() {
-  const config = configmgr.getZoweConfig();
-  const updateObj = {
-    components: {
-      gateway: {
-        enabled: false
-      },
-      discovery: {
-        enabled: false
-      },
-      "caching-service": {
-        enabled: false
-      },
-      zaas: {
-        enabled: false
-      },
-      "api-catalog": {
-        enabled: false
-      },
-      apiml: {
-        enabled: true,
-        port: config.components['gateway'].port
-      }
-    }
-  }
-
-  updateZoweConfig(updateObj, true, 1);
-
-  std.setenv('ZWE_INSTALLED_COMPONENTS', component.findAllInstalledComponents());
-  std.setenv('ZWE_ENABLED_COMPONENTS', component.findAllEnabledComponents());
-  std.setenv('ZWE_LAUNCH_COMPONENTS', component.findAllLaunchComponents());
-}
-
 export function getZoweConfig(): any {
   common.requireZoweYaml();
 
@@ -352,9 +306,19 @@ export function loadEnvironmentVariables(componentId?: string) {
     std.setenv('ZWE_PRIVATE_LOG_LEVEL_ZWELS', logLevel.toUpperCase());
   }
   // generate other variables
+  let enabledComponents = component.findAllEnabledComponents();
   std.setenv('ZWE_INSTALLED_COMPONENTS', component.findAllInstalledComponents());
-  std.setenv('ZWE_ENABLED_COMPONENTS', component.findAllEnabledComponents());
+  std.setenv('ZWE_ENABLED_COMPONENTS', enabledComponents);
   std.setenv('ZWE_LAUNCH_COMPONENTS', component.findAllLaunchComponents());
+
+  //ensure these are set true for backward compat of programs that read the env vars
+  if (enabledComponents.includes('apiml')) {
+    std.setenv('ZWE_components_gateway_enabled', 'true');
+    std.setenv('ZWE_components_discovery_enabled', 'true');
+    std.setenv('ZWE_components_api_catalog_enabled', 'true');
+    std.setenv('ZWE_components_caching_service_enabled', 'true');
+    std.setenv('ZWE_components_zaas_enabled', 'true');
+  }
 
   // ZWE_DISCOVERY_SERVICES_LIST should have been prepared in zowe-install-packaging-tools
 

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -16,7 +16,7 @@
       "artifact": "zowe-server-*.pax.Z"
     },
     "org.zowe.zlux.zlux-core": {
-      "version": "^3.0.0-V3.X-STAGING-ZLUX-CORE",
+      "version": "^3.3.0-zlux-app-server-PR-345",
       "artifact": "*.pax"
     },
     "org.zowe.zlux.sample-angular-app": {
@@ -123,7 +123,8 @@
       "artifact": "*.pax"
     },
     "org.zowe.launcher": {
-      "version": "^3.0.0-STAGING"
+      "version": "^3.3.0-PR-160",
+      "artifact": "*.pax"
     },
     "org.zowe.keyring-utilities": {
       "version": "1.0.4",

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -44,7 +44,7 @@
       "artifact": "*.pax"
     },
     "org.zowe.zss": {
-      "version": "^3.0.0-STAGING",
+      "version": "^3.3.0-PR-787",
       "artifact": "*.pax"
     },
     "org.zowe.explorer-jes": {


### PR DESCRIPTION
This PR includes https://github.com/zowe/launcher/pull/160 and https://github.com/zowe/zlux-app-server/pull/345 and https://github.com/zowe/zss/pull/787

Possibly zss also needs a change, it needs to be reviewed.


This PR attempts to improve backward compatibility of apiml modulith by doing 2 things

1) pretending individual components like "gateway" and "discovery" are enabled whenever "apiml" is
2) having the startup code (this repo, launcher) be smart enough to know that this is a lie, and skip over doing any actual start operations on those individual components

The app-server PR should therefore not be needed, because it should be captured by this compatibility, but to avoid technical debt the app-server PR has been made at this time anyway.

Ideally, this PR would make it so that users do not need to edit their yaml to mark every individual apiml component as "disabled" to use apiml modulith, because setting them to "enabled" won't really do anything, the startup code will ignore it and the startup code will also just inform extensions everything is enabled.