### PR TITLE
z/OSMF code 401 treated as 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Zowe Installer will be documented in this file.
 
 ## `3.5.0`
+- Bugfix: Running z/OSMF is returning 401, if RSU2512 was applied. [#46??](https://github.com/zowe/zowe-install-packaging/pull/46??)
 - Bugfix: `zwe config get` HA instance lookup is case insensitive. [#4609](https://github.com/zowe/zowe-install-packaging/pull/4609)
 - Enhancement: `zwe config get` command uses new `--format` option to format the output. [#4591](https://github.com/zowe/zowe-install-packaging/pull/4591)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zowe Installer will be documented in this file.
 
 ## `3.5.0`
-- Bugfix: Running z/OSMF is returning 401, if RSU2512 was applied. [#46??](https://github.com/zowe/zowe-install-packaging/pull/46??)
+- Bugfix: Running z/OSMF is returning 401, if RSU2512 was applied. [#4657](https://github.com/zowe/zowe-install-packaging/pull/4657)
 - Bugfix: `zwe config get` HA instance lookup is case insensitive. [#4609](https://github.com/zowe/zowe-install-packaging/pull/4609)
 - Enhancement: `zwe config get` command uses new `--format` option to format the output. [#4591](https://github.com/zowe/zowe-install-packaging/pull/4591)
 

--- a/bin/libs/zosmf.sh
+++ b/bin/libs/zosmf.sh
@@ -33,7 +33,8 @@ validate_zosmf_host_and_port() {
   if [ -z "${http_response_code}" ]; then
     print_error "Warning: Could not validate if z/OSMF is available on 'https://${zosmf_host}:${zosmf_port}/zosmf/info'. No response code from z/OSMF server."
     zosmf_check_passed=false
-  elif [ ${http_response_code} != 200 ]; then
+  # RSU2512 -> running z/OSMF is returning 401
+  elif [ ${http_response_code} != 200 -a ${http_response_code} != 401 ]; then
     print_error "Could not contact z/OSMF on 'https://${zosmf_host}:${zosmf_port}/zosmf/info' - ${http_response_code}"
     zosmf_check_passed=false
     return 1

--- a/bin/libs/zosmf.sh
+++ b/bin/libs/zosmf.sh
@@ -42,6 +42,6 @@ validate_zosmf_host_and_port() {
   
 
   if [ "${zosmf_check_passed}" = "true" ]; then
-    print_message "Successfully checked z/OSMF is available on 'https://${zosmf_host}:${zosmf_port}/zosmf/info'"
+    print_message "Successfully checked z/OSMF is available on 'https://${zosmf_host}:${zosmf_port}/zosmf/info' - ${http_response_code}"
   fi
 }

--- a/bin/libs/zosmf.ts
+++ b/bin/libs/zosmf.ts
@@ -42,9 +42,8 @@ export function validateZosmfHostAndPort(zosmfHost: string, zosmfPort: number, s
     zosmfCheckPassed=false
   }
   
-
   if (zosmfCheckPassed) {
-    common.printMessage(`Successfully checked z/OSMF is available on '${scheme}://${zosmfHost}:${zosmfPort}/zosmf/info'`)
+    common.printMessage(`Successfully checked z/OSMF is available on '${scheme}://${zosmfHost}:${zosmfPort}/zosmf/info' - ${execReturn.out}`);
   }
   return zosmfCheckPassed || warnOnly;
 }

--- a/bin/libs/zosmf.ts
+++ b/bin/libs/zosmf.ts
@@ -36,7 +36,8 @@ export function validateZosmfHostAndPort(zosmfHost: string, zosmfPort: number, s
   if (execReturn.rc || !execReturn.out) {
     common.printError(`Warning: Could not validate if z/OSMF is available on '${scheme}://${zosmfHost}:${zosmfPort}/zosmf/info'. No response code from z/OSMF server.`);
     zosmfCheckPassed=false
-  } else if (execReturn.out != '200') {
+  // RSU2512 -> running z/OSMF is returning 401
+  } else if (['200', '401'].includes(execReturn.out) == false) {
     common.printError(`Could not contact z/OSMF on '${scheme}://${zosmfHost}:${zosmfPort}/zosmf/info' - ${execReturn.out}`);
     zosmfCheckPassed=false
   }

--- a/tests/zwe-remote-integration/src/__tests__/internal/__snapshots__/start-prepare.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/internal/__snapshots__/start-prepare.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`start-prepare-tests (SHORT) default startupChecks behavior 1`] = `
-" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v3.4.0
+" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v0.0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) build and hash: {BUILD_BRANCH}#{BUILD_NUMBER} ({BUILD_COMMIT_HASH})
  TESTUSR0 INFO (zwe-internal-start-prepare) z/OS Version: 0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) ESM: ESMT
@@ -9,7 +9,7 @@ exports[`start-prepare-tests (SHORT) default startupChecks behavior 1`] = `
  TESTUSR0 INFO (zwe-internal-start-prepare,global_validate) process global validations ...
  TESTUSR0 INFO (validateNodeHome) NodeJS version: v0.0.0
  TESTUSR0 INFO (validateJavaHome) Java version: v0.0.0
-Successfully checked z/OSMF is available on 'https://some.test.hostname:12321/zosmf/info'
+Successfully checked z/OSMF is available on 'https://some.test.hostname:12321/zosmf/info' - 200
  TESTUSR0 INFO (zwe-internal-start-prepare,global_validate) global validations are successful
  TESTUSR0 INFO (zwe-internal-start-prepare,validate_components) process component validations ...
  TESTUSR0 INFO (zwe-validate-port-available) Checking ports of 11 enabled components
@@ -21,7 +21,7 @@ ERROR:  TESTUSR0 ERROR (zwe-internal-start-prepare,validate_components) Error ZW
 `;
 
 exports[`start-prepare-tests (SHORT) modulith disabled 1`] = `
-" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v3.4.0
+" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v0.0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) build and hash: {BUILD_BRANCH}#{BUILD_NUMBER} ({BUILD_COMMIT_HASH})
  TESTUSR0 INFO (zwe-internal-start-prepare) z/OS Version: 0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) ESM: ESMT
@@ -29,7 +29,7 @@ exports[`start-prepare-tests (SHORT) modulith disabled 1`] = `
  TESTUSR0 INFO (zwe-internal-start-prepare,global_validate) process global validations ...
  TESTUSR0 INFO (validateNodeHome) NodeJS version: v0.0.0
  TESTUSR0 INFO (validateJavaHome) Java version: v0.0.0
-Successfully checked z/OSMF is available on 'https://some.test.hostname:12321/zosmf/info'
+Successfully checked z/OSMF is available on 'https://some.test.hostname:12321/zosmf/info' - 200
  TESTUSR0 INFO (zwe-internal-start-prepare,global_validate) global validations are successful
  TESTUSR0 INFO (zwe-internal-start-prepare,validate_components) process component validations ...
  TESTUSR0 INFO (zwe-validate-port-available) Checking ports of 10 enabled components
@@ -41,7 +41,7 @@ ERROR:  TESTUSR0 ERROR (zwe-internal-start-prepare,validate_components) Error ZW
 `;
 
 exports[`start-prepare-tests (SHORT) set startupChecks disabled 1`] = `
-" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v3.4.0
+" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v0.0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) build and hash: {BUILD_BRANCH}#{BUILD_NUMBER} ({BUILD_COMMIT_HASH})
  TESTUSR0 INFO (zwe-internal-start-prepare) z/OS Version: 0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) ESM: ESMT
@@ -58,7 +58,7 @@ ERROR:  TESTUSR0 ERROR (zwe-internal-start-prepare,validate_components) Error ZW
 `;
 
 exports[`start-prepare-tests (SHORT) set startupChecks warn 1`] = `
-" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v3.4.0
+" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v0.0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) build and hash: {BUILD_BRANCH}#{BUILD_NUMBER} ({BUILD_COMMIT_HASH})
  TESTUSR0 INFO (zwe-internal-start-prepare) z/OS Version: 0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) ESM: ESMT
@@ -66,7 +66,7 @@ exports[`start-prepare-tests (SHORT) set startupChecks warn 1`] = `
  TESTUSR0 INFO (zwe-internal-start-prepare,global_validate) process global validations ...
  TESTUSR0 INFO (validateNodeHome) NodeJS version: v0.0.0
  TESTUSR0 INFO (validateJavaHome) Java version: v0.0.0
-Successfully checked z/OSMF is available on 'https://some.test.hostname:12321/zosmf/info'
+Successfully checked z/OSMF is available on 'https://some.test.hostname:12321/zosmf/info' - 200
  TESTUSR0 INFO (zwe-internal-start-prepare,global_validate) global validations are successful
  TESTUSR0 INFO (zwe-internal-start-prepare,validate_components) process component validations ...
  TESTUSR0 INFO (zwe-validate-port-available) Checking ports of 11 enabled components
@@ -78,7 +78,7 @@ ERROR:  TESTUSR0 ERROR (zwe-internal-start-prepare,validate_components) Error ZW
 `;
 
 exports[`start-prepare-tests (SHORT) test combinations of startup default and ports 1`] = `
-" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v3.4.0
+" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v0.0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) build and hash: {BUILD_BRANCH}#{BUILD_NUMBER} ({BUILD_COMMIT_HASH})
  TESTUSR0 INFO (zwe-internal-start-prepare) z/OS Version: 0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) ESM: ESMT
@@ -86,7 +86,7 @@ exports[`start-prepare-tests (SHORT) test combinations of startup default and po
  TESTUSR0 INFO (zwe-internal-start-prepare,global_validate) process global validations ...
  TESTUSR0 INFO (validateNodeHome) NodeJS version: v0.0.0
  TESTUSR0 INFO (validateJavaHome) Java version: v0.0.0
-Successfully checked z/OSMF is available on 'https://some.test.hostname:12321/zosmf/info'
+Successfully checked z/OSMF is available on 'https://some.test.hostname:12321/zosmf/info' - 200
  TESTUSR0 INFO (zwe-internal-start-prepare,global_validate) global validations are successful
  TESTUSR0 INFO (zwe-internal-start-prepare,validate_components) process component validations ...
 ERROR:  TESTUSR0 ERROR (zwe-internal-start-prepare,validate_components) Error ZWEL0172E: Component zss has commands.validate defined but the file is missing.
@@ -96,7 +96,7 @@ ERROR:  TESTUSR0 ERROR (zwe-internal-start-prepare,validate_components) Error ZW
 `;
 
 exports[`start-prepare-tests (SHORT) test combinations of startup default and ports 2`] = `
-" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v3.4.0
+" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v0.0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) build and hash: {BUILD_BRANCH}#{BUILD_NUMBER} ({BUILD_COMMIT_HASH})
  TESTUSR0 INFO (zwe-internal-start-prepare) z/OS Version: 0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) ESM: ESMT
@@ -104,7 +104,7 @@ exports[`start-prepare-tests (SHORT) test combinations of startup default and po
  TESTUSR0 INFO (zwe-internal-start-prepare,global_validate) process global validations ...
  TESTUSR0 INFO (validateNodeHome) NodeJS version: v0.0.0
  TESTUSR0 INFO (validateJavaHome) Java version: v0.0.0
-Successfully checked z/OSMF is available on 'https://some.test.hostname:12321/zosmf/info'
+Successfully checked z/OSMF is available on 'https://some.test.hostname:12321/zosmf/info' - 200
  TESTUSR0 INFO (zwe-internal-start-prepare,global_validate) global validations are successful
  TESTUSR0 INFO (zwe-internal-start-prepare,validate_components) process component validations ...
 ERROR:  TESTUSR0 ERROR (zwe-internal-start-prepare,validate_components) Error ZWEL0172E: Component zss has commands.validate defined but the file is missing.
@@ -114,7 +114,7 @@ ERROR:  TESTUSR0 ERROR (zwe-internal-start-prepare,validate_components) Error ZW
 `;
 
 exports[`start-prepare-tests (SHORT) test combinations of startup default and ports 3`] = `
-" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v3.4.0
+" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v0.0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) build and hash: {BUILD_BRANCH}#{BUILD_NUMBER} ({BUILD_COMMIT_HASH})
  TESTUSR0 INFO (zwe-internal-start-prepare) z/OS Version: 0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) ESM: ESMT
@@ -133,7 +133,7 @@ ERROR:  TESTUSR0 ERROR (zwe-internal-start-prepare,validate_components) Error ZW
 `;
 
 exports[`start-prepare-tests (SHORT) test combinations of startup default and ports 4`] = `
-" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v3.4.0
+" TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v0.0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) build and hash: {BUILD_BRANCH}#{BUILD_NUMBER} ({BUILD_COMMIT_HASH})
  TESTUSR0 INFO (zwe-internal-start-prepare) z/OS Version: 0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) ESM: ESMT

--- a/tests/zwe-remote-integration/src/__tests__/internal/start-prepare.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/internal/start-prepare.test.ts
@@ -51,6 +51,9 @@ describe(`${testSuiteName}`, () => {
   afterEach(async () => {
     await testRunner.postTest();
     await TestFileActions.deleteAll([workspaceEnv]);
+    defaultCfgYaml = ZoweConfig.getDefaultsYaml();
+    // always reset defaults yaml
+    await testRunner.uploadDefaultsYaml(defaultCfgYaml, undefined, true);
   });
 
   afterAll(() => {

--- a/tests/zwe-remote-integration/src/__tests__/validate/__snapshots__/config.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/validate/__snapshots__/config.test.ts.snap
@@ -311,7 +311,7 @@ Zowe will remove it on success, but if zwe exits with a non-zero code manual cle
 `;
 
 exports[`zwe-validate-commands (SHORT) config validate alias 1`] = `
-"TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v3.4.0
+"TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v0.0.0
 TESTUSR0 INFO (zwe-internal-start-prepare) build and hash: {BUILD_BRANCH}#{BUILD_NUMBER} ({BUILD_COMMIT_HASH})
 Validating Zowe core configuration for file(s)=/test/dir/zowe.test.yaml
 Temporary directory '/tmp/.zweenv-0000' created.
@@ -320,7 +320,7 @@ Zowe core configuration is valid"
 `;
 
 exports[`zwe-validate-commands (SHORT) config validate alias 2`] = `
-"TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v3.4.0
+"TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v0.0.0
 TESTUSR0 INFO (zwe-internal-start-prepare) build and hash: {BUILD_BRANCH}#{BUILD_NUMBER} ({BUILD_COMMIT_HASH})
 Validating Zowe core configuration for file(s)=/test/dir/zowe.test.yaml
 Temporary directory '/tmp/.zweenv-0000' created.

--- a/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
+++ b/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
@@ -435,7 +435,7 @@ export class RemoteTestRunner {
       .replaceAll(REMOTE_SYSTEM_INFO.volume, 'TSTVOL')
       .replaceAll(REMOTE_SYSTEM_INFO.hostname, this.dummyHostname)
       .replaceAll(REMOTE_SYSTEM_INFO.zosmfPort, this.dummyPort)
-      .replaceAll(new RegExp(`Zowe Version: v${getZoweVersion()}`, 'g'), 'Zowe version: v0.0.0')
+      .replaceAll(new RegExp(`Zowe version: v${getZoweVersion()}`, 'g'), 'Zowe version: v0.0.0')
       .replaceAll(/\d{4}-\d{2}-\d{2}.+?<.+?>/g, '')
       .replaceAll(/z\/OS Version: \d\.\d/g, 'z/OS Version: 0.0')
       .replaceAll(/NodeJS version: v.*?$/gm, 'NodeJS version: v0.0.0')


### PR DESCRIPTION
Fixes #4656
* z/OSMF is up and running
* z/OSMF check in form of: `curl https://lpar1.example.com:443/zosmf/info -k -H  "X-CSRF-ZOSMF-HEADER: true" -w "%{http_code}" -s -o /dev/null`
* Without RSU2512: `200`
* With RSU2512: `401`

Workaround without this PR:
* YAML option to change the z/OSMF check behavior:
  * Global setting
    * `zowe.launchScript.startupChecks.default: warn` or
    * `zowe.launchScript.startupChecks.default: disabled` or
  * z/OSMF specific seting:
    * `zowe.launchScript.startupChecks.zosmf: warn` or
    * `zowe.launchScript.startupChecks.zosmf: disabled`

But if there is no change to configuration & RSU2512 applied, this fix is required.

## Changes
* Http code 200 or 401 treated as success.
* Prints code for success. 

## Update 2026/01/21
Seems the workaround will not help, `zaas` is using the same endpoint and will fail too.
API ML fix will be required.