### PR TITLE
V2: replace `which` with `whence`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
 
+## `2.18.4`
+- Bugfix: `detect_java_home` and `detect_node_home` routines used incorrect shell command [#____](https://github.com/zowe/zowe-install-packaging/pull/____)
+
 ## `2.18.3`
 - Bugfix: internal routine `copy_to_data_set` did not correctly check if data set exists. [#4489](https://github.com/zowe/zowe-install-packaging/pull/4489)
 - Bugfix: `--update-config` might fail if the specified config file is a symbolic link. [#4493](https://github.com/zowe/zowe-install-packaging/pull/4493)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
 
 ## `2.18.4`
-- Bugfix: `detect_java_home` and `detect_node_home` routines used incorrect shell command [#____](https://github.com/zowe/zowe-install-packaging/pull/____)
+- Bugfix: `detect_java_home` and `detect_node_home` routines used incorrect shell command [#4572](https://github.com/zowe/zowe-install-packaging/pull/4572)
 
 ## `2.18.3`
 - Bugfix: internal routine `copy_to_data_set` did not correctly check if data set exists. [#4489](https://github.com/zowe/zowe-install-packaging/pull/4489)

--- a/bin/libs/java.sh
+++ b/bin/libs/java.sh
@@ -21,11 +21,11 @@ shell_read_yaml_java_home() {
   yaml="${1}"
 
   java_home=$(shell_read_yaml_config "${yaml}" 'java' 'home')
-  # validate NODE_HOME
+  # validate JAVA_HOME
   result=$(validate_java_home "${java_home}" 2>/dev/null)
   code=$?
   if [ ${code} -ne 0 ]; then
-    # incorrect NODE_HOME, reset and try again
+    # incorrect JAVA_HOME, reset and try again
     # this could be caused by failing to read java.home correctly from zowe.yaml
     java_home=
   fi
@@ -38,15 +38,13 @@ shell_read_yaml_java_home() {
 detect_java_home() {
   java_home=
 
-  # do we have which?
-  java_bin_home=$(which java 2>/dev/null)
+  java_bin_home=$(whence java 2>/dev/null)
   if [ -n "${java_bin_home}" ]; then
     # extract java home from result like: /var/jdk/bin/java
     java_home=$(dirname "$(dirname "${java_bin_home}")")
   fi
 
   # fall back to check PATH
-  java_home=$(which java 2>/dev/null)
   if [ -z "${java_home}" ]; then
     java_home=$(
       IFS=:

--- a/bin/libs/node.sh
+++ b/bin/libs/node.sh
@@ -55,8 +55,7 @@ shell_read_yaml_node_home() {
 detect_node_home() {
   node_home=
 
-  # do we have which?
-  node_bin_home=$(which node 2>/dev/null)
+  node_bin_home=$(whence node 2>/dev/null)
   if [ -n "${node_bin_home}" ]; then
     # extract node home from result like: /var/nodejs/node-v14.16.0-os390-s390x-202103142315/bin/node
     node_home=$(dirname "$(dirname "${node_bin_home}")")


### PR DESCRIPTION
There is no `which` command in Unix System Services. Used code always produced no string as result:
```
$ which java
which: FSUM7351 not found
$ which java 2>/dev/null
```

* `bin/libs/java.sh`
  * Comment update
  * `which` to `whence`
  * removed the second `which` (copy & paste bug?)

* `bin/libs/node.sh`
  * `which` to `whence`

For V3, this is fixed in #4307.

### Quick test
```shell
#!/bin/sh
export ZWE_zowe_runtimeDirectory=/zowe/4572
. /zowe/4572/bin/libs/index.sh

whence java
detect_java_home
```

```
/sys/java64bt/v17r0m0/usr/lpp/java/current/bin/java
DEBUG: after whence: /sys/java64bt/v17r0m0/usr/lpp/java/current
/sys/java64bt/v17r0m0/usr/lpp/java/current
```