### PR TITLE
Fix for apiml + zwe internal start

### DIFF
--- a/bin/libs/component.ts
+++ b/bin/libs/component.ts
@@ -472,8 +472,12 @@ export function findAllLaunchComponents2(): string[] {
   if (!enabledComponents) {
     enabledComponents = findAllEnabledComponents2();
   }
-
+  const usingApimlModulith = enabledComponents.includes('apiml');
+  
   return enabledComponents.filter(function(component: string) {
+    if (usingApimlModulith && INDIVIDUAL_APIML_COMPONENTS.includes(component)) {
+      return false;
+    }
     const componentDir = findComponentDirectory(component);
     if (componentDir) {
       const manifest = getManifest(componentDir);


### PR DESCRIPTION
Related to earlier work in https://github.com/zowe/zowe-install-packaging/pull/4433 

zwe internal start is a testing command, which I use to start components without running the launcher. just makes rapid testing faster.

This command relies upon a function, findAllLaunchComponents(), which says which components to start.
It seems the launcher has the smarts to know not to start apiml components that are already covered by the enabled modulith, because it wasnt using this function.
But zwe internal start does use this function.

The result was, without the fix, zwe internal start would start every enabled component, meaning if modulith was enabled, parts of apiml would start twice, and then cause all sorts of errors.