### PR TITLE
Fix --update-config's bug when zowe.yaml is a soft-link (V2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
+
+## `2.18.3`
+- Bugfix: `--update-config` might fail if the specified config file is a symbolic link. [#4493](https://github.com/zowe/zowe-install-packaging/pull/4493)
+
 ## `2.18.2`
 - Bugfix: JCL sample `ZWEINSTL` did not include the `ZWESLSTC`. [#4382](https://github.com/zowe/zowe-install-packaging/pull/4382)
 - Bugfix: YAML lookup for HA instances within "haInstances" was not working when HA instance names were uppercase. Now, the lookup is case insensitive to allow for any casing of HA instance names. [#4378](https://github.com/zowe/zowe-install-packaging/pull/4378)

--- a/bin/libs/zos-fs.sh
+++ b/bin/libs/zos-fs.sh
@@ -18,6 +18,10 @@
 # output          USS encoding if exists in upper case
 get_file_encoding() {
   file="${1}"
+  # Resolve symbolic link to real file because "ls -T" does not work on symbolic link.
+  if [ -L "${file}" ]; then
+    file=$(readlink -f "${file}")
+  fi
   # m ISO8859-1   T=off <file>
   # - untagged    T=off <file>
   ls -T "${file}" | awk '{print $2;}' | upper_case


### PR DESCRIPTION
Fixes #4491 

(This PR is porting code changes from [PR 4492](https://github.com/zowe/zowe-install-packaging/pull/4492) to Zowe V2)

When specifying a symbolic link to `--config|-c`, the `--update-config` switch might fail to update the config. It is because the get_file_encoding() function fails to figure out the file encoding from symbolic link. The fix is easy: find the real file by readlink before using ls -T.