### PR TITLE
don't remove certauth certs from RACF after build

### DIFF
--- a/playbooks/roles/zowe/tasks/uninstall_keyring_racf.yml
+++ b/playbooks/roles/zowe/tasks/uninstall_keyring_racf.yml
@@ -22,10 +22,10 @@
   loop: "{{ zowe_known_keyring_personal_certificates }}"
   ignore_errors: True
 
-- name: Remove Zowe RACF certauth certficates
-  raw: tsocmd "RACDCERT CERTAUTH DELETE(LABEL('{{ item }}'))"
-  loop: "{{ zowe_known_keyring_certauth_certificates }}"
-  ignore_errors: True 
+# - name: Remove Zowe RACF certauth certficates
+#   raw: tsocmd "RACDCERT CERTAUTH DELETE(LABEL('{{ item }}'))"
+#   loop: "{{ zowe_known_keyring_certauth_certificates }}"
+#   ignore_errors: True 
 
 - name: List user's RACF certificates
   raw: tsocmd "RACDCERT ID({{ zowe_runtime_user }})"


### PR DESCRIPTION
Missing commit in #4514, related to #4640 .