### PR TITLE
Validate yaml in shell `zwe` subcommands 

### DIFF
--- a/bin/commands/.errors
+++ b/bin/commands/.errors
@@ -51,4 +51,5 @@ ZWEL0300W||%s already exists. This %s will be overwritten.
 ZWEL0301W||%s already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
 ZWEL0316E|316|Invalid PARMLIB format %s.
 ZWEL0322E|322|%s is not a valid directory.
-ZWEL0323E||NodeJS required but not found. Errors such as ZWEL0157E may occur as a result. The value 'node.home' in the Zowe YAML is not correct. 
+ZWEL0323E||NodeJS required but not found. Errors such as ZWEL0157E may occur as a result. The value 'node.home' in the Zowe YAML is not correct.
+ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/.errors
+++ b/bin/commands/.errors
@@ -52,4 +52,4 @@ ZWEL0301W||%s already exists and will not be overwritten. For upgrades, you must
 ZWEL0316E|316|Invalid PARMLIB format %s.
 ZWEL0322E|322|%s is not a valid directory.
 ZWEL0323E||NodeJS required but not found. Errors such as ZWEL0157E may occur as a result. The value 'node.home' in the Zowe YAML is not correct.
-ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:
+ZWEL0326E|326|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/.errors
+++ b/bin/commands/.errors
@@ -52,4 +52,4 @@ ZWEL0301W||%s already exists and will not be overwritten. For upgrades, you must
 ZWEL0316E|316|Invalid PARMLIB format %s.
 ZWEL0322E|322|%s is not a valid directory.
 ZWEL0323E||NodeJS required but not found. Errors such as ZWEL0157E may occur as a result. The value 'node.home' in the Zowe YAML is not correct.
-ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:
+ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/config/validate/.examples
+++ b/bin/commands/config/validate/.examples
@@ -1,3 +1,3 @@
 zwe config validate -c /path/to/zowe.yaml
-zwe config validate -c FILE(/customizations/zowe.yaml):FILE(/defaults/zowe.yaml) --all
+zwe config validate -c 'FILE(/customizations/zowe.yaml):FILE(/defaults/zowe.yaml)' --all
 zwe config validate -c 'FILE(/path/to/zowe.yaml):PARMLIB(ZOWE.PARMLIB(YAML))'

--- a/bin/commands/init/.examples
+++ b/bin/commands/init/.examples
@@ -4,4 +4,4 @@ zwe init apfauth -v -c /path/to/zowe.yaml
 
 zwe init certificate -v -c /path/to/zowe.yaml
 
-zwe init --config "PARMLIB(ZOWE.PARMS(MAIN)):PARMLIB(ZOWE.PARMS(DEGUBMOD))" --jcl
+zwe init --config "PARMLIB(ZOWE.PARMS(MAIN)):PARMLIB(ZOWE.PARMS(DEBUGMOD))" --jcl

--- a/bin/commands/init/apfauth/.errors
+++ b/bin/commands/init/apfauth/.errors
@@ -3,4 +3,4 @@ ZWEL0324E|324|The dataset specified in %s does not exist.
 ZWEL0325E|325|Failed to prepare %s
 ZWEL0158I|158|zowe.setup.dataset.authLoadlib is not defined in Zowe YAML configuration file. Using the default value %s.SZWEAUTH.
 ZWEL0159I|159|zowe.setup.dataset.authPluginLib is not defined in Zowe YAML configuration file. Skipping.
-ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:
+ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/apfauth/.errors
+++ b/bin/commands/init/apfauth/.errors
@@ -3,3 +3,4 @@ ZWEL0324E|324|The dataset specified in %s does not exist.
 ZWEL0325E|325|Failed to prepare %s
 ZWEL0158I|158|zowe.setup.dataset.authLoadlib is not defined in Zowe YAML configuration file. Using the default value %s.SZWEAUTH.
 ZWEL0159I|159|zowe.setup.dataset.authPluginLib is not defined in Zowe YAML configuration file. Skipping.
+ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/apfauth/.errors
+++ b/bin/commands/init/apfauth/.errors
@@ -3,4 +3,4 @@ ZWEL0324E|324|The dataset specified in %s does not exist.
 ZWEL0325E|325|Failed to prepare %s
 ZWEL0158I|158|zowe.setup.dataset.authLoadlib is not defined in Zowe YAML configuration file. Using the default value %s.SZWEAUTH.
 ZWEL0159I|159|zowe.setup.dataset.authPluginLib is not defined in Zowe YAML configuration file. Skipping.
-ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:
+ZWEL0326E|326|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/apfauth/index.sh
+++ b/bin/commands/init/apfauth/index.sh
@@ -13,6 +13,10 @@
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
 USE_JCL=$(check_jcl_enabled)
+if [[ "${USE_JCL}" == "error"* ]]; then
+  code=$(echo "${USE_JCL}" | awk '{print $2}')
+  exit $code
+fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -z "${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}" ]; then
 

--- a/bin/commands/init/apfauth/index.sh
+++ b/bin/commands/init/apfauth/index.sh
@@ -12,11 +12,8 @@
 #######################################################################
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
+validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}"
 USE_JCL=$(check_jcl_enabled)
-if [[ "${USE_JCL}" == "error"* ]]; then
-  code=$(echo "${USE_JCL}" | awk '{print $2}')
-  exit $code
-fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -z "${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}" ]; then
 
@@ -42,10 +39,6 @@ DRY_RUN=
 if [ -n "${ZWE_CLI_PARAMETER_DRY_RUN}" ] || [ -n "${ZWE_CLI_PARAMETER_SECURITY_DRY_RUN}" ]; then
   DRY_RUN="true"
 fi
-
-###############################
-# validation
-require_zowe_yaml "skipnode"
 
 # read prefix and validate
 prefix=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.dataset.prefix")

--- a/bin/commands/init/certificate/.errors
+++ b/bin/commands/init/certificate/.errors
@@ -2,3 +2,4 @@ ZWEL0164E|164|Value of %s (%s) defined in Zowe YAML configuration file is invali
 ZWEL0174E|174|Failed to generate certificate in Zowe keyring "%s/%s".
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
 ZWEL0201E|201|File %s does not exist.
+ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/certificate/.errors
+++ b/bin/commands/init/certificate/.errors
@@ -2,4 +2,4 @@ ZWEL0164E|164|Value of %s (%s) defined in Zowe YAML configuration file is invali
 ZWEL0174E|174|Failed to generate certificate in Zowe keyring "%s/%s".
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
 ZWEL0201E|201|File %s does not exist.
-ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:
+ZWEL0326E|326|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/certificate/.errors
+++ b/bin/commands/init/certificate/.errors
@@ -2,4 +2,4 @@ ZWEL0164E|164|Value of %s (%s) defined in Zowe YAML configuration file is invali
 ZWEL0174E|174|Failed to generate certificate in Zowe keyring "%s/%s".
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
 ZWEL0201E|201|File %s does not exist.
-ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:
+ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/certificate/index.sh
+++ b/bin/commands/init/certificate/index.sh
@@ -27,6 +27,10 @@ else
 fi
 
 USE_JCL=$(check_jcl_enabled)
+if [[ "${USE_JCL}" == "error"* ]]; then
+  code=$(echo "${USE_JCL}" | awk '{print $2}')
+  exit $code
+fi
 
 export ZWE_PRIVATE_TMP_MERGED_YAML_DIR=$(create_tmp_file)
 mkdir -p ${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}

--- a/bin/commands/init/certificate/index.sh
+++ b/bin/commands/init/certificate/index.sh
@@ -15,7 +15,7 @@ print_level1_message "Generate certificate"
 
 ###############################
 # validation
-require_zowe_yaml "skipnode"
+validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}"
 
 # Keytool is needed
 require_java

--- a/bin/commands/init/certificate/index.sh
+++ b/bin/commands/init/certificate/index.sh
@@ -27,10 +27,6 @@ else
 fi
 
 USE_JCL=$(check_jcl_enabled)
-if [[ "${USE_JCL}" == "error"* ]]; then
-  code=$(echo "${USE_JCL}" | awk '{print $2}')
-  exit $code
-fi
 
 export ZWE_PRIVATE_TMP_MERGED_YAML_DIR=$(create_tmp_file)
 mkdir -p ${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}

--- a/bin/commands/init/index.sh
+++ b/bin/commands/init/index.sh
@@ -13,6 +13,10 @@
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
 USE_JCL=$(check_jcl_enabled)
+if [[ "${USE_JCL}" == "error"* ]]; then
+  code=$(echo "${USE_JCL}" | awk '{print $2}')
+  exit $code
+fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -z "${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}" ]; then
 

--- a/bin/commands/init/index.sh
+++ b/bin/commands/init/index.sh
@@ -12,11 +12,8 @@
 #######################################################################
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
+validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}"
 USE_JCL=$(check_jcl_enabled)
-if [[ "${USE_JCL}" == "error"* ]]; then
-  code=$(echo "${USE_JCL}" | awk '{print $2}')
-  exit $code
-fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -z "${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}" ]; then
 
@@ -58,7 +55,6 @@ if [ -z "${yaml_java_home}" ]; then
   fi
 fi
 # zowe.runtimeDirectory
-require_zowe_yaml "skipnode"
 update_zowe_runtime_dir=
 # do we have zowe.runtimeDirectory defined in zowe.yaml?
 yaml_runtime_dir=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.runtimeDirectory")

--- a/bin/commands/init/mvs/.errors
+++ b/bin/commands/init/mvs/.errors
@@ -1,2 +1,3 @@
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
 ZWEL0158E|158|%s already exists.
+ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/mvs/.errors
+++ b/bin/commands/init/mvs/.errors
@@ -1,3 +1,3 @@
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
 ZWEL0158E|158|%s already exists.
-ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:
+ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/mvs/.errors
+++ b/bin/commands/init/mvs/.errors
@@ -1,3 +1,3 @@
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
 ZWEL0158E|158|%s already exists.
-ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:
+ZWEL0326E|326|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/mvs/index.sh
+++ b/bin/commands/init/mvs/index.sh
@@ -13,6 +13,10 @@
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
 USE_JCL=$(check_jcl_enabled)
+if [[ "${USE_JCL}" == "error"* ]]; then
+  code=$(echo "${USE_JCL}" | awk '{print $2}')
+  exit $code
+fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -z "${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}" ]; then
 

--- a/bin/commands/init/mvs/index.sh
+++ b/bin/commands/init/mvs/index.sh
@@ -12,11 +12,8 @@
 #######################################################################
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
+validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}"
 USE_JCL=$(check_jcl_enabled)
-if [[ "${USE_JCL}" == "error"* ]]; then
-  code=$(echo "${USE_JCL}" | awk '{print $2}')
-  exit $code
-fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -z "${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}" ]; then
 
@@ -45,10 +42,6 @@ DRY_RUN=
 if [ -n "${ZWE_CLI_PARAMETER_DRY_RUN}" ] || [ -n "${ZWE_CLI_PARAMETER_SECURITY_DRY_RUN}" ]; then
   DRY_RUN="true"
 fi
-
-###############################
-# validation
-require_zowe_yaml "skipnode"
 
 # read prefix and validate
 prefix=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.dataset.prefix")

--- a/bin/commands/init/security/.errors
+++ b/bin/commands/init/security/.errors
@@ -4,3 +4,4 @@ ZWEL0162E|162|Failed to find job %s result.
 ZWEL0163E|163|Job %s ends with code %s.
 ZWEL0163W||Job %s ends with code %s.
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
+ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/security/.errors
+++ b/bin/commands/init/security/.errors
@@ -4,4 +4,4 @@ ZWEL0162E|162|Failed to find job %s result.
 ZWEL0163E|163|Job %s ends with code %s.
 ZWEL0163W||Job %s ends with code %s.
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
-ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:
+ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/security/.errors
+++ b/bin/commands/init/security/.errors
@@ -4,4 +4,4 @@ ZWEL0162E|162|Failed to find job %s result.
 ZWEL0163E|163|Job %s ends with code %s.
 ZWEL0163W||Job %s ends with code %s.
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
-ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:
+ZWEL0326E|326|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/security/index.sh
+++ b/bin/commands/init/security/index.sh
@@ -12,11 +12,8 @@
 #######################################################################
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
+validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}"
 USE_JCL=$(check_jcl_enabled)
-if [[ "${USE_JCL}" == "error"* ]]; then
-  code=$(echo "${USE_JCL}" | awk '{print $2}')
-  exit $code
-fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -z "${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}" ]; then
 
@@ -38,10 +35,6 @@ print_level1_message "Run Zowe security configurations"
 
 ###############################
 # constants
-
-###############################
-# validation
-require_zowe_yaml "skipnode"
 
 # read prefix and validate
 prefix=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.dataset.prefix")

--- a/bin/commands/init/security/index.sh
+++ b/bin/commands/init/security/index.sh
@@ -13,6 +13,10 @@
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
 USE_JCL=$(check_jcl_enabled)
+if [[ "${USE_JCL}" == "error"* ]]; then
+  code=$(echo "${USE_JCL}" | awk '{print $2}')
+  exit $code
+fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -z "${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}" ]; then
 

--- a/bin/commands/init/stc/.errors
+++ b/bin/commands/init/stc/.errors
@@ -3,4 +3,4 @@ ZWEL0129E|129|The path to the Zowe YAML config must be less than 74 characters. 
 ZWEL0130E|130|%s.%s(%s) already exists. This data set member will be overwritten during configuration.
 ZWEL0158E|158|%s already exists.
 ZWEL0159E|159|Failed to modify %s.
-ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:
+ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/stc/.errors
+++ b/bin/commands/init/stc/.errors
@@ -3,3 +3,4 @@ ZWEL0129E|129|The path to the Zowe YAML config must be less than 74 characters. 
 ZWEL0130E|130|%s.%s(%s) already exists. This data set member will be overwritten during configuration.
 ZWEL0158E|158|%s already exists.
 ZWEL0159E|159|Failed to modify %s.
+ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/stc/.errors
+++ b/bin/commands/init/stc/.errors
@@ -3,4 +3,4 @@ ZWEL0129E|129|The path to the Zowe YAML config must be less than 74 characters. 
 ZWEL0130E|130|%s.%s(%s) already exists. This data set member will be overwritten during configuration.
 ZWEL0158E|158|%s already exists.
 ZWEL0159E|159|Failed to modify %s.
-ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:
+ZWEL0326E|326|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/stc/index.sh
+++ b/bin/commands/init/stc/index.sh
@@ -13,6 +13,10 @@
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
 USE_JCL=$(check_jcl_enabled)
+if [[ "${USE_JCL}" == "error"* ]]; then
+  code=$(echo "${USE_JCL}" | awk '{print $2}')
+  exit $code
+fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -z "${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}" ]; then
 

--- a/bin/commands/init/stc/index.sh
+++ b/bin/commands/init/stc/index.sh
@@ -12,11 +12,8 @@
 #######################################################################
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
+validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}"
 USE_JCL=$(check_jcl_enabled)
-if [[ "${USE_JCL}" == "error"* ]]; then
-  code=$(echo "${USE_JCL}" | awk '{print $2}')
-  exit $code
-fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -z "${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}" ]; then
 
@@ -43,10 +40,6 @@ DRY_RUN=
 if [ -n "${ZWE_CLI_PARAMETER_DRY_RUN}" ] || [ -n "${ZWE_CLI_PARAMETER_SECURITY_DRY_RUN}" ]; then
   DRY_RUN="true"
 fi
-
-###############################
-# validation
-require_zowe_yaml "skipnode"
 
 # read prefix and validate
 prefix=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.dataset.prefix")

--- a/bin/commands/init/vsam/.errors
+++ b/bin/commands/init/vsam/.errors
@@ -1,4 +1,4 @@
 ZWEL0158E|158|%s already exists.
 ZWEL0304W|0|Zowe Caching Service is not configured to use VSAM. Command skipped.
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
-ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:
+ZWEL0326E|326|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/vsam/.errors
+++ b/bin/commands/init/vsam/.errors
@@ -1,3 +1,4 @@
 ZWEL0158E|158|%s already exists.
 ZWEL0304W|0|Zowe Caching Service is not configured to use VSAM. Command skipped.
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
+ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/vsam/.errors
+++ b/bin/commands/init/vsam/.errors
@@ -1,4 +1,4 @@
 ZWEL0158E|158|%s already exists.
 ZWEL0304W|0|Zowe Caching Service is not configured to use VSAM. Command skipped.
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
-ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:
+ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/vsam/index.sh
+++ b/bin/commands/init/vsam/index.sh
@@ -12,11 +12,8 @@
 #######################################################################
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
+validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}"
 USE_JCL=$(check_jcl_enabled)
-if [[ "${USE_JCL}" == "error"* ]]; then
-  code=$(echo "${USE_JCL}" | awk '{print $2}')
-  exit $code
-fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -z "${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}" ]; then
 
@@ -41,10 +38,6 @@ DRY_RUN=
 if [ -n "${ZWE_CLI_PARAMETER_DRY_RUN}" ] || [ -n "${ZWE_CLI_PARAMETER_SECURITY_DRY_RUN}" ]; then
   DRY_RUN="true"
 fi
-
-###############################
-# validation
-require_zowe_yaml "skipnode"
 
 caching_storage=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".components.caching-service.storage.mode" | upper_case)
 if [ "${caching_storage}" != "VSAM" ]; then

--- a/bin/commands/init/vsam/index.sh
+++ b/bin/commands/init/vsam/index.sh
@@ -13,6 +13,10 @@
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
 USE_JCL=$(check_jcl_enabled)
+if [[ "${USE_JCL}" == "error"* ]]; then
+  code=$(echo "${USE_JCL}" | awk '{print $2}')
+  exit $code
+fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -z "${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}" ]; then
 

--- a/bin/commands/install/.errors
+++ b/bin/commands/install/.errors
@@ -1,2 +1,2 @@
 ZWEL0301W||%s already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
-ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:
+ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/install/.errors
+++ b/bin/commands/install/.errors
@@ -1,2 +1,2 @@
 ZWEL0301W||%s already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
-ZWEL0158E||%s already exists.
+ZWEL0324E|324|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/install/.errors
+++ b/bin/commands/install/.errors
@@ -1,2 +1,2 @@
 ZWEL0301W||%s already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.
-ZWEL0325E|325|An error occurred while processing Zowe YAML config %s:
+ZWEL0326E|326|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/install/index.sh
+++ b/bin/commands/install/index.sh
@@ -86,7 +86,6 @@ else
         # warning
         print_message "Warning ZWEL0300W: ${prefix}.${ds} already exists. This dataset will be overwritten."
       else
-        # print_error_and_exit "Error ZWEL0158E: ${prefix}.${ds} already exists." "" 158
         # warning
         print_message "Warning ZWEL0301W: ${prefix}.${ds} already exists and will not be overwritten. For upgrades, you must use --allow-overwrite."
       fi

--- a/bin/commands/install/index.sh
+++ b/bin/commands/install/index.sh
@@ -59,8 +59,6 @@ else
   else
     require_zowe_yaml "skipnode"
 
-    validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}"
-
     # read prefix and validate
     prefix=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.dataset.prefix")
     if [ -z "${prefix}" ]; then

--- a/bin/commands/install/index.sh
+++ b/bin/commands/install/index.sh
@@ -19,11 +19,8 @@ if [ -z "${ZWE_PRIVATE_TMP_MERGED_YAML_DIR}" ]; then
 fi
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
+validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}" "ignoreUndefinedConfig"
 USE_JCL=$(check_jcl_enabled)
-if [[ "${USE_JCL}" == "error"* ]]; then
-  code=$(echo "${USE_JCL}" | awk '{print $2}')
-  exit $code
-fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -n "${ZWE_CLI_PARAMETER_CONFIG}" ]; then
     _CEE_RUNOPTS="${CEE_RO}" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/install/cli.js"
@@ -58,8 +55,6 @@ else
       fi
     fi
   else
-    require_zowe_yaml "skipnode"
-
     # read prefix and validate
     prefix=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.dataset.prefix")
     if [ -z "${prefix}" ]; then

--- a/bin/commands/install/index.sh
+++ b/bin/commands/install/index.sh
@@ -20,6 +20,9 @@ fi
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
 USE_JCL=$(check_jcl_enabled)
+if [ "${USE_JCL}" = "yamlError" ]; then
+  exit 324
+fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -n "${ZWE_CLI_PARAMETER_CONFIG}" ]; then
     _CEE_RUNOPTS="${CEE_RO}" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/bin/commands/install/cli.js"

--- a/bin/commands/install/index.sh
+++ b/bin/commands/install/index.sh
@@ -55,6 +55,8 @@ else
       fi
     fi
   else
+    # second validate/require, at this point we cannot ignore an undefined config
+    validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}" 
     # read prefix and validate
     prefix=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.dataset.prefix")
     if [ -z "${prefix}" ]; then

--- a/bin/commands/install/index.sh
+++ b/bin/commands/install/index.sh
@@ -56,6 +56,8 @@ else
   else
     require_zowe_yaml "skipnode"
 
+    validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}"
+
     # read prefix and validate
     prefix=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.dataset.prefix")
     if [ -z "${prefix}" ]; then

--- a/bin/commands/install/index.sh
+++ b/bin/commands/install/index.sh
@@ -20,8 +20,9 @@ fi
 
 CONFIGMGR_SYNTAX=$(check_configmgr_config_syntax)
 USE_JCL=$(check_jcl_enabled)
-if [ "${USE_JCL}" = "yamlError" ]; then
-  exit 324
+if [[ "${USE_JCL}" == "error"* ]]; then
+  code=$(echo "${USE_JCL}" | awk '{print $2}')
+  exit $code
 fi
 if [ "${USE_JCL}" = "true" ]; then
   if [ -n "${ZWE_CLI_PARAMETER_CONFIG}" ]; then

--- a/bin/libs/common.sh
+++ b/bin/libs/common.sh
@@ -110,10 +110,8 @@ validate_zowe_yaml() {
   print_trace "  * Output:"
   print_trace "$(padding_left "${result}" "    ")"
 
-  if [ ${code} -eq 0 ]; then
-    printf "true"
-  else
-    printf "false"
+  if [ ${code} -ne 0 ]; then
+    print_error_and_exit "Error ZWEL0324E The YAML error detected in ${inpFile}."
   fi
 }
 

--- a/bin/libs/common.sh
+++ b/bin/libs/common.sh
@@ -20,7 +20,7 @@ export _BPXK_AUTOCVT="ON"
 export _EDC_ADD_ERRNO2=1                        # show details on error
 unset ENV             # just in case, as it can cause unexpected output
 
-# Leveraging JCL driven init and install is opt-in via config option or 
+# Leveraging JCL driven init and install is opt-in via config option or
 # a flag passed to the calling command.
 check_jcl_enabled() {
   # first, we have to make sure configmgr is enabled
@@ -51,7 +51,7 @@ check_configmgr_config_syntax() {
     echo "true"
   elif [[ ${ZWE_CLI_PARAMETER_CONFIG} == "PARMLIB("* ]]; then
     echo "true"
-  else 
+  else
     echo "false"
   fi
 }
@@ -88,6 +88,35 @@ require_zowe_yaml() {
     print_error_and_exit "Error ZWEL0109E: The Zowe YAML config file specified does not exist." "" 109
   fi
 }
+
+validate_zowe_yaml() {
+  inpFile="${1}"
+
+  if [[ ${inpFile} == "FILE("* ]] || [[ ${inpFile} == "PARMLIB("* ]]; then
+    file="${inpFile}"
+  else
+    file="FILE(${inpFile})"
+  fi
+
+  print_trace "- validate_zowe_yaml process ${file}'"
+
+  configmgr="${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr"
+  schemas="${ZWE_zowe_runtimeDirectory}/schemas/server-common.json:${ZWE_zowe_runtimeDirectory}/schemas/zowe-yaml-schema.json"
+
+  result=$(_CEE_RUNOPTS="XPLINK(ON)" "${configmgr}" -s "${schemas}" -p "${file}" validate)
+  code=$?
+
+  print_trace "  * Exit code: ${code}"
+  print_trace "  * Output:"
+  print_trace "$(padding_left "${result}" "    ")"
+
+  if [ ${code} -eq 0 ]; then
+    printf "true"
+  else
+    printf "false"
+  fi
+}
+
 
 print_raw_message() {
   message="${1}"

--- a/bin/libs/common.sh
+++ b/bin/libs/common.sh
@@ -35,6 +35,11 @@ check_jcl_enabled() {
     echo "true"
     return
   fi
+  validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}"
+  if [ $? -ne 0 ]; then
+    echo "yamlError"
+    return
+  fi
   USE_JCL=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.jcl.enable")
   if [ "${USE_JCL}" = "true" ]; then
     echo "true"
@@ -98,23 +103,18 @@ validate_zowe_yaml() {
     file="FILE(${inpFile})"
   fi
 
-  print_trace "- validate_zowe_yaml process ${file}'"
-
   configmgr="${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr"
   schemas="${ZWE_zowe_runtimeDirectory}/schemas/server-common.json:${ZWE_zowe_runtimeDirectory}/schemas/zowe-yaml-schema.json"
 
-  result=$(_CEE_RUNOPTS="XPLINK(ON)" "${configmgr}" -s "${schemas}" -p "${file}" validate)
+  result=$(_CEE_RUNOPTS="XPLINK(ON)" "${configmgr}" -s "${schemas}" -p "${file}" validate 2>&1 >/dev/null)
   code=$?
 
-  print_trace "  * Exit code: ${code}"
-  print_trace "  * Output:"
-  print_trace "$(padding_left "${result}" "    ")"
-
   if [ ${code} -ne 0 ]; then
-    print_error_and_exit "Error ZWEL0324E The YAML error detected in ${inpFile}."
+    print_error "Error ZWEL0324E: An error was detected in Zowe YAML configuration:"
+    print_error "${result}"
   fi
+  return ${code}
 }
-
 
 print_raw_message() {
   message="${1}"

--- a/bin/libs/common.sh
+++ b/bin/libs/common.sh
@@ -36,8 +36,9 @@ check_jcl_enabled() {
     return
   fi
   validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}"
+  code=$?
   if [ $? -ne 0 ]; then
-    echo "yamlError"
+    echo "error ${code}"
     return
   fi
   USE_JCL=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.jcl.enable")
@@ -110,8 +111,9 @@ validate_zowe_yaml() {
   code=$?
 
   if [ ${code} -ne 0 ]; then
-    print_error "Error ZWEL0324E: An error was detected in Zowe YAML configuration:"
+    print_error "Error ZWEL0324E: An error occurred while processing Zowe YAML config ${inpFile}:"
     print_error "${result}"
+    code=324
   fi
   return ${code}
 }

--- a/bin/libs/common.sh
+++ b/bin/libs/common.sh
@@ -89,39 +89,6 @@ require_zowe_yaml() {
   fi
 }
 
-validate_zowe_yaml() {
-  inpConfig="${1}"
-  ignoreUndefined="${2}"
-
-  if [ -z "${inpConfig}" ]; then
-    if  [ -n "${ignoreUndefined}" ]; then
-      return 0
-    elsew
-      print_error "Error ZWEL0108E: Zowe YAML config file is required."
-      return 108
-    fi
-  fi
-
-  if [[ ${inpConfig} == "FILE("* ]] || [[ ${inpConfig} == "PARMLIB("* ]]; then
-    file="${inpConfig}"
-  else
-    file="FILE(${inpConfig})"
-  fi
-
-  configmgr="${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr"
-  schemas="${ZWE_zowe_runtimeDirectory}/schemas/server-common.json:${ZWE_zowe_runtimeDirectory}/schemas/zowe-yaml-schema.json"
-
-  result=$(_CEE_RUNOPTS="XPLINK(ON)" "${configmgr}" -s "${schemas}" -p "${file}" validate 2>&1 >/dev/null)
-  code=$?
-
-  if [ ${code} -ne 0 ]; then
-    print_error "Error ZWEL0325E: An error occurred while processing Zowe YAML config ${inpFile}:"
-    print_error "${result}"
-    code=325
-  fi
-  return $code
-}
-
 print_raw_message() {
   message="${1}"
   is_error="${2}"

--- a/bin/libs/common.sh
+++ b/bin/libs/common.sh
@@ -35,12 +35,6 @@ check_jcl_enabled() {
     echo "true"
     return
   fi
-  validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}"
-  code=$?
-  if [ $code -ne 0 ]; then
-    echo "error ${code}"
-    return
-  fi
   USE_JCL=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.jcl.enable")
   if [ "${USE_JCL}" = "true" ]; then
     echo "true"
@@ -96,12 +90,22 @@ require_zowe_yaml() {
 }
 
 validate_zowe_yaml() {
-  inpFile="${1}"
+  inpConfig="${1}"
+  ignoreUndefined="${2}"
 
-  if [[ ${inpFile} == "FILE("* ]] || [[ ${inpFile} == "PARMLIB("* ]]; then
-    file="${inpFile}"
+  if [ -z "${inpConfig}" ]; then
+    if  [ -n "${ignoreUndefined}" ]; then
+      return 0
+    elsew
+      print_error "Error ZWEL0108E: Zowe YAML config file is required."
+      return 108
+    fi
+  fi
+
+  if [[ ${inpConfig} == "FILE("* ]] || [[ ${inpConfig} == "PARMLIB("* ]]; then
+    file="${inpConfig}"
   else
-    file="FILE(${inpFile})"
+    file="FILE(${inpConfig})"
   fi
 
   configmgr="${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr"

--- a/bin/libs/common.sh
+++ b/bin/libs/common.sh
@@ -37,7 +37,7 @@ check_jcl_enabled() {
   fi
   validate_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}"
   code=$?
-  if [ $? -ne 0 ]; then
+  if [ $code -ne 0 ]; then
     echo "error ${code}"
     return
   fi
@@ -115,7 +115,7 @@ validate_zowe_yaml() {
     print_error "${result}"
     code=324
   fi
-  return ${code}
+  return $code
 }
 
 print_raw_message() {

--- a/bin/libs/common.sh
+++ b/bin/libs/common.sh
@@ -111,9 +111,9 @@ validate_zowe_yaml() {
   code=$?
 
   if [ ${code} -ne 0 ]; then
-    print_error "Error ZWEL0324E: An error occurred while processing Zowe YAML config ${inpFile}:"
+    print_error "Error ZWEL0325E: An error occurred while processing Zowe YAML config ${inpFile}:"
     print_error "${result}"
-    code=324
+    code=325
   fi
   return $code
 }

--- a/bin/libs/config.sh
+++ b/bin/libs/config.sh
@@ -181,7 +181,7 @@ validate_zowe_yaml() {
   code=$?
 
   if [ ${code} -ne 0 ]; then
-    print_error "Error ZWEL0325E: An error occurred while processing Zowe YAML config ${inpConfig}:"
+    print_error "Error ZWEL0326E: An error occurred while processing Zowe YAML config ${inpConfig}:"
     print_error "$(padding_left "${result}" "    ")"
     exit 325
   else

--- a/bin/libs/config.sh
+++ b/bin/libs/config.sh
@@ -11,7 +11,7 @@
 ################################################################################
 
 ################################################################################
-# @internal 
+# @internal
 
 ###############################
 # Check encoding of a file and convert to IBM-1047 if needed.
@@ -150,5 +150,41 @@ load_environment_variables() {
 
   if [ "${ZWE_RUN_IN_CONTAINER}" = "true" ]; then
     prepare_container_runtime_environments
+  fi
+}
+
+validate_zowe_yaml() {
+  inpConfig="${1}"
+  ignoreUndefined="${2}"
+
+  print_trace "- validate_zowe_yaml configuration ${inpConfig}"
+
+  if [ -z "${inpConfig}" ]; then
+    if  [ -n "${ignoreUndefined}" ]; then
+      print_trace "  - ignore undefined config"
+      return
+    else
+      print_error_and_exit "Error ZWEL0108E: Zowe YAML config file is required." "" 108
+    fi
+  fi
+
+  if [[ ${inpConfig} == "FILE("* ]] || [[ ${inpConfig} == "PARMLIB("* ]]; then
+    file="${inpConfig}"
+  else
+    file="FILE(${inpConfig})"
+  fi
+
+  configmgr="${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr"
+  schemas="${ZWE_zowe_runtimeDirectory}/schemas/server-common.json:${ZWE_zowe_runtimeDirectory}/schemas/zowe-yaml-schema.json"
+
+  result=$(_CEE_RUNOPTS="XPLINK(ON)" "${configmgr}" -s "${schemas}" -p "${file}" validate 2>&1 >/dev/null)
+  code=$?
+
+  if [ ${code} -ne 0 ]; then
+    print_error "Error ZWEL0325E: An error occurred while processing Zowe YAML config ${inpConfig}:"
+    print_error "$(padding_left "${result}" "    ")"
+    exit 325
+  else
+    print_trace
   fi
 }

--- a/bin/libs/config.sh
+++ b/bin/libs/config.sh
@@ -185,6 +185,6 @@ validate_zowe_yaml() {
     print_error "$(padding_left "${result}" "    ")"
     exit 325
   else
-    print_trace
+    print_trace "$(padding_left "${result}" "    ")"
   fi
 }

--- a/tests/zwe-remote-integration/src/__tests__/features/__resources__/bad.yaml
+++ b/tests/zwe-remote-integration/src/__tests__/features/__resources__/bad.yaml
@@ -1,0 +1,9 @@
+zowe:
+  setup:
+    dataset:
+      prefix: ZOWE.PR#4444
+      jcllib ZOWE.PR#4444.JCLLIB
+    jcl:
+      enable: true
+      header: '12345'
+  runtimeDirectory: /zowe/4444

--- a/tests/zwe-remote-integration/src/__tests__/features/__snapshots__/invalidYaml.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/features/__snapshots__/invalidYaml.test.ts.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 1`] = `
-"Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+"Error ZWEL0326E: An error occurred while processing Zowe YAML config /test/dir/zowe.test.yaml:
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 5, column 7, could not find expected ':' at line 6, column 5.
     ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 2`] = `
-"Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+"Error ZWEL0326E: An error occurred while processing Zowe YAML config /test/dir/zowe.test.yaml:
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 5, column 7, could not find expected ':' at line 6, column 5.
     ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 3`] = `
-"Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+"Error ZWEL0326E: An error occurred while processing Zowe YAML config /test/dir/zowe.test.yaml:
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 5, column 7, could not find expected ':' at line 6, column 5.
     ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
@@ -22,36 +22,36 @@ exports[`feat-invalidYaml (SHORT) run commands with bad config 4`] = `
 "-------------------------------------------------------------------------------
 >> Generate certificate
 
-Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+Error ZWEL0326E: An error occurred while processing Zowe YAML config /test/dir/zowe.test.yaml:
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 5, column 7, could not find expected ':' at line 6, column 5.
     ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 5`] = `
-"Error: Could not load config for FILE(zowe.test.yaml):FILE(/test/dir/files/defaults.yaml), status=7
-ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7."
+"Error: Could not load config for FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml), status=7
+ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 5, column 7, could not find expected ':' at line 6, column 5."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 6`] = `
-"Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+"Error ZWEL0326E: An error occurred while processing Zowe YAML config /test/dir/zowe.test.yaml:
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 5, column 7, could not find expected ':' at line 6, column 5.
     ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 7`] = `
-"Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+"Error ZWEL0326E: An error occurred while processing Zowe YAML config /test/dir/zowe.test.yaml:
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 5, column 7, could not find expected ':' at line 6, column 5.
     ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 8`] = `
-"Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+"Error ZWEL0326E: An error occurred while processing Zowe YAML config /test/dir/zowe.test.yaml:
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 5, column 7, could not find expected ':' at line 6, column 5.
     ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 9`] = `
-"Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+"Error ZWEL0326E: An error occurred while processing Zowe YAML config /test/dir/zowe.test.yaml:
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 5, column 7, could not find expected ':' at line 6, column 5.
     ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;

--- a/tests/zwe-remote-integration/src/__tests__/features/__snapshots__/invalidYaml.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/features/__snapshots__/invalidYaml.test.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`feat-invalidYaml (SHORT) run commands with bad config 1`] = `
+"Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+`;
+
+exports[`feat-invalidYaml (SHORT) run commands with bad config 2`] = `
+"Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+`;
+
+exports[`feat-invalidYaml (SHORT) run commands with bad config 3`] = `
+"Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+`;
+
+exports[`feat-invalidYaml (SHORT) run commands with bad config 4`] = `
+"-------------------------------------------------------------------------------
+>> Generate certificate
+
+Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+`;
+
+exports[`feat-invalidYaml (SHORT) run commands with bad config 5`] = `
+"Error: Could not load config for FILE(zowe.test.yaml):FILE(/test/dir/files/defaults.yaml), status=7
+ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7."
+`;
+
+exports[`feat-invalidYaml (SHORT) run commands with bad config 6`] = `
+"Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+`;
+
+exports[`feat-invalidYaml (SHORT) run commands with bad config 7`] = `
+"Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+`;
+
+exports[`feat-invalidYaml (SHORT) run commands with bad config 8`] = `
+"Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+`;
+
+exports[`feat-invalidYaml (SHORT) run commands with bad config 9`] = `
+"Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+`;

--- a/tests/zwe-remote-integration/src/__tests__/features/__snapshots__/invalidYaml.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/features/__snapshots__/invalidYaml.test.ts.snap
@@ -2,20 +2,20 @@
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 1`] = `
 "Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
-ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+    ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 2`] = `
 "Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
-ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+    ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 3`] = `
 "Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
-ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+    ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 4`] = `
@@ -23,8 +23,8 @@ exports[`feat-invalidYaml (SHORT) run commands with bad config 4`] = `
 >> Generate certificate
 
 Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
-ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+    ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 5`] = `
@@ -34,24 +34,24 @@ ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simp
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 6`] = `
 "Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
-ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+    ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 7`] = `
 "Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
-ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+    ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 8`] = `
 "Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
-ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+    ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 9`] = `
 "Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
-ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
-ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+    ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
+    ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;

--- a/tests/zwe-remote-integration/src/__tests__/features/__snapshots__/invalidYaml.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/features/__snapshots__/invalidYaml.test.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 1`] = `
-"Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+"Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
 ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
 ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 2`] = `
-"Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+"Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
 ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
 ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 3`] = `
-"Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+"Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
 ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
 ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
@@ -22,7 +22,7 @@ exports[`feat-invalidYaml (SHORT) run commands with bad config 4`] = `
 "-------------------------------------------------------------------------------
 >> Generate certificate
 
-Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
 ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
 ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
@@ -33,25 +33,25 @@ ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simp
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 6`] = `
-"Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+"Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
 ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
 ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 7`] = `
-"Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+"Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
 ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
 ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 8`] = `
-"Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+"Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
 ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
 ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`feat-invalidYaml (SHORT) run commands with bad config 9`] = `
-"Error ZWEL0324E: An error occurred while processing Zowe YAML config zowe.test.yaml:
+"Error ZWEL0325E: An error occurred while processing Zowe YAML config zowe.test.yaml:
 ZWEL0318E - Couldn't scan file '/test/dir/zowe.test.yaml': while scanning a simple key at line 12, column 7, could not find expected ':' at line 13, column 7.
 ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;

--- a/tests/zwe-remote-integration/src/__tests__/features/invalidYaml.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/features/invalidYaml.test.ts
@@ -41,15 +41,15 @@ describe(`${testSuiteName}`, () => {
 
     it('run commands with bad config', async () => {
       const testCases = [
-        { cmd: 'install', rc: 68 },
-        { cmd: 'init', rc: 68 },
-        { cmd: 'init apfauth', rc: 68 },
-        { cmd: 'init certificate', rc: 68 },
+        { cmd: 'install', rc: 69 },
+        { cmd: 'init', rc: 69 },
+        { cmd: 'init apfauth', rc: 69 },
+        { cmd: 'init certificate', rc: 69 },
         { cmd: 'init generate', rc: 1 },
-        { cmd: 'init mvs', rc: 68 },
-        { cmd: 'init security', rc: 68 },
-        { cmd: 'init stc', rc: 68 },
-        { cmd: 'init vsam', rc: 68 },
+        { cmd: 'init mvs', rc: 69 },
+        { cmd: 'init security', rc: 69 },
+        { cmd: 'init stc', rc: 69 },
+        { cmd: 'init vsam', rc: 69 },
       ];
 
       for (const test of testCases) {

--- a/tests/zwe-remote-integration/src/__tests__/features/invalidYaml.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/features/invalidYaml.test.ts
@@ -11,8 +11,10 @@
 import ZoweYamlType from '../../config/ZoweYamlType';
 import { RemoteTestRunner } from '../../zos/RemoteTestRunner';
 import { ZoweConfig } from '../../config/ZoweConfig';
+import * as path from 'path';
 
 const testSuiteName = 'feat-invalidYaml';
+const yamlResourceDir = path.resolve('src', '__tests__', 'features', '__resources__');
 describe(`${testSuiteName}`, () => {
   let testRunner: RemoteTestRunner;
   let cfgYaml: ZoweYamlType;
@@ -33,13 +35,9 @@ describe(`${testSuiteName}`, () => {
   });
 
   describe('(SHORT)', () => {
-    beforeEach(async () => {
-      // TODO: Replace this with an upload of __resources__/bad.yaml to zowe.test.yaml
-      await testRunner.uploadZoweYaml(cfgYaml);
-      await testRunner.runRaw('sed -e "s#jcllib\\:#jcllib#g" zowe.test.yaml | tee zowe.test.yaml');
-    });
-
     it('run commands with bad config', async () => {
+      const testYamlPath = await testRunner.uploadZoweYamlFromFile(path.resolve(yamlResourceDir, 'bad.yaml'));
+
       const testCases = [
         { cmd: 'install', rc: 69 },
         { cmd: 'init', rc: 69 },
@@ -53,7 +51,7 @@ describe(`${testSuiteName}`, () => {
       ];
 
       for (const test of testCases) {
-        const result = await testRunner.runRaw(`./bin/zwe ${test.cmd} --dry-run -c zowe.test.yaml`);
+        const result = await testRunner.runRaw(`./bin/zwe ${test.cmd} --dry-run -c ${testYamlPath}`);
         expect(result.stdout).not.toBeNull();
         expect(result.cleanedStdout).toMatchSnapshot();
         expect(result.rc).toEqual(test.rc);

--- a/tests/zwe-remote-integration/src/__tests__/features/invalidYaml.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/features/invalidYaml.test.ts
@@ -8,22 +8,16 @@
  * Copyright Contributors to the Zowe Project.
  */
 
-import ZoweYamlType from '../../config/ZoweYamlType';
 import { RemoteTestRunner } from '../../zos/RemoteTestRunner';
-import { ZoweConfig } from '../../config/ZoweConfig';
 import * as path from 'path';
 
 const testSuiteName = 'feat-invalidYaml';
 const yamlResourceDir = path.resolve('src', '__tests__', 'features', '__resources__');
 describe(`${testSuiteName}`, () => {
   let testRunner: RemoteTestRunner;
-  let cfgYaml: ZoweYamlType;
 
   beforeAll(async () => {
     testRunner = new RemoteTestRunner(testSuiteName);
-  });
-  beforeEach(() => {
-    cfgYaml = ZoweConfig.getZoweYaml();
   });
 
   afterEach(async () => {

--- a/tests/zwe-remote-integration/src/__tests__/features/invalidYaml.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/features/invalidYaml.test.ts
@@ -1,0 +1,63 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+import ZoweYamlType from '../../config/ZoweYamlType';
+import { RemoteTestRunner } from '../../zos/RemoteTestRunner';
+import { ZoweConfig } from '../../config/ZoweConfig';
+
+const testSuiteName = 'feat-invalidYaml';
+describe(`${testSuiteName}`, () => {
+  let testRunner: RemoteTestRunner;
+  let cfgYaml: ZoweYamlType;
+
+  beforeAll(async () => {
+    testRunner = new RemoteTestRunner(testSuiteName);
+  });
+  beforeEach(() => {
+    cfgYaml = ZoweConfig.getZoweYaml();
+  });
+
+  afterEach(async () => {
+    await testRunner.postTest();
+  });
+
+  afterAll(() => {
+    testRunner.shutdown();
+  });
+
+  describe('(SHORT)', () => {
+    beforeEach(async () => {
+      // TODO: Replace this with an upload of __resources__/bad.yaml to zowe.test.yaml
+      await testRunner.uploadZoweYaml(cfgYaml);
+      await testRunner.runRaw('sed -e "s#jcllib\\:#jcllib#g" zowe.test.yaml | tee zowe.test.yaml');
+    });
+
+    it('run commands with bad config', async () => {
+      const testCases = [
+        { cmd: 'install', rc: 68 },
+        { cmd: 'init', rc: 68 },
+        { cmd: 'init apfauth', rc: 68 },
+        { cmd: 'init certificate', rc: 68 },
+        { cmd: 'init generate', rc: 1 },
+        { cmd: 'init mvs', rc: 68 },
+        { cmd: 'init security', rc: 68 },
+        { cmd: 'init stc', rc: 68 },
+        { cmd: 'init vsam', rc: 68 },
+      ];
+
+      for (const test of testCases) {
+        const result = await testRunner.runRaw(`./bin/zwe ${test.cmd} --dry-run -c zowe.test.yaml`);
+        expect(result.stdout).not.toBeNull();
+        expect(result.cleanedStdout).toMatchSnapshot();
+        expect(result.rc).toEqual(test.rc);
+      }
+    });
+  });
+});

--- a/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/generate.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/generate.test.ts.snap
@@ -1977,5 +1977,5 @@ noverbose -
 --- End of JCL ---
 Submitting Job ZWEGENER
 Job ZWEGENER(JOB00000) completed with RC=2
-Zowe JCL generated with errors, check job log. Job completion code=0008."
+Zowe JCL generated with errors, check job log. Job completion code=CANCELED."
 `;

--- a/tests/zwe-remote-integration/src/__tests__/init/generate.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/init/generate.test.ts
@@ -199,7 +199,6 @@ describe(`${testSuiteName}`, () => {
         `./bin/utils/zowex job list --rfc | awk -F, 'match($3, "ZWEGENER") && match($4, "ACTIVE") { print $1 }'`,
       );
       let runningJob = jobid.stdout.trim();
-      console.log(`Found running job: ${runningJob}`);
       await testRunner.runRaw(`./bin/utils/zowex job cancel ${runningJob}`);
       await testRunner.runRaw(`./bin/utils/zowex job delete ${runningJob}`);
       let genResult = await deferredResult;

--- a/tests/zwe-remote-integration/src/__tests__/install/__snapshots__/install.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/install/__snapshots__/install.test.ts.snap
@@ -2454,8 +2454,8 @@ Example(s)
 
 exports[`zwe-install (SHORT) zwe install invalid config 1`] = `
 "Error ZWEL0325E: An error occurred while processing Zowe YAML config /not/real/config.yml:
-ZWEL0318E - failed to read '/not/real/config.yml' - EDC5129I No such file or directory. (errno2=0x0594003D)
-ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
+    ZWEL0318E - failed to read '/not/real/config.yml' - EDC5129I No such file or directory. (errno2=0x0594003D)
+    ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`zwe-install (SHORT) zwe install invalid dataset name 1`] = `
@@ -2525,10 +2525,7 @@ ERROR: Error ZWEL0105E: The Zowe YAML config file is associated to Zowe runtime 
 `;
 
 exports[`zwe-install (SHORT) zwe install missing config 1`] = `
-"Error ZWEL0325E: An error occurred while processing Zowe YAML config :
-path building failed
-built config path failed
-Problems with config path rsn=4"
+"Error ZWEL0108E: Zowe YAML config file is required."
 `;
 
 exports[`zwe-install (SHORT) zwe install missing prefix 1`] = `

--- a/tests/zwe-remote-integration/src/__tests__/install/__snapshots__/install.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/install/__snapshots__/install.test.ts.snap
@@ -2453,7 +2453,7 @@ Example(s)
 `;
 
 exports[`zwe-install (SHORT) zwe install invalid config 1`] = `
-"Error ZWEL0324E: An error occurred while processing Zowe YAML config /not/real/config.yml:
+"Error ZWEL0325E: An error occurred while processing Zowe YAML config /not/real/config.yml:
 ZWEL0318E - failed to read '/not/real/config.yml' - EDC5129I No such file or directory. (errno2=0x0594003D)
 ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
@@ -2525,7 +2525,7 @@ ERROR: Error ZWEL0105E: The Zowe YAML config file is associated to Zowe runtime 
 `;
 
 exports[`zwe-install (SHORT) zwe install missing config 1`] = `
-"Error ZWEL0324E: An error occurred while processing Zowe YAML config :
+"Error ZWEL0325E: An error occurred while processing Zowe YAML config :
 path building failed
 built config path failed
 Problems with config path rsn=4"

--- a/tests/zwe-remote-integration/src/__tests__/install/__snapshots__/install.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/install/__snapshots__/install.test.ts.snap
@@ -2453,9 +2453,9 @@ Example(s)
 `;
 
 exports[`zwe-install (SHORT) zwe install invalid config 1`] = `
-"===============================================================================
->> INSTALL ZOWE MVS DATA SETS
-Error ZWEL0109E: The Zowe YAML config file specified does not exist."
+"Error ZWEL0324E: An error occurred while processing Zowe YAML config /not/real/config.yml:
+ZWEL0318E - failed to read '/not/real/config.yml' - EDC5129I No such file or directory. (errno2=0x0594003D)
+ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
 
 exports[`zwe-install (SHORT) zwe install invalid dataset name 1`] = `
@@ -2525,9 +2525,10 @@ ERROR: Error ZWEL0105E: The Zowe YAML config file is associated to Zowe runtime 
 `;
 
 exports[`zwe-install (SHORT) zwe install missing config 1`] = `
-"===============================================================================
->> INSTALL ZOWE MVS DATA SETS
-Error ZWEL0108E: Zowe YAML config file is required."
+"Error ZWEL0324E: An error occurred while processing Zowe YAML config :
+path building failed
+built config path failed
+Problems with config path rsn=4"
 `;
 
 exports[`zwe-install (SHORT) zwe install missing prefix 1`] = `

--- a/tests/zwe-remote-integration/src/__tests__/install/__snapshots__/install.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/install/__snapshots__/install.test.ts.snap
@@ -2453,7 +2453,7 @@ Example(s)
 `;
 
 exports[`zwe-install (SHORT) zwe install invalid config 1`] = `
-"Error ZWEL0325E: An error occurred while processing Zowe YAML config /not/real/config.yml:
+"Error ZWEL0326E: An error occurred while processing Zowe YAML config /not/real/config.yml:
     ZWEL0318E - failed to read '/not/real/config.yml' - EDC5129I No such file or directory. (errno2=0x0594003D)
     ZWEL0319E - Failed to load configuration, element may be bad, or less likely a bad merge."
 `;
@@ -2525,7 +2525,9 @@ ERROR: Error ZWEL0105E: The Zowe YAML config file is associated to Zowe runtime 
 `;
 
 exports[`zwe-install (SHORT) zwe install missing config 1`] = `
-"Error ZWEL0108E: Zowe YAML config file is required."
+"===============================================================================
+>> INSTALL ZOWE MVS DATA SETS
+Error ZWEL0108E: Zowe YAML config file is required."
 `;
 
 exports[`zwe-install (SHORT) zwe install missing prefix 1`] = `

--- a/tests/zwe-remote-integration/src/__tests__/install/install.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/install/install.test.ts
@@ -202,7 +202,7 @@ describe(`${testSuiteName}`, () => {
       const result = await testRunner.runZweTest(null, 'install');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(69);
+      expect(result.rc).toBe(108);
     });
 
     it('zwe install invalid config', async () => {

--- a/tests/zwe-remote-integration/src/__tests__/install/install.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/install/install.test.ts
@@ -202,14 +202,14 @@ describe(`${testSuiteName}`, () => {
       const result = await testRunner.runZweTest(null, 'install');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(108);
+      expect(result.rc).toBe(68);
     });
 
     it('zwe install invalid config', async () => {
       const result = await testRunner.runZweTest(cfgYaml, 'install --dry-run --config /not/real/config.yml');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(109);
+      expect(result.rc).toBe(68);
     });
 
     it('zwe install --dry-run valid ds names', async () => {

--- a/tests/zwe-remote-integration/src/__tests__/install/install.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/install/install.test.ts
@@ -202,14 +202,14 @@ describe(`${testSuiteName}`, () => {
       const result = await testRunner.runZweTest(null, 'install');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(68);
+      expect(result.rc).toBe(69);
     });
 
     it('zwe install invalid config', async () => {
       const result = await testRunner.runZweTest(cfgYaml, 'install --dry-run --config /not/real/config.yml');
       expect(result.stdout).not.toBeNull();
       expect(result.cleanedStdout).toMatchSnapshot();
-      expect(result.rc).toBe(68);
+      expect(result.rc).toBe(69);
     });
 
     it('zwe install --dry-run valid ds names', async () => {

--- a/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
+++ b/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
@@ -127,7 +127,13 @@ export class RemoteTestRunner {
   }
 
   public async runRaw(command: string, cwd: string = REMOTE_SYSTEM_INFO.ussTestDir): Promise<TestOutput> {
+    const start = performance.now();
     const output = await this.uss.runCommand(`${command}`, cwd);
+    const end = performance.now();
+    const duration = end - start;
+    this.totalRuntime += duration;
+    this.totalRuns++;
+    this.maxRuntime = Math.max(this.maxRuntime, duration);
     // Any non-deterministic output should be cleaned up for test snapshots.
     const cleanedOutput = this.cleanOutput(output.consoleLog, []);
     return {

--- a/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
+++ b/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
@@ -476,6 +476,25 @@ export class RemoteTestRunner {
     await files.Upload.bufferToDataSet(this.session, Buffer.from(content), dsPath);
   }
 
+  /**
+   * Uploads a given file directly as the zowe.yaml to be used in a test case (zowe.test.yaml).
+   *
+   * @param filePath
+   * @param remoteCwd
+   * @returns the full path to the uploaded zowe.yaml
+   */
+  public async uploadZoweYamlFromFile(filePath: string, remoteCwd: string = REMOTE_SYSTEM_INFO.ussTestDir): Promise<string> {
+    const testName = expect.getState().currentTestName.replace(/\s/g, '_');
+    const uploadPath = `${remoteCwd}/zowe.test.yaml`;
+    const yamlOutputDir = this.yamlOutputTemplate.replace('{{ testInstance }}', testName);
+    fs.mkdirpSync(yamlOutputDir);
+    const redundantFilePath = this.writeRedundant(`${yamlOutputDir}/zowe.yaml`, fs.readFileSync(filePath, 'utf-8'));
+    await files.Upload.fileToUssFile(this.session, redundantFilePath, uploadPath, {
+      binary: false,
+    });
+    return uploadPath;
+  }
+
   public async uploadZoweYaml(
     zoweYaml: ZoweYamlType,
     addCustomJobHeaders: boolean = true,

--- a/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
+++ b/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
@@ -85,7 +85,6 @@ export class RemoteTestRunner {
     const dlResp = await files.Download.dataSet(this.session, memberName, {
       file: tmpFile,
     });
-    console.log(JSON.stringify(dlResp));
     if (!dlResp.success) {
       console.log('Failed');
     }


### PR DESCRIPTION
Fixes #4443 

Based on the [comment](https://github.com/zowe/zowe-install-packaging/pull/4444#issuecomment-3175433848):

* `validate_zowe_yaml` is standalone
  * Exits for undefined config
    * There is a parameter to ignore it (`zwe install` could run without config)
  * Exits when syntax/other yaml error
  * Called before `check_jcl_enabled`
  * `require_zowe_yaml` removed as redundant
* Error code 324 -> 326

## Testing

Config ready for `JCL` feature, but there is an error, missing `:` after `jcllib`
```yaml
zowe:
  setup:
    dataset:
      prefix: ZOWE.PR#4444
      jcllib ZOWE.PR#4444.JCLLIB
    jcl:
      enable: true
      header: '12345'
  runtimeDirectory: /zowe/4444
```

### Commands with invalid yaml
```diff
+ [ 1/10][expected rc=  0, result rc=  0  ]: /zowe/4444/bin/zwe install --ds-prefix ZOWE.PR#4444
  [ 2/10][expected rc= 69, result rc= 69  ]: /zowe/4444/bin/zwe install --config ./zowe.yaml
  [ 3/10][expected rc= 69, result rc= 69  ]: /zowe/4444/bin/zwe init --config ./zowe.yaml
! [ 4/10][expected rc=  1, result rc=  1  ]: /zowe/4444/bin/zwe init generate --config ./zowe.yaml
  [ 5/10][expected rc= 69, result rc= 69  ]: /zowe/4444/bin/zwe init apfauth --config ./zowe.yaml
  [ 6/10][expected rc= 69, result rc= 69  ]: /zowe/4444/bin/zwe init mvs --config ./zowe.yaml
  [ 7/10][expected rc= 69, result rc= 69  ]: /zowe/4444/bin/zwe init stc --config ./zowe.yaml
  [ 8/10][expected rc= 69, result rc= 69  ]: /zowe/4444/bin/zwe init security --config ./zowe.yaml
  [ 9/10][expected rc= 69, result rc= 69  ]: /zowe/4444/bin/zwe init certificate --config ./zowe.yaml
  [10/10][expected rc= 69, result rc= 69  ]: /zowe/4444/bin/zwe init vsam --config ./zowe.yaml
```

#### Notes
1. `--ds-prefix` working fine
1. `zwe init generate` has a shell only to call `configmgr` - the failure is the same in javascript then, the only difference is the return code
1. rc=69 is (325 modulo 256)