### PR TITLE
restore njq, remove curl pax and zowe-utility-tools zip from `files/`…

### DIFF
--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -223,6 +223,9 @@ fi
 # FIXME: remove/comment this debug code
 # cd "${BASE_DIR}" && rm -fr content && rm -fr smpe && rm -fr templates && cp -r content.bak content
 
+echo "[$SCRIPT_NAME] unpack utility-tools njq ..."
+
+
 echo "[$SCRIPT_NAME] change scripts to be executable ..."
 chmod +x "${ZOWE_ROOT_DIR}"/bin/zwe
 chmod +x "${ZOWE_ROOT_DIR}"/bin/utils/*.sh
@@ -234,6 +237,7 @@ cd "${ZOWE_ROOT_DIR}/bin/utils"
 pax -ppx -rf "${curl_pax}"
 mv "${ZOWE_ROOT_DIR}"/bin/utils/curl-*/bin/curl ./curl
 rm -rf "${ZOWE_ROOT_DIR}"/bin/utils/curl-*
+rm -rf "${curl_pax}"
 
 echo "[$SCRIPT_NAME] change curl to be executable ..."
 chmod +x "${ZOWE_ROOT_DIR}"/bin/utils/curl

--- a/.pax/prepare-workspace.sh
+++ b/.pax/prepare-workspace.sh
@@ -147,6 +147,23 @@ mkdir -p "${CONTENT_DIR}/licenses"
 echo "[${SCRIPT_NAME}] copy license file ..."
 mv "${PAX_BINARY_DEPENDENCIES}/zowe_licenses_full.zip" "${CONTENT_DIR}/licenses"
 
+# extract packaging utility tools to bin/utils
+echo "[${SCRIPT_NAME}] prepare utility tools ..."
+cd "${ROOT_DIR}" && cd "${CONTENT_DIR}/bin/utils"
+echo "[${SCRIPT_NAME}] extract zowe-utility-tools.zip ..."
+jar -xf "${PAX_BINARY_DEPENDENCIES}"/zowe-utility-tools*.zip
+# extract njq and delete the rest
+echo "[${SCRIPT_NAME}] extract zowe-njq ..."
+tar zxf zowe-njq-*.tgz
+mv package njq
+rm zowe-fconv-*.tgz
+rm zowe-config-converter-*.tgz
+rm zowe-njq-*.tgz
+rm zowe-ncert-*.pax
+cd "${ROOT_DIR}"
+rm -f "${PAX_BINARY_DEPENDENCIES}"/zowe-utility-tools*.zip
+
+
 # put text files into ascii folder (recursive & verbose)
 echo "[${SCRIPT_NAME}] move ASCII files out of CONTENT directory for encoding conversion ..."
 rsync -rv \


### PR DESCRIPTION
address #4594 .

Restores `njq` since it's still used in `migrate for kubernetes` and container scripts, even though those functions aren't actively supported.

To be included in 3.4.0