### PR TITLE
Remove 'append' suggestion

### DIFF
--- a/files/examples/setup/certificate/scenario-1.yaml
+++ b/files/examples/setup/certificate/scenario-1.yaml
@@ -13,12 +13,10 @@
 #
 # Pre-requisite: your main zowe.yaml file is configured.
 #
-# To use this example, complete the configuration below and run 
-#  `zwe init --create-certificate` or `zwe init certificate` with either:
-#    - The contents of this file appended to your main 'zowe.yaml' file
-#      OR
-#    - The following configuration parameter, quotes included:
-#      -c "FILE(/path/to/this/scenario-1.yaml):FILE(/path/to/zowe.yaml)"  
+# To use this example, complete the configuration below and run
+# `zwe init --create-certificate` or `zwe init certificate`
+# with following configuration parameter, quotes included:
+# -c "FILE(/path/to/this/scenario-1.yaml):FILE(/path/to/zowe.yaml)"
 ####
 
 zowe:

--- a/files/examples/setup/certificate/scenario-2.yaml
+++ b/files/examples/setup/certificate/scenario-2.yaml
@@ -16,7 +16,7 @@
 # To use this example, complete the configuration below and run
 # `zwe init --create-certificate` or `zwe init certificate`
 # with following configuration parameter, quotes included:
-# -c "FILE(/path/to/this/scenario-1.yaml):FILE(/path/to/zowe.yaml)"
+# -c "FILE(/path/to/this/scenario-2.yaml):FILE(/path/to/zowe.yaml)"
 ####
 
 zowe:

--- a/files/examples/setup/certificate/scenario-2.yaml
+++ b/files/examples/setup/certificate/scenario-2.yaml
@@ -13,12 +13,10 @@
 #
 # Pre-requisite: your main zowe.yaml file is configured.
 #
-# To use this example, complete the configuration below and run 
-#  `zwe init --create-certificate` or `zwe init certificate` with either:
-#    - The contents of this file appended to your main 'zowe.yaml' file
-#      OR
-#    - The following configuration parameter, quotes included:
-#      -c "FILE(/path/to/this/scenario-2.yaml):FILE(/path/to/zowe.yaml)"  
+# To use this example, complete the configuration below and run
+# `zwe init --create-certificate` or `zwe init certificate`
+# with following configuration parameter, quotes included:
+# -c "FILE(/path/to/this/scenario-1.yaml):FILE(/path/to/zowe.yaml)"
 ####
 
 zowe:

--- a/files/examples/setup/certificate/scenario-3.yaml
+++ b/files/examples/setup/certificate/scenario-3.yaml
@@ -16,7 +16,7 @@
 # To use this example, complete the configuration below and run
 # `zwe init --create-certificate` or `zwe init certificate`
 # with following configuration parameter, quotes included:
-# -c "FILE(/path/to/this/scenario-1.yaml):FILE(/path/to/zowe.yaml)"
+# -c "FILE(/path/to/this/scenario-3.yaml):FILE(/path/to/zowe.yaml)"
 ####
 
 zowe:

--- a/files/examples/setup/certificate/scenario-3.yaml
+++ b/files/examples/setup/certificate/scenario-3.yaml
@@ -13,12 +13,10 @@
 #
 # Pre-requisite: your main zowe.yaml file is configured.
 #
-# To use this example, complete the configuration below and run 
-#  `zwe init --create-certificate` or `zwe init certificate` with either:
-#    - The contents of this file appended to your main 'zowe.yaml' file
-#      OR
-#    - The following configuration parameter, quotes included:
-#      -c "FILE(/path/to/this/scenario-3.yaml):FILE(/path/to/zowe.yaml)"  
+# To use this example, complete the configuration below and run
+# `zwe init --create-certificate` or `zwe init certificate`
+# with following configuration parameter, quotes included:
+# -c "FILE(/path/to/this/scenario-1.yaml):FILE(/path/to/zowe.yaml)"
 ####
 
 zowe:

--- a/files/examples/setup/certificate/scenario-4.yaml
+++ b/files/examples/setup/certificate/scenario-4.yaml
@@ -16,7 +16,7 @@
 # To use this example, complete the configuration below and run
 # `zwe init --create-certificate` or `zwe init certificate`
 # with following configuration parameter, quotes included:
-# -c "FILE(/path/to/this/scenario-1.yaml):FILE(/path/to/zowe.yaml)"
+# -c "FILE(/path/to/this/scenario-4.yaml):FILE(/path/to/zowe.yaml)"
 ####
 
 zowe:

--- a/files/examples/setup/certificate/scenario-4.yaml
+++ b/files/examples/setup/certificate/scenario-4.yaml
@@ -13,12 +13,10 @@
 #
 # Pre-requisite: your main zowe.yaml file is configured.
 #
-# To use this example, complete the configuration below and run 
-#  `zwe init --create-certificate` or `zwe init certificate` with either:
-#    - The contents of this file appended to your main 'zowe.yaml' file
-#      OR
-#    - The following configuration parameter, quotes included:
-#      -c "FILE(/path/to/this/scenario-4.yaml):FILE(/path/to/zowe.yaml)"  
+# To use this example, complete the configuration below and run
+# `zwe init --create-certificate` or `zwe init certificate`
+# with following configuration parameter, quotes included:
+# -c "FILE(/path/to/this/scenario-1.yaml):FILE(/path/to/zowe.yaml)"
 ####
 
 zowe:

--- a/files/examples/setup/certificate/scenario-5.yaml
+++ b/files/examples/setup/certificate/scenario-5.yaml
@@ -16,7 +16,7 @@
 # To use this example, complete the configuration below and run
 # `zwe init --create-certificate` or `zwe init certificate`
 # with following configuration parameter, quotes included:
-# -c "FILE(/path/to/this/scenario-1.yaml):FILE(/path/to/zowe.yaml)"
+# -c "FILE(/path/to/this/scenario-5.yaml):FILE(/path/to/zowe.yaml)"
 ####
 
 zowe:

--- a/files/examples/setup/certificate/scenario-5.yaml
+++ b/files/examples/setup/certificate/scenario-5.yaml
@@ -13,12 +13,10 @@
 #
 # Pre-requisite: your main zowe.yaml file is configured.
 #
-# To use this example, complete the configuration below and run 
-#  `zwe init --create-certificate` or `zwe init certificate` with either:
-#    - The contents of this file appended to your main 'zowe.yaml' file
-#      OR
-#    - The following configuration parameter, quotes included:
-#      -c "FILE(/path/to/this/scenario-5.yaml):FILE(/path/to/zowe.yaml)"  
+# To use this example, complete the configuration below and run
+# `zwe init --create-certificate` or `zwe init certificate`
+# with following configuration parameter, quotes included:
+# -c "FILE(/path/to/this/scenario-1.yaml):FILE(/path/to/zowe.yaml)"
 ####
 
 zowe:


### PR DESCRIPTION
For #4238.

>  The contents of this file appended to your main 'zowe.yaml' file

The current instruction is confusing because appending will not work; the content must be edited and integrated into the correct section. While describing the specific steps required would be a more precise solution, it may be too complex for YAML novices.

At this moment, the simplest and most effective solution is to remove the instruction entirely.

