### PR TITLE
change keyring artifact to SNAPSHOT

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -350,7 +350,7 @@
       "componentGroup": "Utilities",
       "entries": [{
         "repository": "keyring-utilities",
-        "tag": "master",
+        "tag": "v3.x/master",
         "destinations": ["Zowe PAX"]
       }, {
         "repository": "zowe-install-packaging-tools",

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -134,7 +134,7 @@
       "artifact": "*.pax"
     },
     "org.zowe.keyring-utilities": {
-      "version": "^3.2.0-MASTER",
+      "version": "^3.2.0-SNAPSHOT",
       "artifact": "*.pax"
     },
     "org.zopencommunity.curl": {


### PR DESCRIPTION
Fixes build issue due to keyring-utilities `-MASTER` artifacts being cleaned up by automation. `SNAPSHOT` artifacts are always skipped and preserved.