### PR TITLE
convert idcams repro to iebcopy for authloadlib

### DIFF
--- a/files/templates/init/mvs/authloadlib.copy.tjcl
+++ b/files/templates/init/mvs/authloadlib.copy.tjcl
@@ -3,13 +3,14 @@
 //* Copy the data set members to authorized load library
 //*
 //*********************************************************************
-//AUTHCOPY EXEC PGM=IEBCOPY
-//SYSPRINT DD SYSOUT=A
-//SYSUT1   DD DSN=${this.zowe.setup.dataset.prefix}.SZWEAUTH,
-//            DISP=SHR
-//SYSUT2   DD DSN=${this.zowe.setup.dataset.authLoadlib},
-//            DISP=SHR
-//SYSIN  DD *
-  COPY OUTDD=SYSUT2,INDD=((SYSUT1,R))
-  SELECT MEMBER=(ZWELNCH,ZWESAUX,ZWESISDL,ZWESIS01)
+//AUTHCOPY EXEC PGM=BPXBATCH
+//STDOUT   DD SYSOUT=*
+//STDERR   DD SYSOUT=*
+//STDPARM  DD *
+SRC="${this.zowe.setup.dataset.prefix}.SZWEAUTH"
+TGT="${this.zowe.setup.dataset.authLoadlib}"
+cp -X "//'$SRC(ZWELNCH)'"  "//'$TGT(ZWELNCH)'"  &&
+cp -X "//'$SRC(ZWESAUX)'"  "//'$TGT(ZWESAUX)'"  &&
+cp -X "//'$SRC(ZWESISDL)'" "//'$TGT(ZWESISDL)'" &&
+cp -X "//'$SRC(ZWESIS01)'" "//'$TGT(ZWESIS01)'"
 /*

--- a/files/templates/init/mvs/authloadlib.copy.tjcl
+++ b/files/templates/init/mvs/authloadlib.copy.tjcl
@@ -3,19 +3,13 @@
 //* Copy the data set members to authorized load library
 //*
 //*********************************************************************
-//AUTHCOPY EXEC PGM=IKJEFT01
-//SYSTSPRT DD SYSOUT=A
-//SYSTSIN  DD *
-REPRO +
-  INDATASET('${this.zowe.setup.dataset.prefix}.SZWEAUTH(ZWELNCH)') +
-  OUTDATASET('${this.zowe.setup.dataset.authLoadlib}(ZWELNCH)')
-REPRO +
-  INDATASET('${this.zowe.setup.dataset.prefix}.SZWEAUTH(ZWESAUX)') +
-  OUTDATASET('${this.zowe.setup.dataset.authLoadlib}(ZWESAUX)')
-REPRO +
-  INDATASET('${this.zowe.setup.dataset.prefix}.SZWEAUTH(ZWESISDL)') +
-  OUTDATASET('${this.zowe.setup.dataset.authLoadlib}(ZWESISDL)')
-REPRO +
-  INDATASET('${this.zowe.setup.dataset.prefix}.SZWEAUTH(ZWESIS01)') +
-  OUTDATASET('${this.zowe.setup.dataset.authLoadlib}(ZWESIS01)')
+//AUTHCOPY EXEC PGM=IEBCOPY
+//SYSPRINT DD SYSOUT=A
+//SYSUT1   DD DSN=${this.zowe.setup.dataset.prefix}.SZWEAUTH,
+//            DISP=SHR
+//SYSUT2   DD DSN=${this.zowe.setup.dataset.authLoadlib},
+//            DISP=SHR
+//SYSIN  DD *
+  COPY OUTDD=SYSUT2,INDD=((SYSUT1,R))
+  SELECT MEMBER=(ZWELNCH,ZWESAUX,ZWESISDL,ZWESIS01)
 /*

--- a/playbooks/group_vars/marist.yml
+++ b/playbooks/group_vars/marist.yml
@@ -24,7 +24,7 @@ zowe_apiml_modulith_mode: true
 zowe_apiml_security_oidc_enabled: true
 
 # use new jcl path for install
-zowe_setup_jcl_enable: false
+zowe_setup_jcl_enable: true
 zowe_jcllib: ZOWEAD3.ZWE.JCLLIB
 zowe_xmem_proclib: VENDOR.PROCLIB
 zowe_xmem_loadlib: ZOWEAD3.ZWE.LOADLIB

--- a/tests/installation/src/__tests__/extended/install-jcl/install-without-jcl.ts
+++ b/tests/installation/src/__tests__/extended/install-jcl/install-without-jcl.ts
@@ -32,7 +32,7 @@ describe(testSuiteName, () => {
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
         'zowe_custom_for_test': 'true',
-        'zowe_setup_jcl_enable': 'true',
+        'zowe_setup_jcl_enable': 'false',
         'zowe_lock_keystore': 'false',
       }
     );

--- a/tests/sanity/test/install/test-installed-files.js
+++ b/tests/sanity/test/install/test-installed-files.js
@@ -48,7 +48,7 @@ describe('verify installed files', function() {
     if (process.env.ZOWE_JAVA_HOME) {
       OPTIONAL_JAVA_HOME = `JAVA_HOME=${process.env.ZOWE_JAVA_HOME} `;
     }
-    const fingerprintStdout = await sshHelper.executeCommandWithNoError(`touch ~/.profile && . ~/.profile && ${OPTIONAL_JAVA_HOME} ${process.env.ZOWE_ROOT_DIR}/bin/zwe support verify-fingerprints`);
+    const fingerprintStdout = await sshHelper.executeCommandWithNoError(`touch ~/.profile && . ~/.profile && ${OPTIONAL_JAVA_HOME} ${process.env.ZOWE_ROOT_DIR}/bin/zwe support verify-fingerprints --verbose`);
     debug('fingerprint show result:', fingerprintStdout);
     addContext(this, {
       title: 'fingerprint show result',


### PR DESCRIPTION
Fixes a bug where load modules are not copied properly to the configured `authLoadLib`. IDCAMS REPRO does not set the control information when copying load modules. https://www.ibm.com/docs/en/zos/3.2.0?topic=repro-parameters 