### PR TITLE
Fix PTF Test Errors

### DIFF
--- a/playbooks/roles/configfmid/tasks/main.yml
+++ b/playbooks/roles/configfmid/tasks/main.yml
@@ -251,7 +251,6 @@
   vars:
     configs:
       "zowe.runtimeDirectory": "{{ zowe_root_dir }}"
-      "zowe.setup.jcl.enable": "{{ zowe_setup_jcl_enable|string|lower }}"
       "zowe.logDirectory": "{{ zowe_instance_dir }}/logs"
       "zowe.workspaceDirectory": "{{ zowe_instance_dir }}/workspace"
       "zowe.extensionDirectory": "{{ zowe_extension_dir }}"


### PR DESCRIPTION
The configfmid playbook should not include newer zowe.yaml fields. In this case, `zowe.setup.jcl.enable` was the cause of the failure because the automation tried to start Zowe 3.0.0 (base FMID) with the configuration.

