### PR TITLE
convert when conditionals to bools explicitly

### DIFF
--- a/playbooks/install-fmid.yml
+++ b/playbooks/install-fmid.yml
@@ -16,7 +16,7 @@
   # ============================================================================
   # uninstall zowe
   - name: Uninstall Zowe
-    when: zowe_uninstall_before_install|default(True)
+    when: zowe_uninstall_before_install|bool|default(True)
     block:
     - import_role:
         name: zowe
@@ -88,10 +88,10 @@
   # Customize for testing
   - import_role:
       name: custom_for_test
-    when: zowe_custom_for_test|default(False)
+    when: zowe_custom_for_test|bool|default(False)
 
   # ============================================================================
   # Start Zowe
   - import_role:
       name: start
-    when: not skip_start|default(False)
+    when: not skip_start|bool|default(False)

--- a/playbooks/install-ptf.yml
+++ b/playbooks/install-ptf.yml
@@ -79,10 +79,10 @@
   # Customize for testing
   - import_role:
       name: custom_for_test
-    when: zowe_custom_for_test|default(False)
+    when: zowe_custom_for_test|bool|default(False)
 
   # ============================================================================
   # Start Zowe
   - import_role:
       name: start
-    when: not skip_start|default(False)
+    when: not skip_start|bool|default(False)

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -20,7 +20,7 @@
   # ============================================================================
   # uninstall zowe
   - name: Uninstall Zowe
-    when: zowe_uninstall_before_install|default(True)
+    when: zowe_uninstall_before_install|bool|default(True)
     block:
     - import_role:
         name: zowe
@@ -48,10 +48,10 @@
   # Customize for testing
   - import_role:
       name: custom_for_test
-    when: zowe_custom_for_test|default(False)
+    when: zowe_custom_for_test|bool|default(False)
 
   # ============================================================================
   # Start Zowe
   - import_role:
       name: start
-    when: not skip_start|default(False)
+    when: not skip_start|bool|default(False)

--- a/playbooks/uninstall.yml
+++ b/playbooks/uninstall.yml
@@ -16,7 +16,7 @@
   # ============================================================================
   # uninstall zowe
   - name: Uninstall Zowe
-    when: zowe_uninstall_before_install|default(True)
+    when: zowe_uninstall_before_install|bool|default(True)
     block:
     - import_role:
         name: zowe


### PR DESCRIPTION
Fixes errors in playbooks related to the github runner upgrade. Ansible v2.19 had breaking changes for conditionals which improves legibility and better represents developer's intentions. The old conversion of strings to truthy values could cause subtle, uncaught errors.

See https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_12.html#playbook

