### PR TITLE
Print `curl` rc and `http` code, when z/OSMF is not validated

### DIFF
--- a/bin/libs/zosmf.sh
+++ b/bin/libs/zosmf.sh
@@ -30,8 +30,9 @@ validate_zosmf_host_and_port() {
   zosmf_check_passed=true
 
   http_response_code=$("${ZWE_zowe_runtimeDirectory}/bin/utils/curl" "https://${zosmf_host}:${zosmf_port}/zosmf/info" -k -H "X-CSRF-ZOSMF-HEADER: true" -w "%{http_code}" -s -o /dev/null)
-  if [ -z "${http_response_code}" ]; then
-    print_error "Warning: Could not validate if z/OSMF is available on 'https://${zosmf_host}:${zosmf_port}/zosmf/info'. No response code from z/OSMF server."
+  curl_rc=$?
+  if [ "${curl_rc}" != 0 ]; then
+    print_error "Warning: Could not validate if z/OSMF is available on 'https://${zosmf_host}:${zosmf_port}/zosmf/info'. No response code from z/OSMF server - curl(${curl_rc}) - ${http_response_code}"
     zosmf_check_passed=false
   # RSU2512 -> running z/OSMF is returning 401
   elif [ ${http_response_code} != 200 -a ${http_response_code} != 401 ]; then

--- a/bin/libs/zosmf.ts
+++ b/bin/libs/zosmf.ts
@@ -34,11 +34,10 @@ export function validateZosmfHostAndPort(zosmfHost: string, zosmfPort: number, s
     std.unsetenv('_BPX_JOBNAME');
   }
   if (execReturn.rc || !execReturn.out) {
-    // Typical scenarios:
-    //  - curl(6) 000 -> wrong host (typo or not defined in /etc/hosts)
-    const printCurlRc = execReturn.rc > 0 ? `curl(${execReturn.rc})` : '';
+    // Typical scenario:
+    //  - curl(6) - 000 => wrong host (typo or not defined in /etc/hosts)
     const printHTTPCode = execReturn.out ? ` - ${execReturn.out}` : '';
-    common.printError(`Warning: Could not validate if z/OSMF is available on '${scheme}://${zosmfHost}:${zosmfPort}/zosmf/info'. No response code from z/OSMF server: ${printCurlRc}${printHTTPCode}`);
+    common.printError(`Warning: Could not validate if z/OSMF is available on '${scheme}://${zosmfHost}:${zosmfPort}/zosmf/info'. No response code from z/OSMF server - curl(${execReturn.rc})${printHTTPCode}`);
     zosmfCheckPassed=false
   // RSU2512 -> running z/OSMF is returning 401
   } else if (['200', '401'].includes(execReturn.out) == false) {

--- a/bin/libs/zosmf.ts
+++ b/bin/libs/zosmf.ts
@@ -34,7 +34,11 @@ export function validateZosmfHostAndPort(zosmfHost: string, zosmfPort: number, s
     std.unsetenv('_BPX_JOBNAME');
   }
   if (execReturn.rc || !execReturn.out) {
-    common.printError(`Warning: Could not validate if z/OSMF is available on '${scheme}://${zosmfHost}:${zosmfPort}/zosmf/info'. No response code from z/OSMF server.`);
+    // Typical scenarios:
+    //  - curl(6) 000 -> wrong host (typo or not defined in /etc/hosts)
+    const printCurlRc = execReturn.rc > 0 ? `curl(${execReturn.rc})` : '';
+    const printHTTPCode = execReturn.out ? ` - ${execReturn.out}` : '';
+    common.printError(`Warning: Could not validate if z/OSMF is available on '${scheme}://${zosmfHost}:${zosmfPort}/zosmf/info'. No response code from z/OSMF server: ${printCurlRc}${printHTTPCode}`);
     zosmfCheckPassed=false
   // RSU2512 -> running z/OSMF is returning 401
   } else if (['200', '401'].includes(execReturn.out) == false) {


### PR DESCRIPTION
To speed up the debugging.

There are some scenarios, when the z/OSMF check could fail and there is easy solution.
## Without change

`ERROR: Warning: Could not validate if z/OSMF is available on 'https://example.com:443/zosmf/info'. No response code from z/OSMF server.` - this is not helpful.

## With change

### Wrong port
`ERROR: Warning: Could not validate if z/OSMF is available on 'https://localhost:444/zosmf/info'. No response code from z/OSMF server - curl(7) - 000`

### Wrong host (typo in host)
`ERROR: Warning: Could not validate if z/OSMF is available on 'https://examplee.com:443/zosmf/info'. No response code from z/OSMF server - curl(6) - 000`

### Host not defined in /etc/hosts
`ERROR: Warning: Could not validate if z/OSMF is available on 'https://example:443/zosmf/info'. No response code from z/OSMF server - curl(6) - 000`
