### PR TITLE
v2 AT-TLS aware playbooks

### DIFF
--- a/.github/workflows/cicd-test.yml
+++ b/.github/workflows/cicd-test.yml
@@ -365,6 +365,7 @@ jobs:
         env:
           ANSIBLE_FORCE_COLOR: true
           TEST_SERVER: ${{ steps.more-test-prep.outputs.TEST_SERVER_NICKNAME }}
+          ZOWE_ATTLS_POLICY_FILE: ${{ secrets.ATTLS_POLICY_FILE }}
           ZOWE_BUILD_LOCAL: "${{ runner.temp }}/zowe/${{ steps.more-test-prep.outputs.ZOWE_ARTIFACTORY_FINAL_FILENAME }}"
           ZOWE_DOCKER_URL: ${{ steps.more-test-prep.outputs.ZOWE_TP_DOCKER_ARTIFACTORY_URL }}
           EXTENSIONS_LIST: ${{ steps.more-test-prep.outputs.EXTENSION_LIST }}

--- a/playbooks/group_vars/marist.yml
+++ b/playbooks/group_vars/marist.yml
@@ -12,6 +12,16 @@ zowe_apiml_verify_certficates_of_services: false
 zos_java_home: /ZOWE/node/J8.0_64
 # enable Non-Strict verify certificates by default
 zowe_apiml_nonstrict_verify_certficates_of_services: true
+# If you want to use attls on Marist, update the two variables below. By default, attls is disabled
+##  and the policy file is passed as an environment variable. The policy file is the dataset member picked up by PAGENT REFRESH.
+zowe_attls_enabled: false
+zowe_attls_policy_file: 
+zowe_attls_full_keyring: safkeyring://ZWESVUSR/ZWEATTLS
+zowe_attls_cert_alias: ZOWE_ATTLS_CERT
+# use apiml modulith mode
+zowe_apiml_modulith_mode: false
+# use new jcl path for install
+zowe_setup_jcl_enable: false
 zowe_jcllib: ZOWEAD3.ZWE.JCLLIB
 zowe_xmem_proclib: VENDOR.PROCLIB
 zowe_xmem_loadlib: ZOWEAD3.ZWE.LOADLIB

--- a/playbooks/roles/configure/files/ATTLS_Rules.txt
+++ b/playbooks/roles/configure/files/ATTLS_Rules.txt
@@ -1,0 +1,115 @@
+TTLSRule ZoweServerInboundRule
+{
+  LocalAddr All
+  RemoteAddr All
+  LocalPortRange 7550-7560 # Range covers all Zowe services
+  Jobname ZWE1* # Jobname according to zowe.job.prefix in zowe.yaml
+  Direction Inbound
+  TTLSGroupActionRef ServerGroupAction
+  TTLSEnvironmentActionRef ZoweServerEnvironmentAction
+  TTLSConnectionActionRef ZoweServerConnectionAction
+}
+
+TTLSRule ZoweServerOutboundRule
+{
+  LocalAddr All
+  RemoteAddr All
+  LocalPortRange 1024-65535
+  Direction Outbound
+  RemotePortRange 7550-7560
+  Jobname ZWE1*
+  TTLSGroupActionRef ServerGroupAction
+  TTLSEnvironmentActionRef ApimlClientEnvironmentAction
+  TTLSConnectionActionRef ApimlX509ClientConnAction
+}
+
+TTLSGroupAction ServerGroupAction
+{
+  TTLSEnabled ON
+}
+
+TTLSEnvironmentAction ZoweServerEnvironmentAction
+{
+  HandshakeRole ServerWithClientAuth
+  EnvironmentUserInstance 0
+  TTLSEnvironmentAdvancedParmsRef ServerEnvironmentAdvParms
+  TTLSKeyringParmsRef ZoweAttlsKeyring
+}
+
+TTLSEnvironmentAdvancedParms ServerEnvironmentAdvParms
+{
+  ClientAuthType Full # Support optional Client Certificate auth
+  ApplicationControlled            Off
+  Renegotiation Disabled
+  SSLv2                            Off
+  SSLv3                            Off
+  TLSv1                            Off
+  TLSv1.1                          Off
+  TLSv1.2                          On
+  TLSv1.3                          Off
+}
+
+TTLSConnectionAction ZoweServerConnectionAction
+{
+  HandshakeRole ServerWithClientAuth
+  TTLSCipherParmsRef CipherParms
+  TTLSConnectionAdvancedParmsRef ZoweConnectionAdvParms
+}
+
+TTLSEnvironmentAction ApimlClientEnvironmentAction
+{
+  HandshakeRole Client
+  TTLSCipherParmsRef CipherParms
+  TTLSEnvironmentAdvancedParmsRef ClientEnvironmentAdvParms
+  TTLSKeyringParmsRef ZoweAttlsKeyring
+}
+
+TTLSEnvironmentAdvancedParms ClientEnvironmentAdvParms
+{
+  Renegotiation Disabled
+  3DESKEYCHECK OFF
+  CLIENTEDHGROUPSIZE legacy
+  SERVEREDHGROUPSIZE legacy
+  PEERMINCERTVERSION any
+  SERVERSCSV OFF
+  MIDDLEBOXCOMPATMODE Off
+  CertValidationMode Any
+}
+
+TTLSConnectionAction ApimlX509ClientConnAction
+{
+  HandshakeRole Client
+  TTLSCipherParmsRef CipherParms
+  TTLSConnectionAdvancedParmsRef ApimlClientX509ConnAdvParms
+}
+
+TTLSConnectionAdvancedParms ApimlClientX509ConnAdvParms
+{
+  ApplicationControlled Off
+  CertificateLabel ZOWE_ATTLS_CERT
+  SecondaryMap Off
+  TLSv1.1                         Off
+  TLSv1.2                         On
+  TLSv1.3                         Off
+}
+
+TTLSConnectionAdvancedParms ZoweConnectionAdvParms
+{
+  ApplicationControlled Off
+  ServerCertificateLabel ZOWE_ATTLS_CERT
+  CertificateLabel ZOWE_ATTLS_CERT
+  SecondaryMap Off
+}
+
+# Keyring, used for TLS, will be used also to load trusted certificates
+TTLSKeyringParms ZoweAttlsKeyring
+{
+  Keyring ZWEATTLS
+}
+
+TTLSCipherParms CipherParms
+{
+  V3CipherSuites                  TLS_CHACHA20_POLY1305_SHA256
+  V3CipherSuites                  TLS_AES_256_GCM_SHA384
+  V3CipherSuites                  TLS_RSA_WITH_AES_256_CBC_SHA
+}

--- a/playbooks/roles/configure/files/zwe-setup-attls.js
+++ b/playbooks/roles/configure/files/zwe-setup-attls.js
@@ -1,0 +1,60 @@
+// using node because sed does not handle multi-line string replacement well
+//  We set ##---start_zowe_dynamic--- and ##---end_zowe_dynamic to track ATTLS rules implemented by automation.
+
+// Expected call pattern:
+//   node zwe-setup-attls.js <attls-enabled> <attls-rules> <attls-member>
+
+// This takes the rules supplied by <attls-rules> and inserts them into the dynamic block of the <attls-member>. 
+//   If <attls-enabled> is false, then <attls-rules> are ignored and the dynamic block is blanked.
+const args = process.argv;
+const fs = require('fs');
+const cp = require('child_process');
+const path = require('path');
+if (args.length !== 5) {
+  throw new Error('Missing command line argument(s). Usage: node zwe-setup-attls.js <attls-enabled> <attls-rules> <attls-member>');
+}
+const attlsEnabled = args[2].toLowerCase();
+const attlsIncomingRulesFile = args[3];
+let attlsPolicyMember = args[4];
+if (attlsEnabled !== 'true' && attlsEnabled !== 'false') {
+  throw new Error('The first argument, attls-enabled, must be either \'true\' or \'false\'');
+}
+if (attlsEnabled == 'true' && (attlsIncomingRulesFile.trim().length > 0 && !fs.existsSync(attlsIncomingRulesFile))) {
+  throw new Error(`Couldn't find the AT-TLS new rules file: ${attlsRulesFile}`);
+}
+if (attlsPolicyMember.includes('//')) {
+  throw new Error('Please remove forward slashes from the policy member. Use a format like <HLQ.PFX.LVL(MEM)>.')
+}
+
+attlsPolicyMember = attlsPolicyMember.replaceAll(/"'/gi,'');
+attlsPolicyMember = `"//'${attlsPolicyMember}'"`;
+
+const tmpdir = fs.mkdtempSync('attls-auto', {encoding: 'cp1047'});
+let attlsContent;
+try {
+  attlsContent = cp.execSync(`cat ${attlsPolicyMember}`).toString();
+} catch(error) {
+  throw new Error(`Couldn't find AT-TLS policy member: `+ attlsPolicyMember);
+}
+
+// clean content out and leave the start block
+let modifiedContent = attlsContent.replace(/(##---start_zowe_dynamic---).*##---end_zowe_dynamic---/gms, '$1')
+
+if (attlsEnabled == 'true') {
+  const rules = fs.readFileSync(attlsIncomingRulesFile, 'cp1047')
+  modifiedContent+=rules;
+}
+
+// end dynamic block
+modifiedContent+="\n##---end_zowe_dynamic---\n";
+const tmpFile = `${tmpdir}${path.sep}attls.final`;
+fs.writeFileSync(tmpFile, modifiedContent, {encoding: 'cp1047'});
+try {
+
+  // make sure policy member is in writable form - "//'<member-name>'"
+  cp.execSync(`cp ${tmpFile} ${attlsPolicyMember}`);
+} catch (error) {
+  console.log(error);
+} finally {
+  fs.rmdirSync(tmpdir, { force: true, recursive: true });
+}

--- a/playbooks/roles/configure/tasks/configure_attls.yml
+++ b/playbooks/roles/configure/tasks/configure_attls.yml
@@ -1,0 +1,90 @@
+---
+# Configures AT-TLS on the remote system
+
+- include_role:
+    name: common
+    tasks_from: validate_variables
+  vars:
+    variable_list:
+    - work_dir_remote
+    - zowe_root_dir
+    - zowe_attls_policy_file
+    - zos_node_home
+
+- name: Copy ATTLS_Rules.txt to local tmp folder
+  copy:
+    src: ATTLS_Rules.txt
+    dest: "{{ work_dir_local }}/{{ inventory_hostname }}/"
+  delegate_to: localhost
+  
+- name: Copy zwe-setup-attls.js to local tmp folder
+  copy:
+    src: zwe-setup-attls.js
+    dest: "{{ work_dir_local }}/{{ inventory_hostname }}/"
+  delegate_to: localhost
+
+- name: Remove and upload AT-TLS automation files
+  include_role: 
+    name: common
+    tasks_from: upload_file
+  vars:
+    file_upload_method: scp
+    file_upload_hashcheck: false
+  loop:
+    - ATTLS_Rules.txt
+    - zwe-setup-attls.js
+  loop_control:
+    loop_var: filename_to_upload
+
+# !!! Important
+# This runs the script that sets the at-tls rules for the system.
+# If zowe_attls_enabled is not defined or empty, the default will be false (AT-TLS disabled).
+# If the zowe_attls_policy_file is not the system's active AT-TLS policy agent config, then this effectively does nothing.
+- name: Make AT-TLS PAGENT rule updates
+  raw: >-
+    touch {{ zos_uss_user_profile }} && \
+    . {{ zos_uss_user_profile }} \
+    {{ zowe_environment_variable_overrides | default('') }} && \
+    cd "{{ work_dir_remote }}" && \
+    node zwe-setup-attls.js {{ zowe_attls_enabled | default('false', true) }} ATTLS_Rules.txt "{{ zowe_attls_policy_file }}"
+
+- name: Refresh the policy agent with the updated rules
+  import_role:
+    name: zos
+    tasks_from: opercmd
+  vars:
+    opercmd: "F PAGENT,REFRESH"
+
+- name: Update zowe.yaml min and max tls settings when AT-TLS is enabled
+  when: zowe_attls_enabled|bool
+  block:
+  - name: Delete server tls enablement
+    import_role:
+      name: zos
+      tasks_from: delete_zowe_yaml
+    vars:
+      configs:
+      - zowe.network.server.tls.maxTls
+      - zowe.network.server.tls.minTls
+
+# Note these updates assume the default state of zowe.yaml includes maxTls, minTls, 
+#   and no ZOSMF_SCHEME env variable.
+# This is not intended to be re-runnable.
+- name: Update the zowe.yaml 
+  import_role:
+    name: zos
+    tasks_from: update_zowe_yaml
+  vars:
+    configs:
+      "zowe.network.server.tls.attls": "{{ zowe_attls_enabled|string|lower | default('false', true) }}"
+      "zowe.network.client.tls.attls": "{{ zowe_attls_enabled|string|lower | default('false', true) }}"
+
+- name: When AT-TLS is set, add ZOSMF_SCHEME environment variable
+  when: zowe_attls_enabled|bool
+  import_role:
+    name: zos
+    tasks_from: update_zowe_yaml
+  vars:
+    configs:
+      "components.zss.agent.http.ipAddresses.0" : "0.0.0.0"
+      "zowe.environments.ZOSMF_SCHEME": "https"

--- a/playbooks/roles/configure/tasks/main.yml
+++ b/playbooks/roles/configure/tasks/main.yml
@@ -52,6 +52,7 @@
     - zowe_zlux_terminal_telnet_port
     - zos_security_system
     - zowe_lock_keystore
+    - zowe_attls_policy_file
 - name: Show value of zowe_root_dir
   debug:
     msg: zowe_root_dir is {{ zowe_root_dir }}
@@ -329,6 +330,11 @@
         "components.{{ item }}.enabled": "true"
     with_items: "{{ zowe_launch_components.split(',') }}"
 
+- name: Update AT-TLS zowe configuration
+  include_role: 
+    name: configure
+    tasks_from: configure_attls
+
 # ============================================================================
 - name: Show zowe.yaml before zwe init
   raw: cat "{{ zowe_instance_dir }}/zowe.yaml" | grep -v '^ *#' | sed '/^[[:space:]]*$/d'
@@ -355,4 +361,54 @@
     name: zos
     tasks_from: run_zwe
   vars:
-    parameters: "init {{ zwe_init_params }}"
+    parameters: "init mvs {{ zwe_init_params }}"
+
+- name: Init Zowe vsam
+  import_role:
+    name: zos
+    tasks_from: run_zwe
+  vars:
+    parameters: "init vsam {{ zwe_init_params }}"
+
+- name: Init Zowe security
+  import_role:
+    name: zos
+    tasks_from: run_zwe
+  vars:
+    parameters: "init security {{ zwe_init_params }}"
+
+- name: Init Zowe apfauth
+  import_role:
+    name: zos
+    tasks_from: run_zwe
+  vars:
+    parameters: "init apfauth {{ zwe_init_params }}"
+
+- name: Init Zowe certificate
+  import_role:
+    name: zos
+    tasks_from: run_zwe
+  vars:
+    parameters: "init certificate {{ zwe_init_params }}"
+
+- name: Init Zowe stc
+  import_role:
+    name: zos
+    tasks_from: run_zwe
+  vars:
+    parameters: "init stc {{ zwe_init_params }}"
+
+- name: Set AT-TLS Certificate Fields
+  when: zowe_attls_enabled|bool
+  import_role:
+    name: zos
+    tasks_from: update_zowe_yaml
+  vars:
+    configs:
+      "zowe.certificate.keystore.type": "JCERACFKS"
+      "zowe.certificate.keystore.file": "{{ zowe_attls_full_keyring }}"
+      "zowe.certificate.keystore.password": "password" # dummy value
+      "zowe.certificate.keystore.alias": "{{ zowe_attls_cert_alias }}"
+      "zowe.certificate.truststore.type": "JCERACFKS"
+      "zowe.certificate.truststore.file": "{{ zowe_attls_full_keyring }}"
+      "zowe.certificate.truststore.password": "password" # dummy value

--- a/tests/installation/src/__tests__/extended/at-tls/basic-install.ts
+++ b/tests/installation/src/__tests__/extended/at-tls/basic-install.ts
@@ -1,0 +1,49 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright IBM Corporation 2022
+ */
+
+import {
+  checkMandatoryEnvironmentVariables,
+  installAndVerifyConvenienceBuild,
+  showZoweRuntimeLogs,
+} from '../../../utils';
+import {
+  KEYSTORE_MODE_KEYRING,
+  TEST_TIMEOUT_CONVENIENCE_BUILD,
+} from '../../../constants';
+
+const testServer = process.env.TEST_SERVER;
+const testSuiteName = 'Test convenience build installation with enabling config manager';
+describe(testSuiteName, () => {
+  beforeAll(() => {
+    // validate variables
+    checkMandatoryEnvironmentVariables([
+      'TEST_SERVER',
+      'ZOWE_BUILD_LOCAL',
+    ]);
+  });
+
+  test('install and verify', async () => {
+    await installAndVerifyConvenienceBuild(
+      testSuiteName,
+      testServer,
+      {
+        'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
+        'zowe_attls_enabled': 'true',
+        'zos_keystore_mode': KEYSTORE_MODE_KEYRING,
+        'zowe_lock_keystore': 'false',
+        // attls-policy-file is lifted from the defaults on every playbook run
+      }
+    );
+  }, TEST_TIMEOUT_CONVENIENCE_BUILD);
+
+  afterAll(async () => {
+    await showZoweRuntimeLogs(testServer);
+  })
+});

--- a/tests/installation/src/constants.ts
+++ b/tests/installation/src/constants.ts
@@ -39,11 +39,12 @@ export const TEST_TIMEOUT_SMPE_PTF: number = 120 * 60 * 1000;
 export const KEYSTORE_MODE_KEYSTORE = 'KEYSTORE_MODE_KEYSTORE';
 export const KEYSTORE_MODE_KEYRING = 'KEYSTORE_MODE_KEYRING';
 
-export const APIML_OIDC_VARS =  {
+export const DEFAULT_PLAYBOOK_VARS =  {
   'zowe_apiml_security_oidc_client_id': process.env['OKTA_CLIENT_ID'] || 'dummy_id_from_constants_ts',
   'zowe_apiml_security_oidc_client_secret': process.env['OKTA_CLIENT_SECRET'] || 'dummy_secret_from_constants_ts',
   'zowe_apiml_security_oidc_registry': process.env['OIDC_REGISTRY'] || 'dummy_registry_from_constants_ts',
   'zowe_apiml_security_oidc_jwks_uri': `https://${process.env['OKTA_HOSTNAME']}/oauth2/default/v1/keys`,
+  'zowe_attls_policy_file': process.env['ZOWE_ATTLS_POLICY_FILE']
 };
 
 // debug(`process.env >>>>>>>>>>>>>>>>>>>>>>>>>>\n${JSON.stringify(process.env)}\n<<<<<<<<<<<<<<<<<<<<<<<`);

--- a/tests/installation/src/utils.ts
+++ b/tests/installation/src/utils.ts
@@ -21,7 +21,7 @@ import {
   ANSIBLE_ROOT_DIR,
   SANITY_TEST_REPORTS_DIR,
   INSTALL_TEST_REPORTS_DIR,
-  APIML_OIDC_VARS,
+  DEFAULT_PLAYBOOK_VARS,
 } from './constants';
 
 /**
@@ -210,7 +210,7 @@ async function installAndVerifyZowe(testcase: string, installPlaybook: string, s
     testcase,
     installPlaybook,
     serverId,
-    { ...APIML_OIDC_VARS , ...extraVars}
+    { ...DEFAULT_PLAYBOOK_VARS , ...extraVars}
   );
 
   expect(resultInstall.code).toBe(0);
@@ -336,7 +336,7 @@ export async function installAndVerifyDockerBuild(testcase: string, serverId: st
     testcase,
     'install-docker.yml',
     serverId,
-    { ...extraVars, ...APIML_OIDC_VARS }
+    { ...extraVars, ...DEFAULT_PLAYBOOK_VARS }
   );
 
   expect(resultInstall.code).toBe(0);
@@ -416,7 +416,7 @@ export async function installAndVerifySmpePtf(testcase: string, serverId: string
     {
       'zowe_build_remote': ZOWE_FMID,
       'skip_start': 'true',
-      ...APIML_OIDC_VARS
+      ...DEFAULT_PLAYBOOK_VARS
     }
   );
 
@@ -427,7 +427,7 @@ export async function installAndVerifySmpePtf(testcase: string, serverId: string
     testcase,
     'install-ptf.yml',
     serverId,
-    { ...extraPtfVars, ...APIML_OIDC_VARS }
+    { ...extraPtfVars, ...DEFAULT_PLAYBOOK_VARS }
   );
 
   expect(resultPtf.code).toBe(0);
@@ -467,7 +467,7 @@ export async function installAndGenerateApiDocs(testcase: string, serverId: stri
     testcase,
     'install.yml',
     serverId,
-    { ...extraVars, ...APIML_OIDC_VARS }
+    { ...extraVars, ...DEFAULT_PLAYBOOK_VARS }
   );
 
   expect(resultInstall.code).toBe(0);
@@ -513,7 +513,7 @@ export async function showZoweRuntimeLogs(serverId: string, extraVars: {[key: st
       'doesn\'t matter',
       'show-logs.yml',
       serverId,
-      { ...extraVars, ...APIML_OIDC_VARS }
+      { ...extraVars, ...DEFAULT_PLAYBOOK_VARS }
     );
   } catch (e) {
     debug(`showZoweRuntimeLogs failed: ${e}`);


### PR DESCRIPTION
v2 ansible playbooks must always disable AT-TLS when we aren't running AT-TLS tests, as the prior system state could lingering with AT-TLS now due to [the v3 at-tls automation](https://github.com/zowe/zowe-install-packaging/pull/4248)

