### PR TITLE
Patch PTF Playbooks (again)

### DIFF
--- a/bin/commands/init/vsam/index.sh
+++ b/bin/commands/init/vsam/index.sh
@@ -72,22 +72,14 @@ if [ "${jcl_existence}" = "true" ]; then
 fi
 
 # VSAM cache cannot be overwritten, must delete manually
-# FIXME: cat cannot be used to test VSAM data set
-vsam_existence=$(is_data_set_exists "${vsam_name}")
-if [ "${vsam_existence}" = "true" ]; then
-  # if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
-  #   result=$(tso_command delete "'${vsam_name}'")
-  # fi
-  # else
-  #   print_error_and_exit "Error ZWEL0158E: ${vsam_name} already exists." "" 158
-  # fi
+vsam_existence=$(tso_is_data_set_exists "${vsam_name}")
+if [ "${vsam_existence}" -eq 0 ]; then
+  if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
+    result=$(tso_command delete "'${vsam_name}'")
+  else
+    print_error_and_exit "Error ZWEL0158E: ${vsam_name} already exists." "" 158
+  fi
 fi
-
-# Blindly delete VSAM when allow-overwrite is set
-if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
-  result=$(tso_command delete "'${vsam_name}'")
-fi
-
 
 if [ "${jcl_existence}" = "true" ] && [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" != "true" ]; then
   print_message "Skipped writing to ${jcllib}(ZWECSVSM). To write, you must use --allow-overwrite."

--- a/bin/commands/init/vsam/index.sh
+++ b/bin/commands/init/vsam/index.sh
@@ -72,7 +72,8 @@ if [ "${jcl_existence}" = "true" ]; then
 fi
 
 # VSAM cache cannot be overwritten, must delete manually
-vsam_existence=$(tso_is_data_set_exists "${vsam_name}")
+tso_is_data_set_exists "${vsam_name}"
+vsam_existence=$?
 if [ "${vsam_existence}" -eq 0 ]; then
   if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
     result=$(tso_command delete "'${vsam_name}'")

--- a/bin/commands/init/vsam/index.sh
+++ b/bin/commands/init/vsam/index.sh
@@ -75,12 +75,19 @@ fi
 # FIXME: cat cannot be used to test VSAM data set
 vsam_existence=$(is_data_set_exists "${vsam_name}")
 if [ "${vsam_existence}" = "true" ]; then
-  if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
-    result=$(tso_command delete "'${vsam_name}'")
-  else
-    print_error_and_exit "Error ZWEL0158E: ${vsam_name} already exists." "" 158
-  fi
+  # if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
+  #   result=$(tso_command delete "'${vsam_name}'")
+  # fi
+  # else
+  #   print_error_and_exit "Error ZWEL0158E: ${vsam_name} already exists." "" 158
+  # fi
 fi
+
+# Blindly delete VSAM when allow-overwrite is set
+if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
+  result=$(tso_command delete "'${vsam_name}'")
+fi
+
 
 if [ "${jcl_existence}" = "true" ] && [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" != "true" ]; then
   print_message "Skipped writing to ${jcllib}(ZWECSVSM). To write, you must use --allow-overwrite."

--- a/playbooks/roles/configure/tasks/main.yml
+++ b/playbooks/roles/configure/tasks/main.yml
@@ -69,7 +69,7 @@
       opercmd: "$D PROCLIB"
   - name: Find the first proclib
     set_fact:
-      zowe_proclib_dsname: "{{ opercmd_result.stdout | regex_search(qry, '\\1') | first }}"
+      zowe_proclib_dsname: "{{ opercmd_result.stdout | regex_search(qry, '\\1') | default([], True) | first }}"
     vars:
       qry: \$HASP319 +DD\(1\)=\(DSNAME=(.+),
 

--- a/playbooks/roles/stop/defaults/main.yml
+++ b/playbooks/roles/stop/defaults/main.yml
@@ -6,3 +6,27 @@
 # ==============================================================================
 # Variables should be verified and overwrittern.
 # ==============================================================================
+
+## Lifted from role: zowe, defaults/main.yml
+
+# this should list all known Zowe job names we ever shipped
+zowe_known_jobnames:
+# job name before 1.4.0: ZOWESVR
+- ZOWESVR
+# job name after 1.4.0: ZOWESV1
+- ZOWESV1
+# job name preparing for 1.5.0: ZOWE1SV
+- ZOWE1SV
+# job name preparing for 1.8.0: ZWE1SV
+- ZWE1SV
+# variations
+- ZWE2SV
+
+# this should list all known xmem Zowe job names we ever shipped
+zowe_known_xmem_jobnames:
+# job name before 1.8.0: ZWESIS01
+- ZWESIS01
+# job name before in some testing 1.7.1: ZWEXMSTC
+- ZWEXMSTC
+# job name preparing for 1.8.0: ZWESISTC
+- ZWESISTC

--- a/playbooks/roles/zos/tasks/check_job_status.yml
+++ b/playbooks/roles/zos/tasks/check_job_status.yml
@@ -28,7 +28,7 @@
 
 - name: Get Job name
   set_fact:
-    jcl_job_name: "{{ opercmd_result.stdout | regex_search(qry, multiline=True, ignorecase=True) }}"
+    jcl_job_name: "{{ opercmd_result.stdout | regex_search(qry, multiline=True, ignorecase=True) | default('') }}"
   vars:
     qry: (?<=\$HASP890 JOB\()[^)]+(?=\))
 
@@ -37,13 +37,13 @@
 # ... $HASP890 JOB(GIMUNZIP)  CC=()  <-- reject this value
 - name: Get Job completion
   set_fact:
-    jcl_job_completion: "{{ opercmd_result.stdout | regex_search(qry, multiline=True, ignorecase=True) }}"
+    jcl_job_completion: "{{ opercmd_result.stdout | regex_search(qry, multiline=True, ignorecase=True) | default('') }}"
   vars:
     qry: (?<=CC=\()[^)]+(?<!\))
 
 - name: Get Job return code
   set_fact:
-    jcl_job_rc: "{{ jcl_job_completion | regex_search(qry, ignorecase=True) }}"
+    jcl_job_rc: "{{ jcl_job_completion | regex_search(qry, ignorecase=True) | default('') }}"
   vars:
     qry: (?<=RC=).+
 

--- a/playbooks/roles/zos/tasks/check_job_status.yml
+++ b/playbooks/roles/zos/tasks/check_job_status.yml
@@ -28,7 +28,7 @@
 
 - name: Get Job name
   set_fact:
-    jcl_job_name: "{{ opercmd_result.stdout | regex_search(qry, multiline=True, ignorecase=True) | default('') }}"
+    jcl_job_name: "{{ opercmd_result.stdout | regex_search(qry, multiline=True, ignorecase=True) | default('', True) }}"
   vars:
     qry: (?<=\$HASP890 JOB\()[^)]+(?=\))
 
@@ -37,13 +37,13 @@
 # ... $HASP890 JOB(GIMUNZIP)  CC=()  <-- reject this value
 - name: Get Job completion
   set_fact:
-    jcl_job_completion: "{{ opercmd_result.stdout | regex_search(qry, multiline=True, ignorecase=True) | default('') }}"
+    jcl_job_completion: "{{ opercmd_result.stdout | regex_search(qry, multiline=True, ignorecase=True) | default('', True) }}"
   vars:
     qry: (?<=CC=\()[^)]+(?<!\))
 
 - name: Get Job return code
   set_fact:
-    jcl_job_rc: "{{ jcl_job_completion | regex_search(qry, ignorecase=True) | default('') }}"
+    jcl_job_rc: "{{ jcl_job_completion | regex_search(qry, ignorecase=True) | default('', True) }}"
   vars:
     qry: (?<=RC=).+
 

--- a/playbooks/roles/zos/tasks/run_jcl.yml
+++ b/playbooks/roles/zos/tasks/run_jcl.yml
@@ -31,7 +31,7 @@
 
 - name: Get Job ID
   set_fact:
-    jcl_job_id: "{{ jcl_submit_result.stdout | regex_search(qry, multiline=True, ignorecase=True) }}"
+    jcl_job_id: "{{ jcl_submit_result.stdout | regex_search(qry, multiline=True, ignorecase=True) | default('', True) }}"
   vars:
     qry: (?!JOB JOB)[0-9]{1,}(?<! submitted)
 


### PR DESCRIPTION
*Tests from this PR need to run before accepting this*

Nightly PTF Automation passes sometimes for v3, and not at all for v2. 

After a closer look, this appears to be related to Ansible updates in the Github runners. Jinja templating is stricter, and a `null` response from a `regex_search` in the playbooks previously returned the empty string, but now it returns null, which breaks existing conditional checks looping while waiting for job output.  This PR sets the `default('')` empty string after the regex to coerce null values into empty strings, preserving the existing conditional checks.

This will need to be ported to v3. As far as I can tell, PTF playbooks will *sometimes* pass if the `LSTFMID` job completes fast enough, but it shouldn't be reliable at all.