### PR TITLE
V2: bugfixes from V3 - `init mvs` and ACF2 data set protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zowe Installer will be documented in this file.
 <!--Add the PR or issue number to the entry if available.-->
 
 ## `2.18.5`
+- Bugfix: `zwe init mvs` skips copying of `ZWESIP00` member if target is identical to source data set. `zwe init security` was using incorrect ACF2 data set protection statement. [#4776](https://github.com/zowe/zowe-install-packaging/pull/4776)
 - Bugfix: Incorrect keyword was used for ACF2 key ring statement. [#4680](https://github.com/zowe/zowe-install-packaging/pull/4680)
 - Bugfix: `cleanup-ipc.mq.sh` script updated to reflect changes in `ipcs` command output. [#4690](https://github.com/zowe/zowe-install-packaging/pull/4690)
 

--- a/bin/commands/init/mvs/index.sh
+++ b/bin/commands/init/mvs/index.sh
@@ -50,8 +50,8 @@ while read -r line; do
   fi
   # check existence
   ds_existence=$(is_data_set_exists "${ds}")
-  any_existence="true"
   if [ "${ds_existence}" = "true" ]; then
+    any_existence="true"
     if [ "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}" = "true" ]; then
       # warning
       print_message "Warning ZWEL0300W: ${ds} already exists. Members in this data set will be overwritten."

--- a/bin/commands/init/mvs/index.sh
+++ b/bin/commands/init/mvs/index.sh
@@ -78,13 +78,21 @@ else
   ###############################
   # copy sample lib members
   parmlib=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.dataset.parmlib")
-  for ds in ZWESIP00; do
-    print_message "Copy ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(${ds}) to ${parmlib}(${ds})"
-    data_set_copy_to_data_set "${prefix}" "${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(${ds})" "${parmlib}(${ds})" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
-    if [ $? -ne 0 ]; then
-      print_error_and_exit "Error ZWEL0111E: Command aborts with error." "" 111
+  parmMember=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.dataset.parmlibMembers.zis")
+  if [ -z "${parmMember}" ]; then
+    parmMember='ZWESIP00'
+  fi
+  if [ "${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWESIP00)" != "${parmlib}(${parmMember})" ]; then
+    print_message "Copy ${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWESIP00) to ${parmlib}(${parmMember})"
+    if [ -z "${DRY_RUN}" ]; then
+      data_set_copy_to_data_set "${prefix}" "${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWESIP00)" "${parmlib}(${parmMember})" "${ZWE_CLI_PARAMETER_ALLOW_OVERWRITE}"
+      if [ $? -ne 0 ]; then
+        print_error_and_exit "Error ZWEL0111E: Command aborts with error." "" 111
+      fi
+    else
+      print_message "Skipping copy operation due to --dry-run parameter."
     fi
-  done
+  fi
 
   ###############################
   # copy auth lib members

--- a/bin/commands/init/security/index.sh
+++ b/bin/commands/init/security/index.sh
@@ -34,6 +34,14 @@ security_product=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.security
 if [ -z "${security_product}" ]; then
   security_product=RACF
 fi
+# If ACF2, check prefix for HLQ and rest
+acf2_rest=
+if [ "${security_product}" = 'ACF2' ]; then
+  acf2_hlq=$(echo "${prefix}" | cut -d. -f1)
+  if [ "${acf2_hlq}" != "${prefix}" ]; then
+    acf2_rest=$(echo "${prefix}" | cut -d. -f2-)
+  fi
+fi
 security_groups_admin=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.security.groups.admin")
 if [ -z "${security_groups_admin}" ]; then
   security_groups_admin=${ZWE_PRIVATE_DEFAULT_ADMIN_GROUP}
@@ -85,6 +93,11 @@ result=$(cat "//'${prefix}.${ZWE_PRIVATE_DS_SZWESAMP}(ZWESECUR)'" | \
         sed   "s/^\/\/ \+SET \+AUXSTC=.*\$/\/\/         SET  AUXSTC=${security_stcs_aux}/" | \
         sed      "s/^\/\/ \+SET \+HLQ=.*\$/\/\/         SET  HLQ=${prefix}/" | \
         sed  "s/^\/\/ \+SET \+SYSPROG=.*\$/\/\/         SET  SYSPROG=${security_groups_sysProg}/")
+if [ ! -z "${acf2_rest}" ]; then
+  result=$(echo "${result}" | \
+        sed "s/^LIST &HLQ\./LIST ${acf2_hlq}/" | \
+        sed "s/^RECKEY &HLQ\. ADD(- +/RECKEY ${acf2_hlq} ADD(${acf2_rest}.- +/")
+fi
 if [ -n "${result}" ]; then
   echo "${result}" > "${tmpfile}"
   code=$?

--- a/files/SZWESAMP/ZWEIACF
+++ b/files/SZWESAMP/ZWEIACF
@@ -217,22 +217,42 @@ RECKEY IRR ADD(RAUDITX ROLE({zowe.setup.security.groups.stc}) +
 F ACF2,REBUILD(FAC)
 
 *
-* DEFINE ZOWE DATA SET PROTECTION .................................
+* DEFINE ZOWE DATA SET PROTECTION - HLQ ONLY ......................
 *
-* - HLQ..SZWEAUTH is an APF authorized data set. It is strongly
+* - HLQ.SZWEAUTH is an APF authorized data set. It is strongly
 *   advised to protect it against updates.
 *
 *  HLQ stub
 SET RULE
 *  general data set protection
 LIST {zowe.setup.dataset.prefix}
-RECKEY {zowe.setup.dataset.prefix} ADD(- UID(-) READ(A) EXEC(P))
 RECKEY {zowe.setup.dataset.prefix} +
-ADD(- UID({zowe.setup.security.groups.sysProg}) +
+  ADD(- ROLE(-) READ(A) EXEC(P))
+RECKEY {zowe.setup.dataset.prefix} +
+  ADD(- ROLE({zowe.setup.security.groups.stc}) +
   READ(A) EXEC(A) ALLOC(A) WRITE(A))
 *
 *  show results
 LIST {zowe.setup.dataset.prefix}
+*
+
+* DEFINE ZOWE DATA SET PROTECTION - COMPOUND DATA SET..............
+* PREFIX_HLQ is the High-Level Qualifier only
+* PREFIX_REST is the rest after the HLQ
+* Example: zowe.setup.dataset.prefix = ZOWE.V2.DEV
+*  -> PREFIX_HLQ = ZOWE
+*  -> PREFIX_REST = V2.DEV
+* SET RULE
+*  general data set protection
+* LIST PREFIX_HLQ
+* RECKEY PREFIX_HLQ +
+*   ADD(PREFIX_REST.- ROLE(-) READ(A) EXEC(P))
+* RECKEY PREFIX_HLQ +
+*   ADD(PREFIX_REST.- ROLE({zowe.setup.security.groups.stc}) +
+*   READ(A) EXEC(A) ALLOC(A) WRITE(A))
+*
+*  show results
+* LIST PREFIX_HLQ
 *
 
 *

--- a/files/SZWESAMP/ZWENOSEC
+++ b/files/SZWESAMP/ZWENOSEC
@@ -317,7 +317,7 @@ SET RESOURCE(FAC)
 RECKEY IRR DEL(RAUDITX ROLE(&STCGRP.) SERVICE(READ) ALLOW)
 F ACF2,REBUILD(FAC)
 
-*  Remove  data set protection
+* Remove data set protection
 SET RULE
 LIST &HLQ.
 DELETE &HLQ.

--- a/files/SZWESAMP/ZWERMVS
+++ b/files/SZWESAMP/ZWERMVS
@@ -20,10 +20,12 @@
 //*  then you must also run "ZWERMVS2".
 //*
 //*********************************************************************
+//  EXPORT SYMLIST=ZISMEMBR
+//  SET ZISMBR={zowe.setup.dataset.parmlibMembers.zis}
 //RMPDSE EXEC PGM=IKJEFT01
 //SYSTSPRT DD SYSOUT=A
-//SYSTSIN DD *
-DELETE ('{zowe.setup.dataset.parmlib}', +
-        '{zowe.setup.dataset.authPluginLib}') +
+//SYSTSIN DD *,SYMBOLS=JCLONLY
+DELETE ('{zowe.setup.dataset.authPluginLib}') +
        SCRATCH NONVSAM
+DELETE '{zowe.setup.dataset.parmlib}(&ZISMEMBR)'
 //*

--- a/workflows/templates/ZWESECUR.vtl
+++ b/workflows/templates/ZWESECUR.vtl
@@ -607,11 +607,12 @@ F ACF2,REBUILD(FAC)
 *
 *  HLQ stub
 SET RULE
-*  general data set protection
+* general data set protection
 LIST &HLQ.
-RECKEY &HLQ. ADD(- UID(-) READ(A) EXEC(P))
-RECKEY &HLQ. +
-ADD(- UID(&SYSPROG.) READ(A) EXEC(A) ALLOC(A) WRITE(A))
+RECKEY &HLQ. ADD(- +
+  ROLE(-) READ(A) EXEC(P))
+RECKEY &HLQ. ADD(- +
+  ROLE(&STCGRP.) READ(A) EXEC(A) ALLOC(A) WRITE(A))
 *
 *  show results
 LIST &HLQ.


### PR DESCRIPTION
V2 version of:
* #4695
* #4769 

* `zwe init mvs` does not copy `ZWESIP00` if the target library is `"SZWESAMP"`
* `zwe init mvs` checks the data set existence correctly
* Shell command `zwe init security` is able to handle compound `zowe.setup.dataset.prefix` for ACF2
  * It uses `ZWESECUR` sample and the replacement is done via `sed` in the command

**Notes:**
* `ZWEIACF` sample generated by `ZWEGENER` is wrong for compound `HLQ`
* There is no simple way how to do it in REXX - it is an exceptional state
* There is a suggestion how to update the ACF2 statements for compound `HLQ`

```
* DEFINE ZOWE DATA SET PROTECTION - HLQ ONLY ......................
*
* - HLQ.SZWEAUTH is an APF authorized data set. It is strongly
*   advised to protect it against updates.
*
*  HLQ stub
SET RULE
*  general data set protection
LIST ZOWE.PR#4776
RECKEY ZOWE.PR#4776 +
  ADD(- ROLE(-) READ(A) EXEC(P))
RECKEY ZOWE.PR#4776 +
  ADD(- ROLE(ZWEADMIN) +
  READ(A) EXEC(A) ALLOC(A) WRITE(A))
*
*  show results
LIST ZOWE.PR#4776
*

* DEFINE ZOWE DATA SET PROTECTION - COMPOUND DATA SET..............
* PREFIX_HLQ is the High-Level Qualifier only
* PREFIX_REST is the rest after the HLQ
* Example: zowe.setup.dataset.prefix = ZOWE.V2.DEV
*  -> PREFIX_HLQ = ZOWE
*  -> PREFIX_REST = V2.DEV
* SET RULE
*  general data set protection
* LIST PREFIX_HLQ
* RECKEY PREFIX_HLQ +
*   ADD(PREFIX_REST.- ROLE(-) READ(A) EXEC(P))
* RECKEY PREFIX_HLQ +
*   ADD(PREFIX_REST.- ROLE(ZWEADMIN) +
*   READ(A) EXEC(A) ALLOC(A) WRITE(A))
*
*  show results
* LIST PREFIX_HLQ       
```