### PR TITLE
Switch `ulimit` to non-interactive shell

### DIFF
--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -132,8 +132,8 @@ function globalValidate(enabledComponents:string[]): void {
   const logLevel = std.getenv("ZWE_PRIVATE_LOG_LEVEL_ZWELS");
   const isDebug = (logLevel == "DEBUG" || logLevel == "TRACE");
   if (isDebug) {
-    const hardUlimitResult = shell.execOutSync('ulimit', '-Ha');
-    const softUlimitResult = shell.execOutSync('ulimit', '-a');
+    const hardUlimitResult = shell.execOutSync('sh', '-c', 'ulimit -Ha');
+    const softUlimitResult = shell.execOutSync('sh', '-c', 'ulimit -Ha');
 
     if (hardUlimitResult.rc == 0) {
       common.printFormattedDebug("ZWELS", "zwe-internal-start-prepare,global_validate", `ulimit -Ha output:\n${hardUlimitResult.out}`);

--- a/bin/commands/support/verify-fingerprints/index.ts
+++ b/bin/commands/support/verify-fingerprints/index.ts
@@ -80,7 +80,7 @@ export function execute(doNotExit: Boolean, javaHome: string): void {
 
   common.printMessage('- Create Zowe directory file list');
   const allFiles = fs.createTmpFile(tmpFilePrefix);
-  shell.execOutSync('sh', '-c', `cd '${zoweRuntime}' && find . -name ./SMPE -prune -o -name "./ZWE*" -prune -o -name ./fingerprint -prune -o -name ./.sh_history -prune -o -type f -print > "${allFiles}"`);
+  shell.execOutSync('sh', '-c', `cd '${zoweRuntime}' && find . -name ./SMPE -prune -o -name "./ZWE*" -prune -o -name ./fingerprint -prune -o -type f -print > "${allFiles}"`);
   if (!fs.fileExists(allFiles)) {
     common.printErrorAndExit(`Error ZWEL0151E: Failed to create temporary file ${allFiles}. Please check permission or volume free space.`, undefined, 151);
   }


### PR DESCRIPTION
In #4751, we used an interactive shell to invoke `ulimit`, which created a `.sh_history` file in the runtime directory. This file popped up in `zwe support verify-fingerprints`, causing the command to fail. Switching `ulimit` to a non-interactive shell `sh -c` now prevents creation of the `.sh_history` file.

For reviewers: in #4758 , I updated the verify fingerprints to ignore .sh_history. Should we keep or revert that change?

If we keep the change...

Pro:
* Verify-fingerprints is more tolerant / higher signal

Con:
* We don't find out if other commands use an interactive shell. Not necessarily an issue, but our established pattern is non-interactive shells.