### PR TITLE
Curl version update

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -138,7 +138,7 @@
       "artifact": "*.pax"
     },
     "org.zopencommunity.curl": {
-      "version": "^8.17.0",
+      "version": "^8.18.0",
       "artifact": "*.pax.Z"
     },
     "org.zowe.utility-tools": {


### PR DESCRIPTION
`curl` updated to version 8.18.

Quick test:
```
$ cd /zowe/pr4682/bin/utils
$ ./curl https://our.dev.lpar.zosmf:443/zosmf/info -u USERID -k -H "X-CSRF-ZOSMF-HEADER: true" -w "%{http_code}"
$ {"zos_version":"05.30.00","zosmf_port":"443",...}
$ 200
$ ./curl https://our.dev.lpar.zosmf:443/zosmf/info -k -H "X-CSRF-ZOSMF-HEADER: true" -w "%{http_code}"
$ 401
```

Note: `our.dev.lpar` is with RSU2512.