### PR TITLE
Perform cleanup of old apiml static def files from workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zowe Installer will be documented in this file.
 
 ## `3.4.0`
 - Bugfix: internal routine `copy_to_data_set` did not correctly check if data set exists. [#4476](https://github.com/zowe/zowe-install-packaging/pull/4476)
+- Bugfix: Zowe startup now removes outdated static definition files from workspace/api-mediation/api-defs, which previously caused wrong or duplicate registrations of servers to APIML. [#4526](https://github.com/zowe/zowe-install-packaging/pull/4526)
 
 ## `3.3.0`
 

--- a/bin/libs/component.ts
+++ b/bin/libs/component.ts
@@ -424,6 +424,11 @@ function isClientAttls() {
   }
 }
 
+// This function both creates static definition files from manifest templates,
+// And cleans up existing ones that seem to be outdated
+// It does not touch existing files that are neither - it continues to permit sideloaded static definition files
+// TODO - this also means it permits outdated files from extensions that no longer exist.
+//        uninstalling an extension does not do any such cleanup, so this bug continues to exist.
 export function processComponentApimlStaticDefinitions(componentDir: string): boolean {
   const STATIC_DEF_DIR=std.getenv('ZWE_STATIC_DEFINITIONS_DIR');
   if (!STATIC_DEF_DIR) {
@@ -441,6 +446,15 @@ export function processComponentApimlStaticDefinitions(componentDir: string): bo
   const componentName = manifest.name;
   if (manifest.apimlServices && manifest.apimlServices.static) {
     let staticDefs = manifest.apimlServices.static;
+
+    const existingFiles = fs.getFilesInDirectory(STATIC_DEF_DIR);
+    const definedHaInstanceNames = ZOWE_CONFIG.haInstances ?
+                                 Object.keys(ZOWE_CONFIG.haInstances).map(name=>configUtils.sanitizeHaInstanceId(name)) :
+                                 [];
+
+    const currentHaInstanceName = configUtils.sanitizeHaInstanceId();
+    const haInstanceNames = definedHaInstanceNames.includes(currentHaInstanceName) ? definedHaInstanceNames : [currentHaInstanceName].concat(definedHaInstanceNames);
+
     for (let i = 0; i < staticDefs.length; i++) {
       const staticDef = staticDefs[i];
       const file=staticDef.file;
@@ -473,9 +487,10 @@ export function processComponentApimlStaticDefinitions(componentDir: string): bo
 
           const resolvedContents = varlib.resolveShellTemplate(contents);
 
-          const zweCliParameterHaInstance=std.getenv("ZWE_CLI_PARAMETER_HA_INSTANCE");
+          
           //discovery static code requires specifically .yml. Not .yaml
-          const outPath=`${STATIC_DEF_DIR}/${componentName}.${sanitizedDefName}.${zweCliParameterHaInstance}.yml`;
+          const outFileName = `${componentName}.${sanitizedDefName}.${currentHaInstanceName}.yml`;
+          const outPath=`${STATIC_DEF_DIR}/${outFileName}`;
 
           common.printDebug(`- writing ${outPath}`);
 
@@ -489,6 +504,39 @@ export function processComponentApimlStaticDefinitions(componentDir: string): bo
             shell.execSync(`chmod`, `770`, outPath);
           } else {
             common.printError(`Could not write static definition file ${outPath}, errobj=`+errorObj);
+          }
+
+          //cleanup outdated static definision files of same type
+          common.printDebug(`Checking for old static defs for cleanup`);
+          if (existingFiles) {
+            let prefix = `${componentName}.${sanitizedDefName}.`;
+            let apimlPrefix = `apiml.${sanitizedDefName}.`;
+            let discoveryPrefix = `discovery.${sanitizedDefName}.`;
+            let suffix = '.yml';
+            for (let i = 0; i < existingFiles.length; i++) {
+              let existingFile = existingFiles[i];
+              if (existingFile.endsWith(suffix)) {
+                if (existingFile.startsWith(prefix)) {
+                  let haInstanceFound = existingFile.substring(prefix.length, existingFile.length - suffix.length);
+                  if (!haInstanceNames.includes(haInstanceFound) && existingFile != outFileName) {
+                    common.printDebug(`Removing outdated static def ${existingFile}`);
+                    os.remove(`${STATIC_DEF_DIR}/${existingFile}`);
+                  } else {
+                    common.printDebug(`Ignored static def ${existingFile}`);
+                  }
+                } else if (componentName == 'discovery' && existingFile.startsWith(apimlPrefix)) {
+                  common.printDebug(`Removing apiml modulith static def ${existingFile}`);
+                  os.remove(`${STATIC_DEF_DIR}/${existingFile}`);
+                } else if (componentName == 'apiml' && existingFile.startsWith(discoveryPrefix)) {
+                  common.printDebug(`Removing discovery non-modulith static def ${existingFile}`);
+                  os.remove(`${STATIC_DEF_DIR}/${existingFile}`);
+                } else {
+                  common.printDebug(`Ignored static def ${existingFile}`);
+                }
+              }
+            }
+          } else {
+            common.printDebug(`No prior static defs for ${componentName} found`);
           }
         }
       }

--- a/bin/libs/config.ts
+++ b/bin/libs/config.ts
@@ -225,10 +225,12 @@ export function generateInstanceEnvFromYamlConfig(haInstance: string) {
 }
 
 
-// check and sanitize ZWE_CLI_PARAMETER_HA_INSTANCE
-export function sanitizeHaInstanceId(): string|undefined {
-  // ignore default value passed from ZWESLSTC
-  let zweCliParameterHaInstance = std.getenv('ZWE_CLI_PARAMETER_HA_INSTANCE');
+// check and sanitize input or env var "ZWE_CLI_PARAMETER_HA_INSTANCE"
+// if input is not given, the env var will be updated.
+export function sanitizeHaInstanceId(input?: string): string|undefined {
+  let zweCliParameterHaInstance = input ? input : std.getenv('ZWE_CLI_PARAMETER_HA_INSTANCE');
+
+  // ignore default value passed from ZWESLSTC - this is intended to be transformed by us.
   if (zweCliParameterHaInstance == "{{ha_instance_id}}" || zweCliParameterHaInstance == "__ha_instance_id__") {
     std.unsetenv('ZWE_CLI_PARAMETER_HA_INSTANCE');
     zweCliParameterHaInstance=undefined;
@@ -239,7 +241,9 @@ export function sanitizeHaInstanceId(): string|undefined {
   // sanitize instance id
   if (zweCliParameterHaInstance){
     zweCliParameterHaInstance=stringlib.sanitizeAlphanum(zweCliParameterHaInstance.toLowerCase());
-    std.setenv('ZWE_CLI_PARAMETER_HA_INSTANCE', zweCliParameterHaInstance );
+    if (!input) { // env var used downstream, update env var.
+      std.setenv('ZWE_CLI_PARAMETER_HA_INSTANCE', zweCliParameterHaInstance );
+    }
   }
   return zweCliParameterHaInstance;
 }


### PR DESCRIPTION
fixes https://github.com/zowe/zowe-install-packaging/issues/3853

If a user moves their zowe config from one system to another, or changes their ha instance name, or switches between apiml modulith on/off, entries like the zosmf static registration file can get duplicated within workspace/api-mediation/api-defs.
This then causes unpredictable behavior - some requests succeed, some fail, if apiml is switching between existing and not existing servers from multiple registration files.

This PR resolves that by using the startup code to checking for files that seem to be generated by the startup code, but are invalid for the current configuration.
Invalid old files would be if 'discovery' was found when modulith is used, or vice-versa, or if a file is found from a component which is from an ha instance which seems to not exist currently.

This does not target 'sideloaded' files. If there's a file in the folder that doesnt match the pattern that this code produces, then it is untouched.

Currently this also means files made by extensions that no longer exist - this code could be expanded to cover that, but does not currently.

Here's a test for the functionality - 
[test.js](https://github.com/user-attachments/files/22598268/test.js)

