### PR TITLE
`zwe init vsam` shell to resolve new template

### DIFF
--- a/bin/commands/init/vsam/index.sh
+++ b/bin/commands/init/vsam/index.sh
@@ -118,10 +118,11 @@ else
   tmpfile=$(create_tmp_file $(echo "zwe ${ZWE_CLI_COMMANDS_LIST}" | sed "s# #-#g"))
   print_debug "- Copy ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWECSVSM) to ${tmpfile}"
   result=$(cat "//'${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWECSVSM)'" | \
-          sed  "s/^\/\/ \+SET \+MODE=.*\$/\/\/         SET  MODE=${vsam_mode}/" | \
-          sed  "/^\/\/ALLOC/,9999s/#dsname/${vsam_name}/g" | \
-          sed  "/^\/\/ALLOC/,9999s/#volume/${vsam_volume}/g" | \
-          sed  "/^\/\/ALLOC/,9999s/#storclas/${vsam_storageClass}/g" \
+          sed /\{zowe\.setup\.jcl\.header\}// | \
+          sed /\{zowe\.setup\.vsam\.name\}/${vsam_name}/ | \
+          sed /\{zowe\.setup\.vsam\.mode\}/${vsam_mode}/ | \
+          sed /\{zowe\.setup\.vsam\.storageClass\}/${vsam_storageClass}/ | \
+          sed /\{zowe\.setup\.vsam\.volume\}/${vsam_volume}/ \
           > "${tmpfile}")
   code=$?
   chmod 700 "${tmpfile}"

--- a/bin/commands/init/vsam/index.sh
+++ b/bin/commands/init/vsam/index.sh
@@ -118,14 +118,19 @@ else
   tmpfile=$(create_tmp_file $(echo "zwe ${ZWE_CLI_COMMANDS_LIST}" | sed "s# #-#g"))
   print_debug "- Copy ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWECSVSM) to ${tmpfile}"
   result=$(cat "//'${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWECSVSM)'" | \
-          sed /\{zowe\.setup\.jcl\.header\}// | \
-          sed /\{zowe\.setup\.vsam\.name\}/${vsam_name}/ | \
-          sed /\{zowe\.setup\.vsam\.mode\}/${vsam_mode}/ | \
-          sed /\{zowe\.setup\.vsam\.storageClass\}/${vsam_storageClass}/ | \
-          sed /\{zowe\.setup\.vsam\.volume\}/${vsam_volume}/ \
-          > "${tmpfile}")
-  code=$?
-  chmod 700 "${tmpfile}"
+          sed "s/{zowe\.setup\.jcl\.header}//" | \
+          sed "s/{zowe\.setup\.vsam\.name}/${vsam_name}/" | \
+          sed "s/{zowe\.setup\.vsam\.mode}/${vsam_mode}/" | \
+          sed "s/{zowe\.setup\.vsam\.storageClass}/${vsam_storageClass}/" | \
+          sed "s/{zowe\.setup\.vsam\.volume}/${vsam_volume}/")
+
+  if [ -n "${result}" ]; then
+    echo "${result}" > "${tmpfile}"
+    code=$?
+  else
+    code=1
+  fi
+
   if [ ${code} -eq 0 ]; then
     print_debug "  * Succeeded"
     print_trace "  * Exit code: ${code}"
@@ -144,6 +149,7 @@ else
   if [ ! -f "${tmpfile}" ]; then
     print_error_and_exit "Error ZWEL0159E: Failed to modify ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWECSVSM)" "" 159
   fi
+  chmod 700 "${tmpfile}"
   print_trace "- ${tmpfile} created with content"
   print_trace "$(cat "${tmpfile}")"
   print_trace "- ensure ${tmpfile} encoding before copying into data set"


### PR DESCRIPTION
Fixes #4452

Now working fine, it will replace what is needed:

### Config
```yaml
zowe:
  setup:
    dataset:
      prefix: ZOWE.PR#4454
      jcllib: ZOWE.PR#4454.JCL
    vsam:
      volume: 'ABC123) DANGEROUS_SYNTAX(TRUE'
components:
  caching-service:
    storage:
      mode: VSam
      vsam:
        name: MISSING_SCHEMA_VALIDATION
```

### Resolved JCL
```jcl
//ZWECSVSM JOB
//*
//*
//ALLOC    EXEC PGM=IDCAMS,REGION=0M
//SYSPRINT DD SYSOUT=*
//SYSIN    DD *
  DEFINE CLUSTER -
   (NAME(MISSING_SCHEMA_VALIDATION) -
//         DD DDNAME=NONRLS
//         DD *
    REC(80 20) -
    INDEXED) -
   DATA(NAME(MISSING_SCHEMA_VALIDATION.DATA) -
    RECSZ(4096 4096) -
    UNIQUE -
    KEYS(128 0)) -
   INDEX(NAME(MISSING_SCHEMA_VALIDATION.INDEX) -
    UNIQUE)
//RLS      DD *
    STORCLAS() -
    LOG(NONE) -
//NONRLS   DD *
    VOLUME(ABC123) DANGEROUS_SYNTAX(TRUE) -
    SHAREOPTIONS(2 3) -
//*
```