### PR TITLE
`zwe install`: ZWEL0105E - do not print `undefined`

### DIFF
--- a/bin/commands/install/index.ts
+++ b/bin/commands/install/index.ts
@@ -47,10 +47,11 @@ export function execute(): void {
     runtime = runtimeEnv;
   } else {
     // We need clean path for xplatform.loadFileUTF8, otherwise will fail for e.g. /zowe/./files/SZWESAMP//ZWEINSTL
-    runtime = fs.convertToAbsolutePath(runtime);
-    if (runtime != runtimeEnv) {
+    const runtimeAbs = fs.convertToAbsolutePath(runtime);
+    if (runtimeAbs != runtimeEnv) {
       common.printErrorAndExit(`Error ZWEL0105E: The Zowe YAML config file is associated to Zowe runtime "${runtime}", which is not same as where zwe command is located "${runtimeEnv}".`, undefined, 105);
     }
+    runtime = runtimeAbs;
   }
 
   if (!prefix) {

--- a/bin/commands/install/index.ts
+++ b/bin/commands/install/index.ts
@@ -48,7 +48,7 @@ export function execute(): void {
   } else {
     // We need clean path for xplatform.loadFileUTF8, otherwise will fail for e.g. /zowe/./files/SZWESAMP//ZWEINSTL
     const runtimeAbs = fs.convertToAbsolutePath(runtime);
-    if (runtimeAbs != runtimeEnv) {
+    if (runtimeAbs == undefined || runtimeAbs != runtimeEnv) {
       common.printErrorAndExit(`Error ZWEL0105E: The Zowe YAML config file is associated to Zowe runtime "${runtime}", which is not same as where zwe command is located "${runtimeEnv}".`, undefined, 105);
     }
     runtime = runtimeAbs;

--- a/tests/zwe-remote-integration/src/__tests__/install/__snapshots__/install.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/install/__snapshots__/install.test.ts.snap
@@ -2521,7 +2521,7 @@ Zowe will remove it on success, but if zwe exits with a non-zero code manual cle
 -------------------------------------------------------------------------------
 >> Install Zowe MVS data sets
 ERROR: Could not convert /not/a/real/path to absolute path, err=129
-ERROR: Error ZWEL0105E: The Zowe YAML config file is associated to Zowe runtime "undefined", which is not same as where zwe command is located "/test/dir"."
+ERROR: Error ZWEL0105E: The Zowe YAML config file is associated to Zowe runtime "/not/a/real/path", which is not same as where zwe command is located "/test/dir"."
 `;
 
 exports[`zwe-install (SHORT) zwe install missing config 1`] = `


### PR DESCRIPTION
* `zwe install` - JCL feature
* Incorrect `zowe.runtimeDirectory` - e.g. typo in path, which causes `convertToAbsolutePath` is returning [`undefined`](https://github.com/zowe/zowe-install-packaging/blob/193b75be0142a347d186a1d6d1390e1eccdea5a7/bin/libs/fs.ts#L256)
* Then following error message `ZWEL0105E` refers to `undefined`

## Input config

```yaml
zowe:
  setup:
    jcl:
      enable: true
      header: '12345'
    dataset:
      prefix: ZOWE
  runtimeDirectory: /typo/in/path/
```

## Without fix

```
ERROR: Could not convert /typo/in/path/ to absolute path, err=129
ERROR: Error ZWEL0105E: The Zowe YAML config file is associated to Zowe runtime "undefined", which is not same as where zwe command is located "/zowe/test/4463".
```

## With fix

```
ERROR: Could not convert /typo/in/path/ to absolute path, err=129
ERROR: Error ZWEL0105E: The Zowe YAML config file is associated to Zowe runtime "/typo/in/path/", which is not same as where zwe command is located "/zowe/test/4463".
```