### PR TITLE
No additional items for `java` and `node`

### DIFF
--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -786,6 +786,7 @@
     },
     "java": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "home": {
           "$ref": "/schemas/v2/server-common#zoweOptionalPath",
@@ -795,6 +796,7 @@
     },
     "node": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "home": {
           "$ref": "/schemas/v2/server-common#zoweOptionalPath",


### PR DESCRIPTION
Eliminates errors like this (wrong `node` indentation):

```yaml
zowe:
  launchScript:
    startupChecks:
      default: exit
      default: This does not matter
  externalPort: 7554
  externalPort: This does not matter
java:
  home: /path/to/java/
  node:
  home: /path/to/node/
```
```
zwe config get -c ./zowe.yaml --path .java
{
  "home": "/path/to/node/",
  "node": null
}
```

Note:
* `java.home` is defined twice and the second value is used.
* For other types (`enum` | `number`) it looks like the first value is used and the rest is ignored.
