### PR TITLE
Refactor certificate analyser command arguments

### DIFF
--- a/bin/commands/validate/certificate/index.ts
+++ b/bin/commands/validate/certificate/index.ts
@@ -100,12 +100,17 @@ export function execute(quitOnError?: boolean, level?: string): number {
     common.printFormattedWarn(common.MSG_KEY, COMMAND_NAME, `Truststore unknown type ${truststoreType}`);
   }
   
-  const argsString = `-Djava.protocol.handler.pkgs=com.ibm.crypto.provider -jar ${std.getenv('ZWE_zowe_runtimeDirectory')}/bin/utils/certificate-analyser.jar ` +
-    `-k ${keystoreLocation} -kt ${keystoreType} -kp ${keystorePass} -a ${keystoreAlias} ` +
-    `-t ${truststoreLocation} -tt ${truststoreType} -tp ${truststorePass} ` +
-    `-d ${ZOWE_CONFIG.zowe.externalDomains.join(',')}`;
-  
-  const result = shell.execOutErrSync('java', ...argsString.split(' '));
+  const argsString = [
+    '-Djava.protocol.handler.pkgs=com.ibm.crypto.provider', '-jar', `${std.getenv('ZWE_zowe_runtimeDirectory')}/bin/utils/certificate-analyser.jar`,
+    '-k', `${keystoreLocation}`, '-kt', `${keystoreType}`, '-kp', `${keystorePass}`, '-a', `${keystoreAlias}`,
+    '-t', `${truststoreLocation}`, '-tt', `${truststoreType}`, '-tp', `${truststorePass}`,
+    '-d', `${ZOWE_CONFIG.zowe.externalDomains.join(',')}`
+  ];
+
+  common.printTrace('Certificate-analyser command:');
+  common.printTrace('java ' + argsString.join(' '));
+
+  const result = shell.execOutErrSync('java', ...argsString);
   const rc = result.rc;
   
   let configLines = [];


### PR DESCRIPTION
PR for #4554

1) print trace with actual values
2) original code (`...argsString.split(' ')`) is wrong for input with spaces.

For example:

`zowe.runtimeDirectory="/path\ with\ spaces"`

Will be executed by `shell.execOutErrSync()` as:

`"-Djava.protocol.handler.pkgs=com.ibm.crypto.provider" "-jar" "/path" "with" "spaces/bin/utils/certificate-analyser.jar"...`

And `with` will be recognized as invalid parameter.
