### PR TITLE
`copy_to_data_set` bug fix and related changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Zowe Installer will be documented in this file.
 
+## `3.4.0`
+- Bugfix: internal routine `copy_to_data_set` did not correctly check if data set exists. [#4476](https://github.com/zowe/zowe-install-packaging/pull/4476)
+
 ## `3.3.0`
 
 - Bugfix: YAML lookup for HA instances within "haInstances" was not working when HA instance names were uppercase. Now, the lookup is case insensitive to allow for any casing of HA instance names. [#4370](https://github.com/zowe/zowe-install-packaging/pull/4370)

--- a/bin/commands/init/.parameters
+++ b/bin/commands/init/.parameters
@@ -3,3 +3,4 @@ skip-security-setup||boolean|||||Whether to skip security related setup.
 security-dry-run,dry-run||boolean|||||Generates JCL or displays actions to be taken on the system without modifying the system.
 ignore-security-failures||boolean|||||Whether to ignore security setup job failures.
 update-config||boolean|||||Whether to update YAML configuration file with initialization result.
+jcl||boolean|||||Generates and submits JCL to drive the init command, rather than using USS utilities.

--- a/bin/commands/init/certificate/.parameters
+++ b/bin/commands/init/certificate/.parameters
@@ -2,4 +2,3 @@ allow-overwrite,allow-overwritten||boolean|||||Allow overwritten existing MVS da
 update-config||boolean|||||Whether to update YAML configuration file with initialization result.
 ignore-security-failures||boolean|||||Whether to ignore security setup job failures.
 security-dry-run,dry-run||boolean|||||Generates and prints JCL but does not execute.
-jcl||boolean|||||Generates and submits JCL to drive the install, rather than using USS utilities.

--- a/bin/commands/init/mvs/index.sh
+++ b/bin/commands/init/mvs/index.sh
@@ -70,6 +70,7 @@ while read -r line; do
   # check existence
   ds_existence=$(is_data_set_exists "${ds}")
   if [ "${ds_existence}" = "true" ]; then
+    any_existence="true"
     if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
       # warning
       print_message "Warning ZWEL0300W: ${ds} already exists. This dataset will be overwritten."
@@ -94,16 +95,16 @@ $(echo "${cust_ds_list}")
 EOF
 print_message
 
-if [ "${ds_existence}" = "true" ] &&  [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" != "true" ]; then
-  print_message "Skipped writing to ${ds}. To write, you must use --allow-overwrite."
+if [ "${any_existence}" = "true" ] && [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" != "true" ]; then
+  print_message "Skipped writing, you must use --allow-overwrite."
 else
   ###############################
   # copy sample lib members
   parmlib=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.dataset.parmlib")
-  for ds in ZWESIP00; do
-    print_message "Copy ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(${ds}) to ${parmlib}(${ds})"
+  for mb in ZWESIP00; do
+    print_message "Copy ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(${mb}) to ${parmlib}(${mb})"
     if [ -z "${DRY_RUN}" ]; then
-      data_set_copy_to_data_set "${prefix}" "${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(${ds})" "${parmlib}(${ds})" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
+      data_set_copy_to_data_set "${prefix}" "${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(${mb})" "${parmlib}(${mb})" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
       if [ $? -ne 0 ]; then
         print_error_and_exit "Error ZWEL0111E: Command aborts with error." "" 111
       fi
@@ -114,14 +115,12 @@ else
 
   ###############################
   # copy auth lib members
-  # FIXME: data_set_copy_to_data_set cannot be used to copy program?
   authLoadlib=$(read_yaml_configmgr "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.dataset.authLoadlib")
   if [ -n "${authLoadlib}" ]; then
-    for ds in ZWESIS01 ZWESAUX ZWESISDL; do
-      print_message "Copy components/zss/LOADLIB/${ds} to ${authLoadlib}(${ds})"
+    for mb in ZWESIS01 ZWESAUX ZWESISDL; do
+      print_message "Copy components/zss/LOADLIB/${mb} to ${authLoadlib}(${mb})"
       if [ -z "${DRY_RUN}" ]; then
-        # data_set_copy_to_data_set "${prefix}" "${prefix}.${ZWE_PRIVATE_DS_SZWEAUTH}(${ds})" "${authLoadlib}(${ds})" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
-        copy_to_data_set "${ZWE_zowe_runtimeDirectory}/components/zss/LOADLIB/${ds}" "${authLoadlib}(${ds})" "-X" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
+        copy_to_data_set "${ZWE_zowe_runtimeDirectory}/components/zss/LOADLIB/${mb}" "${authLoadlib}(${mb})" "-X" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
         if [ $? -ne 0 ]; then
           print_error_and_exit "Error ZWEL0111E: Command aborts with error." "" 111
         fi
@@ -129,11 +128,10 @@ else
         print_message "Skipping copy operation due to --dry-run parameter."  
       fi
     done
-    for ds in ZWELNCH; do
-      print_message "Copy components/launcher/bin/zowe_launcher to ${authLoadlib}(${ds})"
+    for mb in ZWELNCH; do
+      print_message "Copy components/launcher/bin/zowe_launcher to ${authLoadlib}(${mb})"
       if [ -z "${DRY_RUN}" ]; then
-        # data_set_copy_to_data_set "${prefix}" "${prefix}.${ZWE_PRIVATE_DS_SZWEAUTH}(${ds})" "${authLoadlib}(${ds})" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
-        copy_to_data_set "${ZWE_zowe_runtimeDirectory}/components/launcher/bin/zowe_launcher" "${authLoadlib}(${ds})" "-X" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
+        copy_to_data_set "${ZWE_zowe_runtimeDirectory}/components/launcher/bin/zowe_launcher" "${authLoadlib}(${mb})" "-X" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
         if [ $? -ne 0 ]; then
           print_error_and_exit "Error ZWEL0111E: Command aborts with error." "" 111
         fi

--- a/bin/commands/init/security/.parameters
+++ b/bin/commands/init/security/.parameters
@@ -1,4 +1,3 @@
-jcl||boolean|||||Generates and submits JCL to drive the install, rather than using USS utilities.
 security-dry-run,dry-run||boolean|||||Generates and prints JCL but does not execute.
 ignore-security-failures||boolean|||||Whether to ignore security setup job failures.
 generate||boolean|||||Whether to force rebuild of JCL prior to submission. Use this when you've changed zowe.yaml and are re-submitting this command.

--- a/bin/commands/init/security/index.sh
+++ b/bin/commands/init/security/index.sh
@@ -101,10 +101,13 @@ result=$(cat "//'${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWESECUR)'" | \
         sed   "s/^\/\/ \+SET \+ZISSTC=.*\$/\/\/         SET  ZISSTC=${security_stcs_zis}/" | \
         sed   "s/^\/\/ \+SET \+AUXSTC=.*\$/\/\/         SET  AUXSTC=${security_stcs_aux}/" | \
         sed      "s/^\/\/ \+SET \+HLQ=.*\$/\/\/         SET  HLQ=${prefix}/" | \
-        sed  "s/^\/\/ \+SET \+SYSPROG=.*\$/\/\/         SET  SYSPROG=${security_groups_sysProg}/" \
-        > "${tmpfile}")
-code=$?
-chmod 700 "${tmpfile}"
+        sed  "s/^\/\/ \+SET \+SYSPROG=.*\$/\/\/         SET  SYSPROG=${security_groups_sysProg}/")
+if [ -n "${result}" ]; then
+  echo "${result}" > "${tmpfile}"
+  code=$?
+else
+  code=1
+fi
 if [ ${code} -eq 0 ]; then
   print_debug "  * Succeeded"
   print_trace "  * Exit code: ${code}"
@@ -123,6 +126,7 @@ fi
 if [ ! -f "${tmpfile}" ]; then
   print_error_and_exit "Error ZWEL0159E: Failed to modify ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWESECUR)" "" 159
 fi
+chmod 700 "${tmpfile}"
 print_trace "- ensure ${tmpfile} encoding before copying into data set"
 ensure_file_encoding "${tmpfile}" "SPDX-License-Identifier"
 print_trace "- ${tmpfile} created, copy to ${jcllib}(${tmpdsm})"

--- a/bin/commands/init/stc/.errors
+++ b/bin/commands/init/stc/.errors
@@ -1,6 +1,5 @@
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
 ZWEL0129E|129|The path to the Zowe YAML config must be less than 74 characters. Config: %s
-ZWEL0130E|130|%s.%s(%s) already exists. This data set member will be overwritten during configuration.
 ZWEL0158E|158|%s already exists.
 ZWEL0159E|159|Failed to modify %s.
 ZWEL0326E|326|An error occurred while processing Zowe YAML config %s:

--- a/bin/commands/init/stc/index.sh
+++ b/bin/commands/init/stc/index.sh
@@ -90,13 +90,14 @@ for mb in ${proclibs}; do
   # source in SZWESAMP
   samp_existence=$(is_data_set_exists "${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(${mb})")
   if [ "${samp_existence}" != "true" ]; then
-      print_error_and_exit "Error ZWEL0130E: ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(${mb}) already exists. This data set member will be overwritten during configuration." "" 130
+      print_error_and_exit "Error ZWEL0201E: File ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(${mb}) does not exist." "" 201
   fi
 done
 for mb in ${target_proclibs}; do
   # JCL for preview purpose
   jcl_existence=$(is_data_set_exists "${jcllib}(${mb})")
   if [ "${jcl_existence}" = "true" ]; then
+    any_jcl_existence="true"
     if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
       # warning
       print_message "Warning ZWEL0300W: ${jcllib}(${mb}) already exists. This member will be overwritten."
@@ -110,6 +111,7 @@ for mb in ${target_proclibs}; do
   # STCs in target proclib
   stc_existence=$(is_data_set_exists "${proclib}(${mb})")
   if [ "${stc_existence}" = "true" ]; then
+    any_stc_existence="true"
     if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
       # warning
       print_message "Warning ZWEL0300W: ${proclib}(${mb}) already exists. This member will be overwritten."
@@ -121,8 +123,8 @@ for mb in ${target_proclibs}; do
   fi
 done
 
-if [ "${jcl_existence}" = "true" ] &&  [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" != "true" ]; then
-  print_message "Skipped writing to ${jcllib}(${mb}). To write, you must use --allow-overwrite."
+if [ "${any_jcl_existence}" = "true" ] &&  [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" != "true" ]; then
+  print_message "Skipped writing to ${jcllib}. To write, you must use --allow-overwrite."
 else
   ###############################
   # prepare STCs
@@ -284,15 +286,15 @@ else
   print_message
 fi
 
-if [ "${stc_existence}" = "true" ] &&  [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" != "true" ]; then
-  print_message "Skipped writing to ${proclib}(${mb}). To write, you must use --allow-overwrite."
+if [ "${any_stc_existence}" = "true" ] &&  [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" != "true" ]; then
+  print_message "Skipped writing to ${proclib}. To write, you must use --allow-overwrite."
 else
   ###############################
   # copy to proclib
   for mb in ${target_proclibs}; do
     print_message "Copy ${jcllib}(${mb}) to ${proclib}(${mb})"
     if [ -z "${DRY_RUN}" ]; then
-      data_set_copy_to_data_set "${prefix}" "${jcllib}(${mb})" "${proclib}(${mb})" "-X" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
+      data_set_copy_to_data_set "${prefix}" "${jcllib}(${mb})" "${proclib}(${mb})" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
       if [ $? -ne 0 ]; then
         print_error_and_exit "Error ZWEL0111E: Command aborts with error." "" 111
       fi

--- a/bin/commands/init/stc/index.sh
+++ b/bin/commands/init/stc/index.sh
@@ -123,7 +123,7 @@ for mb in ${target_proclibs}; do
   fi
 done
 
-if [ "${any_jcl_existence}" = "true" ] &&  [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" != "true" ]; then
+if [ "${any_jcl_existence}" = "true" ] && [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" != "true" ]; then
   print_message "Skipped writing to ${jcllib}. To write, you must use --allow-overwrite."
 else
   ###############################
@@ -286,7 +286,7 @@ else
   print_message
 fi
 
-if [ "${any_stc_existence}" = "true" ] &&  [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" != "true" ]; then
+if [ "${any_jcl_existence}" = "true" ] || [ "${any_stc_existence}" = "true" ] && [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" != "true" ]; then
   print_message "Skipped writing to ${proclib}. To write, you must use --allow-overwrite."
 else
   ###############################

--- a/bin/commands/init/stc/index.sh
+++ b/bin/commands/init/stc/index.sh
@@ -141,12 +141,13 @@ else
   fi
   result=$(cat "//'${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWESLSTC)'" | \
           sed "s/^\/\/STEPLIB .*\$/\/\/STEPLIB  DD   DSNAME=${authLoadlib},/" | \
-          sed "s#^CONFIG=.*\$#CONFIG=${configAbsolutePath}#" \
-          > "${tmpfile}")
-  # FIXME: result=$(cat ./FileWhichDoesNotExist | sed "s/a/b/" > /dev/null)
-  #        echo $? -> always 0
-  code=$?
-  chmod 700 "${tmpfile}"
+          sed "s#^CONFIG=.*\$#CONFIG=${configAbsolutePath}#")
+  if [ -n "${result}" ]; then
+    echo "${result}" > "${tmpfile}"
+    code=$?
+  else
+    code=1
+  fi
   if [ ${code} -eq 0 ]; then
     print_debug "  * Succeeded"
     print_trace "  * Exit code: ${code}"
@@ -165,6 +166,7 @@ else
   if [ ! -f "${tmpfile}" ]; then
     print_error_and_exit "Error ZWEL0159E: Failed to modify ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWESLSTC)" "" 159
   fi
+  chmod 700 "${tmpfile}"
   print_trace "- ensure ${tmpfile} encoding before copying into data set"
   ensure_file_encoding "${tmpfile}" "SPDX-License-Identifier"
   print_trace "- ${tmpfile} created, copy to ${jcllib}(${security_stcs_zowe})"
@@ -192,10 +194,13 @@ else
 ' |
           sed '/^..PARMLIB.*parmlib.*/c\
 //PARMLIB  DD  DSNAME='${parmlib}',
-' \
-          > "${tmpfile}")
-  code=$?
-  chmod 700 "${tmpfile}"
+')
+  if [ -n "${result}" ]; then
+    echo "${result}" > "${tmpfile}"
+    code=$?
+  else
+    code=1
+  fi
   if [ ${code} -eq 0 ]; then
     print_debug "  * Succeeded"
     print_trace "  * Exit code: ${code}"
@@ -215,6 +220,7 @@ else
   if [ ! -f "${tmpfile}" ]; then
     print_error_and_exit "Error ZWEL0159E: Failed to modify ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWESISTC)" "" 159
   fi
+  chmod 700 "${tmpfile}"
   print_trace "- ensure ${tmpfile} encoding before copying into data set"
   ensure_file_encoding "${tmpfile}" "SPDX-License-Identifier"
   print_trace "- ${tmpfile} created, copy to ${jcllib}(${security_stcs_zis})"
@@ -236,9 +242,13 @@ else
 \//STEPLIB  DD  DSNAME='${authLoadlib}',
 ' | sed '/^.*DD.*authPluginLib.*/c\
 \//         DD  DSNAME='${authPluginLib}',
-' > "${tmpfile}")
-  code=$?
-  chmod 700 "${tmpfile}"
+')
+  if [ -n "${result}" ]; then
+    echo "${result}" > "${tmpfile}"
+    code=$?
+  else
+    code=1
+  fi
   if [ ${code} -eq 0 ]; then
     print_debug "  * Succeeded"
     print_trace "  * Exit code: ${code}"
@@ -258,6 +268,7 @@ else
   if [ ! -f "${tmpfile}" ]; then
     print_error_and_exit "Error ZWEL0159E: Failed to modify ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWESASTC)" "" 159
   fi
+  chmod 700 "${tmpfile}"
   print_trace "- ensure ${tmpfile} encoding before copying into data set"
   ensure_file_encoding "${tmpfile}" "SPDX-License-Identifier"
   print_trace "- ${tmpfile} created, copy to ${jcllib}(${security_stcs_aux})"

--- a/bin/commands/init/vsam/.help
+++ b/bin/commands/init/vsam/.help
@@ -19,12 +19,12 @@ components:
     storage:
       mode: VSAM
       vsam:
-        name: 
+        name:
 ```
 
 - `zowe.setup.dataset.prefix` shows where the `SZWESAMP` data set is installed.
 - `zowe.setup.dataset.jcllib` is the custom JCL library. Zowe server command may
-  generate sample JCLs and put into this data set. 
+  generate sample JCLs and put into this data set.
 - `zowe.setup.vsam.mode` indicates whether the VSAM will utilize Record Level
   Sharing (RLS) services or not. Valid value is `RLS` or `NONRLS`.
 - `zowe.setup.vsam.volume` indicates the name of volume.
@@ -36,5 +36,6 @@ components:
   Service will be used. Only if this value is `VSAM`, this command will try to
   create VSAM data set.
 - `components.caching-service.storage.vsam.name` defines the VSAM data set name.
-  This field can be omitted and automatically updated with parameter
+  This field is required for shell based `zwe init vsam` command.
+  Otherwise this field can be omitted and automatically updated with parameter
   `--update-config`.

--- a/bin/commands/init/vsam/index.sh
+++ b/bin/commands/init/vsam/index.sh
@@ -108,7 +108,7 @@ if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
 fi
 
 
-if [ "${jcl_existence}" = "true" ] &&  [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" != "true" ]; then
+if [ "${jcl_existence}" = "true" ] && [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" != "true" ]; then
   print_message "Skipped writing to ${jcllib}(ZWECSVSM). To write, you must use --allow-overwrite."
 else
   ###############################

--- a/bin/commands/init/vsam/index.sh
+++ b/bin/commands/init/vsam/index.sh
@@ -94,16 +94,15 @@ fi
 # FIXME: cat cannot be used to test VSAM data set
 vsam_existence=$(is_data_set_exists "${vsam_name}")
 if [ "${vsam_existence}" = "true" ]; then
-  # error
-  print_error_and_exit "Error ZWEL0158E: ${vsam_name} already exists." "" 158
-fi
-if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
-  # delete blindly and ignore errors
-  print_message "Deleting ${vsam_name}"
-  if [ -z "${DRY_RUN}" ]; then
-    result=$(tso_command delete "'${vsam_name}'")
+  if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
+    print_message "Deleting ${vsam_name}"
+    if [ -z "${DRY_RUN}" ]; then
+      result=$(tso_command delete "'${vsam_name}'")
+    else
+      print_message "Skipping delete operation due to --dry-run parameter."
+    fi
   else
-    print_message "Skipping delete operation due to --dry-run parameter."
+    print_error_and_exit "Error ZWEL0158E: ${vsam_name} already exists." "" 158
   fi
 fi
 
@@ -163,33 +162,34 @@ else
   fi
   print_message "- ${jcllib}(ZWECSVSM) is prepared"
   print_message
-fi
 
-###############################
-# submit job
-print_message "Submit ${jcllib}(ZWECSVSM)"
-if [ -z "${DRY_RUN}" ]; then
-  jobid=$(submit_job "//'${jcllib}(ZWECSVSM)'")
-  code=$?
-  if [ ${code} -ne 0 ]; then
-    print_error_and_exit "Error ZWEL0161E: Failed to run JCL ${jcllib}(ZWECSVSM)." "" 161
-  fi
-  print_debug "- job id ${jobid}"
-  jobstate=$(wait_for_job "${jobid}")
-  code=$?
-  if [ ${code} -eq 1 ]; then
-    print_error_and_exit "Error ZWEL0162E: Failed to find job ${jobid} result." "" 162
-  fi
-  jobname=$(echo "${jobstate}" | awk -F, '{print $2}')
-  jobcctext=$(echo "${jobstate}" | awk -F, '{print $3}')
-  jobcccode=$(echo "${jobstate}" | awk -F, '{print $4}')
-  if [ ${code} -eq 0 ]; then
-    print_message "- Job ${jobname}(${jobid}) ends with code ${jobcccode} (${jobcctext})."
+  ###############################
+  # submit job
+  print_message "Submit ${jcllib}(ZWECSVSM)"
+  if [ -z "${DRY_RUN}" ]; then
+    jobid=$(submit_job "//'${jcllib}(ZWECSVSM)'")
+    code=$?
+    if [ ${code} -ne 0 ]; then
+      print_error_and_exit "Error ZWEL0161E: Failed to run JCL ${jcllib}(ZWECSVSM)." "" 161
+    fi
+    print_debug "- job id ${jobid}"
+    jobstate=$(wait_for_job "${jobid}")
+    code=$?
+    if [ ${code} -eq 1 ]; then
+      print_error_and_exit "Error ZWEL0162E: Failed to find job ${jobid} result." "" 162
+    fi
+    jobname=$(echo "${jobstate}" | awk -F, '{print $2}')
+    jobcctext=$(echo "${jobstate}" | awk -F, '{print $3}')
+    jobcccode=$(echo "${jobstate}" | awk -F, '{print $4}')
+    if [ ${code} -eq 0 ]; then
+      print_message "- Job ${jobname}(${jobid}) ends with code ${jobcccode} (${jobcctext})."
+    else
+      print_error_and_exit "Error ZWEL0163E: Job ${jobname}(${jobid}) ends with code ${jobcccode} (${jobcctext})." "" 163
+    fi
   else
-    print_error_and_exit "Error ZWEL0163E: Job ${jobname}(${jobid}) ends with code ${jobcccode} (${jobcctext})." "" 163
+    print_message "Skipping JCL submission due to --dry-run parameter."
   fi
-else
-  print_message "Skipping JCL submission due to --dry-run parameter."
+
 fi
 
 ###############################

--- a/bin/commands/init/vsam/index.sh
+++ b/bin/commands/init/vsam/index.sh
@@ -112,8 +112,7 @@ if [ "${jcl_existence}" = "true" ] &&  [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" 
   print_message "Skipped writing to ${jcllib}(ZWECSVSM). To write, you must use --allow-overwrite."
 else
   ###############################
-  # prepare STCs
-  # ZWESLSTC
+  # ZWECSVSM
   print_message "Modify ZWECSVSM"
   tmpfile=$(create_tmp_file $(echo "zwe ${ZWE_CLI_COMMANDS_LIST}" | sed "s# #-#g"))
   print_debug "- Copy ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWECSVSM) to ${tmpfile}"

--- a/bin/commands/install/index.sh
+++ b/bin/commands/install/index.sh
@@ -116,7 +116,7 @@ EOF
     cd "${ZWE_zowe_runtimeDirectory}/files/${ZWE_PRIVATE_DS_SZWESAMP}"
     for mb in $(find . -type f); do
       print_message "Copy files/${ZWE_PRIVATE_DS_SZWESAMP}/$(basename ${mb}) to ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}"
-      copy_to_data_set "${mb}" "${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}" "" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
+      copy_to_data_set "${mb}" "${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}" "" "true"
       if [ $? -ne 0 ]; then
         print_error_and_exit "Error ZWEL0111E: Command aborts with error." "" 111
       fi
@@ -125,7 +125,7 @@ EOF
     cd "${ZWE_zowe_runtimeDirectory}/files/${ZWE_PRIVATE_DS_SZWEEXEC}"
     for mb in $(find . -type f); do
       print_message "Copy files/${ZWE_PRIVATE_DS_SZWEEXEC}/$(basename ${mb}) to ${prefix}.${ZWE_PRIVATE_DS_SZWEEXEC}"
-      copy_to_data_set "${mb}" "${prefix}.${ZWE_PRIVATE_DS_SZWEEXEC}" "" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
+      copy_to_data_set "${mb}" "${prefix}.${ZWE_PRIVATE_DS_SZWEEXEC}" "" "true"
       if [ $? -ne 0 ]; then
         print_error_and_exit "Error ZWEL0111E: Command aborts with error." "" 111
       fi
@@ -134,12 +134,12 @@ EOF
     # prepare MVS for launcher
     cd "${ZWE_zowe_runtimeDirectory}/components/launcher"
     print_message "Copy components/launcher/samplib/ZWESLSTC to ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}"
-    copy_to_data_set "samplib/ZWESLSTC" "${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}" "" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
+    copy_to_data_set "samplib/ZWESLSTC" "${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}" "" "true"
     if [ $? -ne 0 ]; then
       print_error_and_exit "Error ZWEL0111E: Command aborts with error." "" 111
     fi
     print_message "Copy components/launcher/bin/zowe_launcher to ${prefix}.${ZWE_PRIVATE_DS_SZWEAUTH}"
-    copy_to_data_set "bin/zowe_launcher" "${prefix}.${ZWE_PRIVATE_DS_SZWEAUTH}(ZWELNCH)" "-X" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
+    copy_to_data_set "bin/zowe_launcher" "${prefix}.${ZWE_PRIVATE_DS_SZWEAUTH}(ZWELNCH)" "-X" "true"
     if [ $? -ne 0 ]; then
       print_error_and_exit "Error ZWEL0111E: Command aborts with error." "" 111
     fi
@@ -148,7 +148,7 @@ EOF
     cd "${ZWE_zowe_runtimeDirectory}/files/${ZWE_PRIVATE_DS_SZWELOAD}"
     for mb in $(find . -type f); do
       print_message "Copy files/${ZWE_PRIVATE_DS_SZWELOAD}/$(basename ${mb}) to ${prefix}.${ZWE_PRIVATE_DS_SZWELOAD}"
-      copy_to_data_set "${mb}" "${prefix}.${ZWE_PRIVATE_DS_SZWELOAD}" "" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
+      copy_to_data_set "${mb}" "${prefix}.${ZWE_PRIVATE_DS_SZWELOAD}" "" "true"
       if [ $? -ne 0 ]; then
         print_error_and_exit "Error ZWEL0111E: Command aborts with error." "" 111
       fi
@@ -160,7 +160,7 @@ EOF
     zss_samplib="ZWESASTC ZWESIP00 ZWESISTC ZWESISCH"
     for mb in ${zss_samplib}; do
       print_message "Copy components/zss/SAMPLIB/${mb} to ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(${mb})"
-      copy_to_data_set "SAMPLIB/${mb}" "${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(${mb})" "" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
+      copy_to_data_set "SAMPLIB/${mb}" "${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(${mb})" "" "true"
       if [ $? -ne 0 ]; then
         print_error_and_exit "Error ZWEL0111E: Command aborts with error." "" 111
       fi
@@ -168,7 +168,7 @@ EOF
     zss_loadlib="ZWESIS01 ZWESAUX ZWESISDL"
     for mb in ${zss_loadlib}; do
       print_message "Copy components/zss/LOADLIB/${mb} to ${prefix}.${ZWE_PRIVATE_DS_SZWEAUTH}"
-      copy_to_data_set "LOADLIB/${mb}" "${prefix}.${ZWE_PRIVATE_DS_SZWEAUTH}" "-X" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
+      copy_to_data_set "LOADLIB/${mb}" "${prefix}.${ZWE_PRIVATE_DS_SZWEAUTH}" "-X" "true"
       if [ $? -ne 0 ]; then
         print_error_and_exit "Error ZWEL0111E: Command aborts with error." "" 111
       fi

--- a/bin/libs/zos-dataset.sh
+++ b/bin/libs/zos-dataset.sh
@@ -75,7 +75,7 @@ copy_to_data_set() {
   allow_overwrite="${4}"
 
   if [ "${allow_overwrite}" != "true" ]; then
-    if [ "$(is_data_set_exists "//'${ds_name}'")" = "true" ]; then
+    if [ "$(is_data_set_exists "${ds_name}")" = "true" ]; then
       print_error_and_exit "Error ZWEL0133E: Data set ${ds_name} already exists" "" 133
     fi
   fi

--- a/bin/libs/zos-dataset.sh
+++ b/bin/libs/zos-dataset.sh
@@ -105,7 +105,7 @@ data_set_copy_to_data_set() {
   allow_overwrite="${4}"
 
   if [ "${allow_overwrite}" != "true" ]; then
-    if [ "$(is_data_set_exists '${ds_to}')" = "true" ]; then
+    if [ "$(is_data_set_exists "${ds_to}")" = "true" ]; then
       print_error_and_exit "Error ZWEL0133E: Data set ${ds_to} already exists" "" 133
     fi
   fi


### PR DESCRIPTION
Fixes #3729.

## Changes

### `bin/libs/zos-dataset.sh`
Extra `//` causes, that `false` is  always returned.

### `bin/commands/install/index.sh`
For `copy_to_data_set` change the last parameter to be always `true` (overwrite), otherwise e.g. for fresh install, we will create data sets and then prints error, that data sets can't be overwritten.
In the past, this part of the code was working **because** there was a bug in `copy_to_data_set` 😄 
```
[1/3][expected rc=  0, result rc=  0  ]: /zowe/4476/bin/zwe install -c ./yaml/zowe.basic.yaml
[2/3][expected rc=  0, result rc=  0  ]: /zowe/4476/bin/zwe install -c ./yaml/zowe.basic.yaml
[   ]['Warning ZWEL0301W: ZOWE.PR#4476-.SZWESAMP already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.' found]
[3/3][expected rc=  0, result rc=  0  ]: /zowe/4476/bin/zwe install -c ./yaml/zowe.basic.yaml --allow-overwrite
[   ]['Warning ZWEL0300W: ZOWE.PR#4476-.SZWEEXEC already exists. This dataset will be overwritten.' found]
```

### `bin/commands/init/mvs/index.sh`
`ds_existence` is just for the last data set, new variable `any_existence`.
```
[1/3][expected rc=  0, result rc=  0  ]: /zowe/4476/bin/zwe init mvs -c ./yaml/zowe.basic.yaml
[   ]['Creating ZOWE.PR#4476-.ZWESAPL' found]
[2/3][expected rc=  0, result rc=  0  ]: /zowe/4476/bin/zwe init mvs -c ./yaml/zowe.basic.yaml
[   ]['Skipped writing, you must use --allow-overwrite.' found]
[3/3][expected rc=  0, result rc=  0  ]: /zowe/4476/bin/zwe init mvs -c ./yaml/zowe.basic.yaml --allow-overwrite
[   ]['Copy components/launcher/bin/zowe_launcher to ZOWE.PR#4476-.ZWESALL(ZWELNCH)' found]
```

### `bin/commands/init/security/index.sh`
Small `result=$(...` update.

### `bin/commands/init/stc/index.sh`
Mysterious check `samp_existence` modified to check, what was suggested in comment, i.e. samples.
Small `result=$(...` update.

### `bin/commands/init/vsam/index.sh`
If VSAM already exists and `--allow-overwrite` is `true`, delete it and continue (there was a bug before ending on the VSAM existence).
If JCL `zowe.setup.dataset.jcllib(ZWECSVSM)` already exists and `--allow-overwrite` not used, do not submit this JCL, it might be old/incorrect version.

## Note
* `zwe init security` is modifying `ZWESECUR` job as `zowe.setup.dataset.jcllib(ZW12345)`, where 12345 is a date/random number
  * `--allow-overwrite` does not make sense here - random member name is checked to be unique
  * User must read the `zwe init security` output to know, which job is the most recent one
* `zwe init vsam` is modifying `ZWECSVSM` job as `zowe.setup.dataset.jcllib(ZWECSVSM)`
  * It make sense to use `--allow-overwrite` as the temporary job member name is the same
  * It is easy to find the resulted job

```
[ 1/11][expected rc=  0, result rc=  0  ]: zwe install -c ./yaml/zowe.basic.yaml
[ 2/11][expected rc=  0, result rc=  0  ]: zwe install -c ./yaml/zowe.basic.yaml
[     ]['Warning ZWEL0301W: ZOWE.PR#4476-.SZWESAMP already exists and will not be overwritten. For upgrades, you must use --allow-overwrite.' found]
[ 3/11][expected rc=  0, result rc=  0  ]: zwe install -c ./yaml/zowe.basic.yaml --allow-overwrite
[     ]['Warning ZWEL0300W: ZOWE.PR#4476-.SZWEEXEC already exists. This dataset will be overwritten.' found]
[ 4/11][expected rc=  0, result rc=  0  ]: zwe init mvs -c ./yaml/zowe.basic.yaml
[     ]['Creating ZOWE.PR#4476-.ZWESAPL' found]
[ 5/11][expected rc=  0, result rc=  0  ]: zwe init mvs -c ./yaml/zowe.basic.yaml
[     ]['Skipped writing, you must use --allow-overwrite.' found]
[ 6/11][expected rc=  0, result rc=  0  ]: zwe init mvs -c ./yaml/zowe.basic.yaml --allow-overwrite
[     ]['Copy components/launcher/bin/zowe_launcher to ZOWE.PR#4476-.ZWESALL(ZWELNCH)' found]
[ 7/11][expected rc=  0, result rc=  0  ]: zwe init vsam -c ./yaml/zowe.basic.yaml --dry-run
[     ]['ZOWE.PR#4476-.JCLLIB(ZWECSVSM) is prepared' found]
[ 8/11][expected rc=  0, result rc=  0  ]: zwe init vsam -c ./yaml/zowe.basic.yaml --dry-run
[     ]['ZOWE.PR#4476-.JCLLIB(ZWECSVSM) already exists and will not be overwritten.' found]
[ 9/11][expected rc=  0, result rc=  0  ]: zwe init stc -c ./yaml/zowe.basic.yaml
[10/11][expected rc=  0, result rc=  0  ]: zwe init stc -c ./yaml/zowe.basic.yaml
[     ]['Skipped writing to ZOWE.PR#4476-.JCLLIB. To write, you must use --allow-overwrite.' found]
[     ]['Skipped writing to ZOWE.PR#4476-.PROCLIB. To write, you must use --allow-overwrite.' found]
[11/11][expected rc=  0, result rc=  0  ]: zwe init security -c ./yaml/zowe.basic.yaml --dry-run
```