### PR TITLE
`formatZosVersion`: support z/OS 3.2

### DIFF
--- a/bin/libs/zos.ts
+++ b/bin/libs/zos.ts
@@ -108,6 +108,7 @@ export function verifyGeneratedJcl(config:any): string | undefined {
 
 export function formatZosVersion(format?: string, versionNumber?: string | number): string {
   const ZOS_VERS = {
+    'Z1030200': { 'osname': 'z/OS', 'hbb': 'HBB77F0', 'major': '3', 'minor': '2' },
     'Z1030100': { 'osname': 'z/OS', 'hbb': 'HBB77E0', 'major': '3', 'minor': '1' },
     'Z1020500': { 'osname': 'z/OS', 'hbb': 'HBB77D0', 'major': '2', 'minor': '5' },
     'Z1020400': { 'osname': 'z/OS', 'hbb': 'HBB77C0', 'major': '2', 'minor': '4' },


### PR DESCRIPTION
Support z/OS 3.2 version in formatting routine `formatZosVersion`.

```javascript
console.log(zosLib.formatZosVersion('0x1030200 is {osname} {major}.{minor} [{hbb}]', 0x1030200));
```
returns
```
0x1030200 is z/OS 3.2 [HBB77F0]
```

Feedback from z/OS 3.2 testing, current implementation prints error when resolving z/OS version, but this error is not critical and processing continues.

Thanks to @iansergeant42 tested on z/OS 3.2:
```
INFO (zwe-internal-start-prepare) z/OS Version: 3.2
```