### PR TITLE
Delete unused pax file

### DIFF
--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -34,7 +34,7 @@
 #              If unset, conversion happens in-place
 #              If set, conversion will mirror directory structure in output
 # (output) converted files or directory following $2
-# TODO: is this replacable with autoconv?
+# TODO: is this replaceable with autoconv?
 # ---------------------------------------------------------------------
 function _convertEbcdicToAscii {
     input=$1
@@ -240,6 +240,7 @@ cp "${ZOWE_ROOT_DIR}/bin/utils/zowe-server/zowex" "${ZOWE_ROOT_DIR}/bin/utils/zo
 chmod +x "${ZOWE_ROOT_DIR}/bin/utils/zowex"
 cd "${ZOWE_ROOT_DIR}/bin/utils"
 rm -rf "${ZOWE_ROOT_DIR}/bin/utils/zowe-server"
+rm -rf "${ZOWE_ROOT_DIR}/files/zowe-server-*.pax.Z"
 
 echo "[$SCRIPT_NAME] change keyring-util to be executable ..."
 chmod +x "${ZOWE_ROOT_DIR}"/bin/utils/keyring-util/keyring-util

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -240,7 +240,7 @@ cp "${ZOWE_ROOT_DIR}/bin/utils/zowe-server/zowex" "${ZOWE_ROOT_DIR}/bin/utils/zo
 chmod +x "${ZOWE_ROOT_DIR}/bin/utils/zowex"
 cd "${ZOWE_ROOT_DIR}/bin/utils"
 rm -rf "${ZOWE_ROOT_DIR}/bin/utils/zowe-server"
-rm -rf "${ZOWE_ROOT_DIR}/files/zowe-server-*.pax.Z"
+rm "${ZOWE_ROOT_DIR}/files/zowe-server-*.pax.Z"
 
 echo "[$SCRIPT_NAME] change keyring-util to be executable ..."
 chmod +x "${ZOWE_ROOT_DIR}"/bin/utils/keyring-util/keyring-util

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -240,6 +240,9 @@ cp "${ZOWE_ROOT_DIR}/bin/utils/zowe-server/zowex" "${ZOWE_ROOT_DIR}/bin/utils/zo
 chmod +x "${ZOWE_ROOT_DIR}/bin/utils/zowex"
 cd "${ZOWE_ROOT_DIR}/bin/utils"
 rm -rf "${ZOWE_ROOT_DIR}/bin/utils/zowe-server"
+## TMP
+ls -al "${ZOWE_ROOT_DIR}/files"
+## TMP
 rm "${ZOWE_ROOT_DIR}/files/zowe-server-*.pax.Z"
 
 echo "[$SCRIPT_NAME] change keyring-util to be executable ..."

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -240,7 +240,7 @@ cp "${ZOWE_ROOT_DIR}/bin/utils/zowe-server/zowex" "${ZOWE_ROOT_DIR}/bin/utils/zo
 chmod +x "${ZOWE_ROOT_DIR}/bin/utils/zowex"
 cd "${ZOWE_ROOT_DIR}/bin/utils"
 rm -rf "${ZOWE_ROOT_DIR}/bin/utils/zowe-server"
-rm "${zowex_components}"
+rm -rf "${zowex_components}"
 
 echo "[$SCRIPT_NAME] change keyring-util to be executable ..."
 chmod +x "${ZOWE_ROOT_DIR}"/bin/utils/keyring-util/keyring-util

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -240,7 +240,7 @@ cp "${ZOWE_ROOT_DIR}/bin/utils/zowe-server/zowex" "${ZOWE_ROOT_DIR}/bin/utils/zo
 chmod +x "${ZOWE_ROOT_DIR}/bin/utils/zowex"
 cd "${ZOWE_ROOT_DIR}/bin/utils"
 rm -rf "${ZOWE_ROOT_DIR}/bin/utils/zowe-server"
-rm "${ZOWE_ROOT_DIR}/files/${zowex_components}"
+rm "${zowex_components}"
 
 echo "[$SCRIPT_NAME] change keyring-util to be executable ..."
 chmod +x "${ZOWE_ROOT_DIR}"/bin/utils/keyring-util/keyring-util

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -240,10 +240,7 @@ cp "${ZOWE_ROOT_DIR}/bin/utils/zowe-server/zowex" "${ZOWE_ROOT_DIR}/bin/utils/zo
 chmod +x "${ZOWE_ROOT_DIR}/bin/utils/zowex"
 cd "${ZOWE_ROOT_DIR}/bin/utils"
 rm -rf "${ZOWE_ROOT_DIR}/bin/utils/zowe-server"
-## TMP
-ls -al "${ZOWE_ROOT_DIR}/files"
-## TMP
-rm "${ZOWE_ROOT_DIR}/files/zowe-server-*.pax.Z"
+rm "${ZOWE_ROOT_DIR}/files/${zowex_components}"
 
 echo "[$SCRIPT_NAME] change keyring-util to be executable ..."
 chmod +x "${ZOWE_ROOT_DIR}"/bin/utils/keyring-util/keyring-util


### PR DESCRIPTION
```shell
cd /zowe-night-build/files
ls
SZWEEXEC                 SZWESAMP                 sca                      zowe-server-0.1.4.pax.Z
SZWELOAD                 defaults.yaml            workflows
```
`zowe-server-*.pax.Z` is used to get a binary `zowex` and copy it into `bin/utils`. Then it should be probably deleted.