### PR TITLE
V2: update `cleanup-ipc-mq.sh` for supported z/OS versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
 
+## `2.18.5`
+- Bugfix: `cleanup-ipc.mq.sh` script updated to reflect changes in `ipcs` command output. [#4690](https://github.com/zowe/zowe-install-packaging/pull/4690)
+
 ## `2.18.4`
 - Bugfix: Running z/OSMF is returning 401, if RSU2512 was applied. [#4658](https://github.com/zowe/zowe-install-packaging/pull/4658)
 - Bugfix: `detect_java_home` and `detect_node_home` routines used incorrect shell command [#4572](https://github.com/zowe/zowe-install-packaging/pull/4572)

--- a/bin/utils/cleanup-ipc-mq.sh
+++ b/bin/utils/cleanup-ipc-mq.sh
@@ -10,7 +10,6 @@
 # Copyright IBM Corporation 2020
 ################################################################################
 
-
 # node.js instance is not fully cleaned up when exits. As time going, the message
 # queue will be full and any node.js command will generate this error:
 #
@@ -27,19 +26,24 @@
 # This is proper way to cleanup IPC message queues.
 
 id=$(id -nu)
-for s in $(ipcs -a | awk 'match($1,"q|m|s") && $5 == "'${id}'" {print $1","$2":"$16}'); do
-    x=${s%%:*}
-    pid=${s##*:}
-    type=${x%%,*}
-    num=${x##*,}
-    if [[ $pid -gt 0 ]]; then
-        kill -0 "$pid" 1>/dev/null 2>&1
-        if [ $? -eq 0 ]; then
-            true
-        else
-            ipcrm -$type $num
+# Trying to capture columns T, ID, and second to last column, which for q=LSPID, m=CPID
+for s in $(ipcs -a | awk 'match($1,"q|m") && $5 == "'${id}'" { print "type=\""$1"\";num=\""$2"\";pidOne=\""$(NF-1)"\";pidTwo=\""$(NF)"\"" }'); do    
+    eval "${s}"
+    if [ $pidOne -gt 0 ] && [ $pidTwo -gt 0 ]; then
+        kill -0 "$pidOne" 1>/dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            kill -0 "$pidTwo" 1>/dev/null 2>&1
+            if [ $? -ne 0 ]; then   # Neither pid exists, safe to remove q/m
+                ipcrm -$type $num
+            fi
         fi
-    else
-        ipcrm -$type $num
+    fi
+done
+
+# Trying to capture columns T, ID, WTRPID. When WTRPID is empty, semaphore is orphaned.
+for s in $(ipcs -sw | awk 'match($1,"s") && $3 == "'${id}'" { print "sem=\""$2"\";pid=\""$5"\"" }'); do
+    eval "${s}"
+    if [[ $pid -eq 0 ]]; then
+        ipcrm -s $sem
     fi
 done

--- a/bin/utils/cleanup-ipc-mq.sh
+++ b/bin/utils/cleanup-ipc-mq.sh
@@ -34,7 +34,7 @@ for s in $(ipcs -a | awk 'match($1,"q|m") && $5 == "'${id}'" { print "type=\""$1
         if [ $? -ne 0 ]; then
             kill -0 "$pidTwo" 1>/dev/null 2>&1
             if [ $? -ne 0 ]; then   # Neither pid exists, safe to remove q/m
-                ipcrm -$type $num
+                ipcrm -$type $num 1>/dev/null 2>&1
             fi
         fi
     fi
@@ -44,6 +44,6 @@ done
 for s in $(ipcs -sw | awk 'match($1,"s") && $3 == "'${id}'" { print "sem=\""$2"\";pid=\""$5"\"" }'); do
     eval "${s}"
     if [[ $pid -eq 0 ]]; then
-        ipcrm -s $sem
+        ipcrm -s $sem 1>/dev/null 2>&1
     fi
 done


### PR DESCRIPTION
The layout of `ipcs` output was changed in previous z/OS versions.

In Zowe V3, this script is part of the `app-server`, because the cleaning is made for Node.js.

In this PR, the script is only updated to process the current output (z/OS 2.5+).

Related [issue](https://github.com/zowe/zlux/issues/1072).
