### PR TITLE
Prepare 2.18.3-RC2

### DIFF
--- a/bin/commands/init/vsam/index.sh
+++ b/bin/commands/init/vsam/index.sh
@@ -72,9 +72,9 @@ if [ "${jcl_existence}" = "true" ]; then
 fi
 
 # VSAM cache cannot be overwritten, must delete manually
-# FIXME: cat cannot be used to test VSAM data set
-vsam_existence=$(is_data_set_exists "${vsam_name}")
-if [ "${vsam_existence}" = "true" ]; then
+tso_is_data_set_exists "${vsam_name}"
+vsam_existence=$?
+if [ "${vsam_existence}" -eq 0 ]; then
   if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
     result=$(tso_command delete "'${vsam_name}'")
   else

--- a/playbooks/roles/configure/tasks/main.yml
+++ b/playbooks/roles/configure/tasks/main.yml
@@ -69,7 +69,7 @@
       opercmd: "$D PROCLIB"
   - name: Find the first proclib
     set_fact:
-      zowe_proclib_dsname: "{{ opercmd_result.stdout | regex_search(qry, '\\1') | first }}"
+      zowe_proclib_dsname: "{{ opercmd_result.stdout | regex_search(qry, '\\1') | default([], True) | first }}"
     vars:
       qry: \$HASP319 +DD\(1\)=\(DSNAME=(.+),
 

--- a/playbooks/roles/stop/defaults/main.yml
+++ b/playbooks/roles/stop/defaults/main.yml
@@ -6,3 +6,27 @@
 # ==============================================================================
 # Variables should be verified and overwrittern.
 # ==============================================================================
+
+## Lifted from role: zowe, defaults/main.yml
+
+# this should list all known Zowe job names we ever shipped
+zowe_known_jobnames:
+# job name before 1.4.0: ZOWESVR
+- ZOWESVR
+# job name after 1.4.0: ZOWESV1
+- ZOWESV1
+# job name preparing for 1.5.0: ZOWE1SV
+- ZOWE1SV
+# job name preparing for 1.8.0: ZWE1SV
+- ZWE1SV
+# variations
+- ZWE2SV
+
+# this should list all known xmem Zowe job names we ever shipped
+zowe_known_xmem_jobnames:
+# job name before 1.8.0: ZWESIS01
+- ZWESIS01
+# job name before in some testing 1.7.1: ZWEXMSTC
+- ZWEXMSTC
+# job name preparing for 1.8.0: ZWESISTC
+- ZWESISTC

--- a/playbooks/roles/zos/tasks/check_job_status.yml
+++ b/playbooks/roles/zos/tasks/check_job_status.yml
@@ -28,7 +28,7 @@
 
 - name: Get Job name
   set_fact:
-    jcl_job_name: "{{ opercmd_result.stdout | regex_search(qry, multiline=True, ignorecase=True) }}"
+    jcl_job_name: "{{ opercmd_result.stdout | regex_search(qry, multiline=True, ignorecase=True) | default('', True) }}"
   vars:
     qry: (?<=\$HASP890 JOB\()[^)]+(?=\))
 
@@ -37,13 +37,13 @@
 # ... $HASP890 JOB(GIMUNZIP)  CC=()  <-- reject this value
 - name: Get Job completion
   set_fact:
-    jcl_job_completion: "{{ opercmd_result.stdout | regex_search(qry, multiline=True, ignorecase=True) }}"
+    jcl_job_completion: "{{ opercmd_result.stdout | regex_search(qry, multiline=True, ignorecase=True) | default('', True) }}"
   vars:
     qry: (?<=CC=\()[^)]+(?<!\))
 
 - name: Get Job return code
   set_fact:
-    jcl_job_rc: "{{ jcl_job_completion | regex_search(qry, ignorecase=True) }}"
+    jcl_job_rc: "{{ jcl_job_completion | regex_search(qry, ignorecase=True) | default('', True) }}"
   vars:
     qry: (?<=RC=).+
 

--- a/playbooks/roles/zos/tasks/run_jcl.yml
+++ b/playbooks/roles/zos/tasks/run_jcl.yml
@@ -31,7 +31,7 @@
 
 - name: Get Job ID
   set_fact:
-    jcl_job_id: "{{ jcl_submit_result.stdout | regex_search(qry, multiline=True, ignorecase=True) }}"
+    jcl_job_id: "{{ jcl_submit_result.stdout | regex_search(qry, multiline=True, ignorecase=True) | default('', True) }}"
   vars:
     qry: (?!JOB JOB)[0-9]{1,}(?<! submitted)
 


### PR DESCRIPTION
Includes changes from #4542 which fixes a bug in the `init vsam` command group and additionally fixes PTF tests in CICD.