### PR TITLE
Fix zwe-remote-integration in non-unix environments

### DIFF
--- a/tests/zwe-remote-integration/src/globalSetup.ts
+++ b/tests/zwe-remote-integration/src/globalSetup.ts
@@ -248,9 +248,9 @@ async function uploadRemotePaxSpecs(
     const localPath = path.resolve(ctx.downloadsDirPath, base);
     let remoteUssPath: string;
     if ('useSourceBasename' in spec && spec.useSourceBasename === true) {
-      remoteUssPath = path.join(uploadRoot, base);
+      remoteUssPath = path.posix.join(uploadRoot, base);
     } else {
-      remoteUssPath = path.join(uploadRoot, spec.remoteName);
+      remoteUssPath = path.posix.join(uploadRoot, spec.remoteName);
     }
     await uploadFileToUss(localPath, remoteUssPath, { binary: true });
   }

--- a/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
+++ b/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
@@ -629,7 +629,7 @@ export class RemoteTestRunner {
     for (const testFile of testFiles) {
       results.push(
         await this.runRaw(
-          `ZWE_CLI_PARAMETER_CONFIG="${cfgPath}" ZWE_zowe_runtimeDirectory="${REMOTE_SYSTEM_INFO.ussTestDir}" ./bin/utils/configmgr -script ${path.join(REMOTE_SYSTEM_INFO.ussTestDir, '.unit_tests', testFile)}`,
+          `ZWE_CLI_PARAMETER_CONFIG="${cfgPath}" ZWE_zowe_runtimeDirectory="${REMOTE_SYSTEM_INFO.ussTestDir}" ./bin/utils/configmgr -script ${path.posix.join(REMOTE_SYSTEM_INFO.ussTestDir, '.unit_tests', testFile)}`,
         ),
       );
     }


### PR DESCRIPTION
Adjusts two places where `path.join` were used for z/OS directories creating invalid `\a\b\c` paths. Replaced the function with `path.posix.join` to ensure it's always forward-slashes.

