### PR TITLE
3.4.0-RC2 component install was not updating zowe.yaml

### DIFF
--- a/bin/libs/json.ts
+++ b/bin/libs/json.ts
@@ -108,16 +108,17 @@ function buildUpdateObjWithArrays(zoweConfig: any, key: string): any {
 }
 
 /**
- * Updates the YAML key in the zowe.yaml passed by the caller with val. Always overwrites on-disk.
+ * Updates the provided zowe.yaml file ONLY with the YAML key and value passed by the caller. Always overwrites on-disk. 
+ * Schema validation after update is optional, and defaults to true.
  * 
- * Example: `updateZoweYaml('/path/to/zowe.yaml', 'components.zss.enabled', true);
+ * Example: `updateZoweYamlFileOnly('/path/to/zowe.yaml', 'components.zss.enabled', true);
  * 
  * @param file 
  * @param key 
  * @param val 
  * @returns 
  */
-export function updateZoweYaml(file: string, key: string, val: any, validate: boolean=true): number {
+export function updateZoweYamlFileOnly(file: string, key: string, val: any, validate: boolean=true): number {
   common.printMessage(`- update zowe config ${file}, key: "${key}" with value: ${val}, and validate: ${validate}`);
   let mergeObj = {};
   if (/\[\d+\]/.test(key)) {
@@ -132,6 +133,30 @@ export function updateZoweYaml(file: string, key: string, val: any, validate: bo
   } else {
     common.printError(`  * Error`); 
     return -1;
+  }
+}
+
+/**
+ * Updates the YAML key in the zowe.yaml passed by the caller with val, AND updates the zowe.yaml which can be found via ZOWE_CONFIG_PATH. 
+ * This can result in multiple zowe.yaml file updates, typically in both a private merged file and the original zowe.yaml.
+ * 
+ * Example: `updateZoweYaml('/path/to/zowe.merged.yaml', 'components.zss.enabled', true);
+ *   --> This will update both zowe.merged.yaml, and whatever YAML was passed to the calling program via ("-c my.zowe.yaml").
+ * 
+ * @param file 
+ * @param key 
+ * @param val 
+ * @returns 
+ */
+export function updateZoweYaml(file: string, key: string, val: any) {
+  common.printMessage(`- update zowe config ${file}, key: "${key}" with value: ${val}`);
+  let [ success, updateObj ] = fakejq.jqset({}, key, val);
+  
+  if (success) {
+    common.printMessage(`  * Success`);
+    config.updateZoweConfig(updateObj, true, 1); //TODO externalize array merge strategy = 1
+  } else {
+    common.printError(`  * Error`); 
   }
 }
 

--- a/bin/utils/ModifyZoweYaml.ts
+++ b/bin/utils/ModifyZoweYaml.ts
@@ -57,7 +57,7 @@ if (modType == MOD_TYPES.update) {
 
   common.printTrace(`Updating: ${file}, ${key}, ${newValue}, ${validate}`)
 
-  rc = jsonlib.updateZoweYaml(file, key, newValue, validate);
+  rc = jsonlib.updateZoweYamlFileOnly(file, key, newValue, validate);
 } else if (modType == MOD_TYPES.delete) {
   const validate: boolean = setValidate(pgmArgs[3]); 
   common.printTrace(`Deleting: ${file}, ${key}`);


### PR DESCRIPTION
This fixes an issue found in RC2 where component installations were not updating the zowe.yaml file properly.

Before the Node.JS removal PR, all updates through `json.ts#updateZoweYaml` would write to both the supplied file parameter **and** an originating `zowe.yaml` file. This `zowe.yaml` file is uncovered through `ZOWE_CONFIG_PATH` in `configmgr.ts`, and _not_ via the env `ZWE_CLI_PARAMETER_CONFIG`, as this value is sometimes modified and updated to a temporary merged yaml file. If the file parameter and the original `zowe.yaml` are one and the same, then it's written twice.

After the Node.JS removal PR, updates were only written to the supplied file parameter. This behavior has been separated into a new function and is called by `ModifyZoweYaml.ts`, while all other calls will continue with the older behavior.

