### PR TITLE
Update tag for Zowe Visual Studio Code Extension

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -381,7 +381,7 @@
       "componentGroup": "Zowe Visual Studio Code Extension",
       "entries": [{
         "repository": "zowe-explorer-vscode",
-        "tag": "v3.4.1",
+        "tag": "443880ccec841f95c5b8d8631f318bf051a163b5",
         "destinations": ["Visual Studio Code Marketplace"]
       }]
     },


### PR DESCRIPTION
Using commit hash instead of tag since the 3.5 release hasn't been tagged yet