### PR TITLE
Use JCL by default in Ansible playbooks for v3

### DIFF
--- a/playbooks/group_vars/marist.yml
+++ b/playbooks/group_vars/marist.yml
@@ -24,7 +24,7 @@ zowe_apiml_modulith_mode: true
 zowe_apiml_security_oidc_enabled: true
 
 # use new jcl path for install
-zowe_setup_jcl_enable: false
+zowe_setup_jcl_enable: true
 zowe_jcllib: ZOWEAD3.ZWE.JCLLIB
 zowe_xmem_proclib: VENDOR.PROCLIB
 zowe_xmem_loadlib: ZOWEAD3.ZWE.LOADLIB

--- a/tests/installation/src/__tests__/extended/install-jcl/install-with-jcl.ts
+++ b/tests/installation/src/__tests__/extended/install-jcl/install-with-jcl.ts
@@ -16,7 +16,7 @@ import {
 import { TEST_TIMEOUT_CONVENIENCE_BUILD } from '../../../constants';
 
 const testServer = process.env.TEST_SERVER;
-const testSuiteName = 'Test convenience build installation using JCL';
+const testSuiteName = 'Test convenience build installation without using JCL';
 describe(testSuiteName, () => {
   beforeAll(() => {
     // validate variables
@@ -32,7 +32,7 @@ describe(testSuiteName, () => {
       {
         'zowe_build_local': process.env['ZOWE_BUILD_LOCAL'],
         'zowe_custom_for_test': 'true',
-        'zowe_setup_jcl_enable': 'true',
+        'zowe_setup_jcl_enable': 'false',
         'zowe_lock_keystore': 'false',
       }
     );


### PR DESCRIPTION
Switches `zowe_setup_jcl_enable` to `true` by default in our Ansible playbooks.