### PR TITLE
Do not resolve `ZWEIAPF`

### DIFF
--- a/files/SZWEEXEC/ZWEGEN00
+++ b/files/SZWEEXEC/ZWEGEN00
@@ -182,7 +182,8 @@ if FreeByDD('zweto') > 0 then do
 end
 
 /* members not processed */
-excludeList = "ZWEKRING ZWENOKYR ZWEGENER ZWESIP00 ZWESIPRG ZWESISCH ZWESECKG"
+excludeList = "ZWEKRING ZWENOKYR ZWEGENER ZWESIP00 ZWESIPRG ZWESISCH ZWESECKG",
+  "ZWEIAPF"
 do el = 1 to words(excludeList)
   ret = DeleteDataSet(jclCopy'('word(excludeList, el)')')
 end

--- a/files/SZWESAMP/ZWEIAPF
+++ b/files/SZWESAMP/ZWEIAPF
@@ -12,24 +12,25 @@
 //*********************************************************************
 //*
 //*  This JCL is used to set APF for the two datasets of Zowe
-//*  Which need it. You can issue this, or use another
-//*  Way to accomplish the task.
+//*  which need it. You can issue this, or use another
+//*  way to accomplish the task.
+//*
+//* CAUTION: This is neither a JCL procedure nor a complete job.
+//* Before using this JCL, you will have to make the following
+//* modifications:
+//*
+//* 1) Replace {zowe.setup.jcl.header} to meet your system requirements.
+//* 2) Replace {zowe.setup.dataset.authLoadlib}
+//*    and {zowe.setup.dataset.authPluginLib} with data set names.
+//* 3) If SMS not used, replace SMS with VOLUME=volume
 //*
 //*********************************************************************
 //*
 //EXEC14   EXEC  PGM=IEFBR14
 //*
-//*  This dataset holds the APF portion of Zowe
-//         SET LOADLIB='{zowe.setup.dataset.authLoadlib}'
-//*  SMS may have to be replaced with VOLUME=SOME.DSN when not SMS
-//         SET LOADLOC='SMS'
+//* {zowe.setup.dataset.authLoadlib} holds the APF portion of Zowe
+//  COMMAND 'SETPROG APF,ADD,DSN={zowe.setup.dataset.authLoadlib},SMS'
 //*
-//*  This dataset holds product plugins for ZIS,
-//*  ZIS is located in the LOADLIB.
-//         SET PLUGLIB='{zowe.setup.dataset.authPluginLib}'
-//         SET PLUGLOC='SMS'
-//*
-//APFLOAD  COMMAND 'SETPROG APF,ADD,DSN=&LOADLIB.,&LOADLOC.'
-//*
-//APFLIB   COMMAND 'SETPROG APF,ADD,DSN=&PLUGLIB.,&PLUGLOC.'
+//* {zowe.setup.dataset.authPluginLib} holds product plugins for ZIS
+//  COMMAND 'SETPROG APF,ADD,DSN={zowe.setup.dataset.authPluginLib},SMS'
 //*

--- a/files/SZWESAMP/ZWEIAPF
+++ b/files/SZWESAMP/ZWEIAPF
@@ -29,8 +29,8 @@
 //EXEC14   EXEC  PGM=IEFBR14
 //*
 //* {zowe.setup.dataset.authLoadlib} holds the APF portion of Zowe
-//  COMMAND 'SETPROG APF,ADD,DSN={zowe.setup.dataset.authLoadlib},SMS'
+// COMMAND 'SETPROG APF,ADD,DSN={zowe.setup.dataset.authLoadlib},SMS'
 //*
 //* {zowe.setup.dataset.authPluginLib} holds product plugins for ZIS
-//  COMMAND 'SETPROG APF,ADD,DSN={zowe.setup.dataset.authPluginLib},SMS'
+// COMMAND 'SETPROG APF,ADD,DSN={zowe.setup.dataset.authPluginLib},SMS'
 //*


### PR DESCRIPTION
Fixes #4451

* `ZWEGEN00` excludes this sample from `zowe.setup.dataset.jcllib`
* Sample is used for manual editing

```jcl
//EXEC14   EXEC  PGM=IEFBR14
//*
//* {zowe.setup.dataset.authLoadlib} holds the APF portion of Zowe
// COMMAND 'SETPROG APF,ADD,DSN={zowe.setup.dataset.authLoadlib},SMS'
//*
//* {zowe.setup.dataset.authPluginLib} holds product plugins for ZIS
----+----1----+----2----+----3----+----4----+----5----+----6----+----7----+----8
// COMMAND 'SETPROG APF,ADD,DSN={zowe.setup.dataset.authPluginLib},SMS'
//*
//* |----+----1----+----2----+----3----+----4----+----5----+----6----+----7----+----8
//* |{zowe.setup.dataset.authPluginLib}
```

The reason for exclusion is, that the example could be resolved only when the data set is up to 34 chars and `SMS`. Otherwise another exception must be coded in `ZWEGEN00` or find another solution.

Updated `ZWEIAPF` is basically better version of this example
https://github.com/zowe/zowe-install-packaging/blob/ed0660c52768e0fac51f32b1eed457b59e854832/files/SZWESAMP/ZWESIPRG#L1-L2

## Small test

`ZWEIAPF` missing in `zowe.setup.dataset.jcllib`.
```
...
--- End of JCL ---
Submitting Job ZWEGENER
Job ZWEGENER(JOB79307) completed with RC=0
Zowe JCL generated successfully

tsocmd "LISTDS 'ZOWE.PR#4452.JCL' MEMBERS"

LISTDS 'ZOWE.PR#4452.JCL' MEMBERS
ZOWE.PR#4452.JCL
--RECFM-LRECL-BLKSIZE-DSORG
  FB    80    27920   PO
--VOLUMES--
  WRKD24
--MEMBERS--
  ZWECSRVS
  ZWECSVSM
  ZWEIAPF2
  ZWEIKRT1
  ZWEIKRT2
  ZWEIKRT3
  ZWEIMVS
  ZWEIMVS1
  ZWEIMVS2
  ZWEINSTL
  ZWEISTC
  ZWEITSS
  ZWEITSSZ
  ZWENOKRT
  ZWENOSEC
  ZWERMVS
  ZWERMVS1
  ZWERMVS2
  ZWERSTC
  ZWESASTC
  ZWESECUR
  ZWESISTC
  ZWESLSTC
```