### PR TITLE
add missing label to export command

### DIFF
--- a/bin/libs/certificate.sh
+++ b/bin/libs/certificate.sh
@@ -1132,7 +1132,7 @@ keyring_export_to_pkcs12() {
 
     # export private key
     print_debug "- Export private key of \"${label}\" in PEM format"
-    result=$(keyring_util EXPORT "${keyring_owner}" "${keyring_name}" "${label}" -k -f "${uss_temp_target}.p12" -p "${keystore_password}")
+    result=$(keyring_util EXPORT "${keyring_owner}" "${keyring_name}" -l "${label}" -k -f "${uss_temp_target}.p12" -p "${keystore_password}")
     if [ $? -ne 0 ]; then
       return 1
     fi

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -134,7 +134,7 @@
       "artifact": "*.pax"
     },
     "org.zowe.keyring-utilities": {
-      "version": "^3.0.0-MASTER",
+      "version": "^3.2.0-MASTER",
       "artifact": "*.pax"
     },
     "org.zopencommunity.curl": {


### PR DESCRIPTION
Lines up with PR in [keyring-utilities](https://github.com/zowe/keyring-utilities/pull/21). 

Fixes a bug in certificate EXPORTs, and ensures `--label-only` and `--owner-only` print no extraneous information to the `read -r` functions used in shell scripts.

To be included in 3.4.0.