### PR TITLE
Bugfix: set z/OSMF auth scheme from env variable

### DIFF
--- a/bin/libs/component.ts
+++ b/bin/libs/component.ts
@@ -500,7 +500,7 @@ export function processComponentApimlStaticDefinitions(componentDir: string): bo
           if (!authProvider) {
             authProvider = 'zosmf';
           }
-          let authScheme = 'zosmf';
+          let authScheme = zosmfAuthenticationScheme || 'zosmf';
           if (!zosmfAuthenticationScheme && (authProvider === 'saf')) {
             authScheme = 'httpBasicPassTicket';
           }


### PR DESCRIPTION
Bug from https://github.com/zowe/zowe-install-packaging/pull/4563


zosmfAuthenticationScheme is never actualy used if it is set