### PR TITLE
Fix invalid gateway warning when it is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Zowe Installer will be documented in this file.
 - Enhancement: Utility to toggle comments in provided YAML examples. [#4689](https://github.com/zowe/zowe-install-packaging/pull/4689)
 - Bugfix: Incorrect keyword was used for ACF2 key ring statement. [#4671](https://github.com/zowe/zowe-install-packaging/pull/4671)
 - Bugfix: `zwe config get` HA instance lookup is case insensitive. [#4609](https://github.com/zowe/zowe-install-packaging/pull/4609)
+- Bugfix: Fixed error preventing startup which reported that z/OSMF gateway configuration was invalid despite the gateway being disabled [#4718](https://github.com/zowe/zowe-install-packaging/pull/4591)
 - Enhancement: `zwe config get` command uses new `--format` option to format the output. [#4591](https://github.com/zowe/zowe-install-packaging/pull/4591)
 - Enhancement: Removed the unused `components.apiml.debug` debug property for the APIML Single-Service deployment mode (Modulith) in favour of the `components.gateway.debug`, to keep consistency with the rest of the current configuration. [#4702](https://github.com/zowe/zowe-install-packaging/pull/4702)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Zowe Installer will be documented in this file.
 - Enhancement: Utility to toggle comments in provided YAML examples. [#4689](https://github.com/zowe/zowe-install-packaging/pull/4689)
 - Bugfix: Incorrect keyword was used for ACF2 key ring statement. [#4671](https://github.com/zowe/zowe-install-packaging/pull/4671)
 - Bugfix: `zwe config get` HA instance lookup is case insensitive. [#4609](https://github.com/zowe/zowe-install-packaging/pull/4609)
-- Bugfix: Fixed error preventing startup which reported that z/OSMF gateway configuration was invalid despite the gateway being disabled [#4718](https://github.com/zowe/zowe-install-packaging/pull/4591)
+- Bugfix: Fixed error preventing startup which reported that z/OSMF gateway configuration was invalid despite the gateway being disabled [#4718](https://github.com/zowe/zowe-install-packaging/pull/4718)
 - Enhancement: `zwe config get` command uses new `--format` option to format the output. [#4591](https://github.com/zowe/zowe-install-packaging/pull/4591)
 - Enhancement: Removed the unused `components.apiml.debug` debug property for the APIML Single-Service deployment mode (Modulith) in favour of the `components.gateway.debug`, to keep consistency with the rest of the current configuration. [#4702](https://github.com/zowe/zowe-install-packaging/pull/4702)
 

--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -216,7 +216,7 @@ function globalValidate(enabledComponents:string[]): void {
         privateErrors++;
         common.printFormattedError('ZWELS', "zwe-internal-start-prepare,global_validate", "Zosmf validation failed");
       }
-    } else if (std.getenv('ZWE_components_gateway_apiml_security_auth_provider') == "zosmf") {
+    } else if (enabledComponents.includes('gateway') && std.getenv('ZWE_components_gateway_apiml_security_auth_provider') == "zosmf") {
         privateErrors++;
         common.printError("Using z/OSMF as 'components.gateway.apiml.security.auth.provider' is not possible: discovery is disabled.");
         common.printFormattedError('ZWELS', "zwe-internal-start-prepare,global_validate", "Zosmf validation failed");


### PR DESCRIPTION
the preflight zosmf check has some over-eager check which says

"Using z/OSMF as 'components.gateway.apiml.security.auth.provider' is not possible: discovery is disabled."

But it says this even when the gateway is disabled. Which is a very likely situation for when the discovery is also disabled.

We shouldn't have checks about what a disabled server would or wouldn't do, so I just added a check to guarantee either 'apiml' or 'gateway' are enabled before this check runs.