### PR TITLE
Fix workflow `init generate`

### DIFF
--- a/pswi/scripts/wf_run_test.sh
+++ b/pswi/scripts/wf_run_test.sh
@@ -84,7 +84,7 @@ if [ "$run" = "run" ]; then
       if [ "$ZWECONF" = "ZWECONF" ]; then
         STEP_NAME=$(echo $RESP | grep -o '"currentStepName":".*"' | cut -f4 -d\")
         if [ "$STEP_NAME" = "install_zowe" ]; then
-          echo "The workflow is ZWECONF and it should end in step 'install_zowe', third step of the workflow. If the default zowe.setup.jcl.enable is now true, then ZWECONF should end in 'configure', step two of the workflow."
+          echo "The workflow is ZWECONF and it should end in step 'install_zowe', third step of the workflow. If the default zowe.setup.jcl.enable is later updated to \"true\", then ZWECONF should end in 'configure', step two of the workflow."
           STATUS="FINISHED"
         else
           echo "The workflow is ZWECONF but ended in different step: '$STEP_NAME'" >>$LOG_DIR/report.txt

--- a/pswi/scripts/wf_run_test.sh
+++ b/pswi/scripts/wf_run_test.sh
@@ -83,8 +83,8 @@ if [ "$run" = "run" ]; then
       echo "Checking if the workflow is ZWECONF" >>$LOG_DIR/report.txt
       if [ "$ZWECONF" = "ZWECONF" ]; then
         STEP_NAME=$(echo $RESP | grep -o '"currentStepName":".*"' | cut -f4 -d\")
-        if [ "$STEP_NAME" = "configure" ]; then
-          echo "The workflow is ZWECONF and should end in step 'configure', second step of the workflow."
+        if [ "$STEP_NAME" = "install_zowe" ]; then
+          echo "The workflow is ZWECONF and it should end in step 'install_zowe', third step of the workflow. If the default zowe.setup.jcl.enable is now true, then ZWECONF should end in 'configure', step two of the workflow."
           STATUS="FINISHED"
         else
           echo "The workflow is ZWECONF but ended in different step: '$STEP_NAME'" >>$LOG_DIR/report.txt

--- a/workflows/files/ZWEAMLCF.xml
+++ b/workflows/files/ZWEAMLCF.xml
@@ -1412,12 +1412,14 @@ echo '#       zss:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '#         port: 28542' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '#       caching-service:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '#         enabled: false' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+#if (${instance-zowe_setup_jcl_enable} == "true" )
 
 export JAVA_HOME='${instance-java_home}'
 export PATH=$PATH:'${instance-zowe_runtimeDirectory}/bin'
 
 zwe init generate --allow-overwrite -c '${instance-zowe_runtimeDirectory}/zowe.yaml'
 
+#end
 ]]></inlineTemplate>
             <submitAs maxRc="0">shell-JCL</submitAs>
             <maxLrecl>1024</maxLrecl>

--- a/workflows/files/ZWECONF.xml
+++ b/workflows/files/ZWECONF.xml
@@ -2218,12 +2218,14 @@ echo '#       zss:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '#         port: 28542' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '#       caching-service:' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
 echo '#         enabled: false' >> "${instance-zowe_runtimeDirectory}/zowe.yaml"
+#if (${instance-zowe_setup_jcl_enable} == "true" )
 
 export JAVA_HOME='${instance-java_home}'
 export NODE_HOME='${instance-node_home}'
 export PATH=$PATH:'${instance-zowe_runtimeDirectory}/bin'
 
 zwe init generate --allow-overwrite -c '${instance-zowe_runtimeDirectory}/zowe.yaml'
+#end
 ]]></inlineTemplate>
             <submitAs maxRc="0">shell-JCL</submitAs>
             <maxLrecl>1024</maxLrecl>


### PR DESCRIPTION
Zowe configuration workflows should only run `init generate` when `zowe.setup.jcl.enable` is true.

If left as-is, `zwe init generate` can throw an error during step 2 of the configuration if the user requires jobcard parameters and has not supplied them because they weren't expecting to.