### PR TITLE
add FIXCAT for z/OS 3.2 support to 2.18.3

### DIFF
--- a/smpe/bld/service/current-close.txt
+++ b/smpe/bld/service/current-close.txt
@@ -10,3 +10,4 @@ The Zowe community version was updated to #version.
 This PTF provides the community changes in SMP/E format.
 Follow this link for more details on the community changes:
 #link
+FIXCAT: ZOS0302T/K


### PR DESCRIPTION
This FIXCAT should've been included in 2.18.2 but the discussion on this topic happened after the release. As it turns out this was for the best, as 2.18.2 had a z/OS 3.2 support related bug, and so 2.18.3 will be the release that officially supports 3.2.

We need to manually remove this FIXCAT after release.