### PR TITLE
Updating `zwe` doc for v2

### DIFF
--- a/.github/workflows/zwe-doc-generation.yml
+++ b/.github/workflows/zwe-doc-generation.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOCS_SITE_ZWE_COMMAND_REFERENCE_DIR: docs/appendix/zwe_server_command_reference
+  DOCS_SITE_ZWE_COMMAND_REFERENCE_DIR: versioned_docs/version-v2.18.x/appendix/zwe_server_command_reference
   DOCS_SITE_TARGET_BRANCH: docs-staging
   DOCS_SITE_COMMIT_BRANCH: auto-update-zwe-reference
   ZWE_DOC_GENERATION_DIR: .dependency/zwe_doc_generation


### PR DESCRIPTION
Updating `zwe` doc for v2 should write out to the versioned branch of the docs, not the live `zwe` doc.

This automation has been flaky so we may be out of sync already, as a follow up we should ensure `zwe` doc is accurate and has been recently updated by this automation for both v2 and v3.