### PR TITLE
Switch the schema files order for `validate_zowe_yaml`

### DIFF
--- a/bin/libs/config.sh
+++ b/bin/libs/config.sh
@@ -175,7 +175,7 @@ validate_zowe_yaml() {
   fi
 
   configmgr="${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr"
-  schemas="${ZWE_zowe_runtimeDirectory}/schemas/server-common.json:${ZWE_zowe_runtimeDirectory}/schemas/zowe-yaml-schema.json"
+  schemas="${ZWE_zowe_runtimeDirectory}/schemas/zowe-yaml-schema.json:${ZWE_zowe_runtimeDirectory}/schemas/server-common.json"
 
   result=$(_CEE_RUNOPTS="XPLINK(ON)" "${configmgr}" -s "${schemas}" -p "${file}" validate 2>&1 >/dev/null)
   code=$?


### PR DESCRIPTION
# It seems the order of schema files is crucial!

Wrong config was validated as fine, when switching the order, the error was detected.
It seems `extract` does not care about schema order or schema itself. It requires schema, but always return a value.

```shell
#!/bin/sh

echo "*** Input config:"
cat ./invalidZowe.yaml

ZWE_zowe_runtimeDirectory='/zowe/3.3.0-RC3'
configmgr="${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr"

echo "*** VALIDATE zowe-yaml-schema : server-common"
schemas="${ZWE_zowe_runtimeDirectory}/schemas/zowe-yaml-schema.json:${ZWE_zowe_runtimeDirectory}/schemas/server-common.json"
_CEE_RUNOPTS="XPLINK(ON)" "${configmgr}" -s "${schemas}" -p "FILE(invalidZowe.yaml)" validate


echo "*** VALIDATE server-common : zowe-yaml-schema"
schemas="${ZWE_zowe_runtimeDirectory}/schemas/server-common.json:${ZWE_zowe_runtimeDirectory}/schemas/zowe-yaml-schema.json"
_CEE_RUNOPTS="XPLINK(ON)" "${configmgr}" -s "${schemas}" -p "FILE(invalidZowe.yaml)" validate


echo "*** EXTRACT zowe-yaml-schema : server-common"
schemas="${ZWE_zowe_runtimeDirectory}/schemas/zowe-yaml-schema.json:${ZWE_zowe_runtimeDirectory}/schemas/server-common.json"
_CEE_RUNOPTS="XPLINK(ON)" "${configmgr}" -s "${schemas}" -p "FILE(invalidZowe.yaml)" extract "/zowe/setup/dataset/prefix"


echo "*** EXTRACT server-common : zowe-yaml-schema"
schemas="${ZWE_zowe_runtimeDirectory}/schemas/server-common.json:${ZWE_zowe_runtimeDirectory}/schemas/zowe-yaml-schema.json"
_CEE_RUNOPTS="XPLINK(ON)" "${configmgr}" -s "${schemas}" -p "FILE(invalidZowe.yaml)" extract "/zowe/setup/dataset/prefix"

```

```
*** Input config:
zowe:
  setup:
    dataset:
      prefix: '123456'
*** VALIDATE zowe-yaml-schema : server-common
about to validate merged yamls as
{
  "zowe": {
    "setup": {
      "dataset": {
        "prefix": "123456"
      }
    }
  }
}
validate status = 4
Validity Exceptions:
Validity Exceptions(s) with object at
  Validity Exceptions(s) with object at /zowe
    Validity Exceptions(s) with object at /zowe/setup
      Validity Exceptions(s) with object at /zowe/setup/dataset
        Schema at '/zowe/setup/dataset/prefix' invalid
          not oneOf schemas at '/zowe/setup/dataset/prefix' are valid, 0 are
            Validity Exceptions(s) with string at /zowe/setup/dataset/prefix
              string pattern match fail s='123456', pat='^([A-Z\$\#\@]){1}([A-Z0-9\$\#\@\-]){0,7}(\.([A-Z\$\#\@]){1}([A-Z0-9\$\#\@\-]){0,7}){0,11}$', at /zowe/setup/dataset/prefix
            Validity Exceptions(s) with string at /zowe/setup/dataset/prefix
              string too long (len=6) '123456' 6 > MAX=0 at /zowe/setup/dataset/prefix
*** VALIDATE server-common : zowe-yaml-schema
about to validate merged yamls as
{
  "zowe": {
    "setup": {
      "dataset": {
        "prefix": "123456"
      }
    }
  }
}
validate status = 0
No validity Exceptions
*** EXTRACT zowe-yaml-schema : server-common
123456
*** EXTRACT server-common : zowe-yaml-schema
123456
```