### PR TITLE
restrict startupCheck config values to enum

### DIFF
--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -771,6 +771,11 @@
                   "description": "Checks that the Node runtime version does not exceed the maximum supported version. Defaults to zowe.launchScript.startupChecks.default, or 'warn' if unset.",
                   "enum": ["exit", "warn", "disabled"]
                 }
+              },
+              "patternProperties": {
+                "^.*$": {
+                  "$ref": "/schemas/v2/server-common#startupCheck"
+                }
               }
             }
           }

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -748,28 +748,24 @@
                   "description": "Checks that every component listed under 'components' in zowe.yaml has a valid manifest file (manifest.yaml, manifest.yml, or manifest.json). Components missing a manifest cannot be started."
                 },
                 "javaMin": {
-                  "type": "string",
+                  "$ref": "/schemas/v2/server-common#startupCheck",
                   "default": "exit",
                   "description": "Checks that the Java runtime version meets the minimum required version. Defaults to zowe.launchScript.startupChecks.default, or 'exit' if unset.",
-                  "enum": ["exit", "warn", "disabled"]
                 },
                 "javaMax": {
-                  "type": "string",
+                  "$ref": "/schemas/v2/server-common#startupCheck",
                   "default": "warn",
                   "description": "Checks that the Java runtime version does not exceed the maximum supported version. Defaults to zowe.launchScript.startupChecks.default, or 'warn' if unset.",
-                  "enum": ["exit", "warn", "disabled"]
                 },
                 "nodeMin": {
-                  "type": "string",
+                  "$ref": "/schemas/v2/server-common#startupCheck",
                   "default": "exit",
                   "description": "Checks that the Node runtime version meets the minimum required version. Defaults to zowe.launchScript.startupChecks.default, or 'exit' if unset.",
-                  "enum": ["exit", "warn", "disabled"]
                 },
                 "nodeMax": {
-                  "type": "string",
+                  "$ref": "/schemas/v2/server-common#startupCheck",
                   "default": "warn",
                   "description": "Checks that the Node runtime version does not exceed the maximum supported version. Defaults to zowe.launchScript.startupChecks.default, or 'warn' if unset.",
-                  "enum": ["exit", "warn", "disabled"]
                 }
               },
               "patternProperties": {

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -750,22 +750,22 @@
                 "javaMin": {
                   "$ref": "/schemas/v2/server-common#startupCheck",
                   "default": "exit",
-                  "description": "Checks that the Java runtime version meets the minimum required version. Defaults to zowe.launchScript.startupChecks.default, or 'exit' if unset.",
+                  "description": "Checks that the Java runtime version meets the minimum required version. Defaults to zowe.launchScript.startupChecks.default, or 'exit' if unset."
                 },
                 "javaMax": {
                   "$ref": "/schemas/v2/server-common#startupCheck",
                   "default": "warn",
-                  "description": "Checks that the Java runtime version does not exceed the maximum supported version. Defaults to zowe.launchScript.startupChecks.default, or 'warn' if unset.",
+                  "description": "Checks that the Java runtime version does not exceed the maximum supported version. Defaults to zowe.launchScript.startupChecks.default, or 'warn' if unset."
                 },
                 "nodeMin": {
                   "$ref": "/schemas/v2/server-common#startupCheck",
                   "default": "exit",
-                  "description": "Checks that the Node runtime version meets the minimum required version. Defaults to zowe.launchScript.startupChecks.default, or 'exit' if unset.",
+                  "description": "Checks that the Node runtime version meets the minimum required version. Defaults to zowe.launchScript.startupChecks.default, or 'exit' if unset."
                 },
                 "nodeMax": {
                   "$ref": "/schemas/v2/server-common#startupCheck",
                   "default": "warn",
-                  "description": "Checks that the Node runtime version does not exceed the maximum supported version. Defaults to zowe.launchScript.startupChecks.default, or 'warn' if unset.",
+                  "description": "Checks that the Node runtime version does not exceed the maximum supported version. Defaults to zowe.launchScript.startupChecks.default, or 'warn' if unset."
                 }
               },
               "patternProperties": {

--- a/tests/zwe-remote-integration/src/__tests__/internal/__snapshots__/start-prepare.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/internal/__snapshots__/start-prepare.test.ts.snap
@@ -59,6 +59,15 @@ ERROR:  TESTUSR0 ERROR (zwe-internal-start-prepare,validate_components) Error ZW
  TESTUSR0 INFO (zwe-internal-start-prepare) Zowe runtime environment prepared"
 `;
 
+exports[`start-prepare-tests (SHORT) invalid startupChecks value 1`] = `
+"Error: Validation of FILE(/test/dir/zowe.test.yaml):FILE(/test/dir/files/defaults.yaml) against schema /test/dir/schemas/zowe-yaml-schema.json:/test/dir/schemas/server-common.json found invalid JSON Schema data
+Validity Exceptions(s) with object at
+  Validity Exceptions(s) with object at zowe
+    Validity Exceptions(s) with object at zowe.launchScript
+      Validity Exceptions(s) with object at zowe.launchScript.startupChecks
+        no matching enum value at zowe.launchScript.startupChecks.user; expecting one of values '[exit, warn, disabled]' of type 'string'"
+`;
+
 exports[`start-prepare-tests (SHORT) modulith disabled 1`] = `
 " TESTUSR0 INFO (zwe-internal-start-prepare) Zowe version: v0.0.0
  TESTUSR0 INFO (zwe-internal-start-prepare) build and hash: {BUILD_BRANCH}#{BUILD_NUMBER} ({BUILD_COMMIT_HASH})

--- a/tests/zwe-remote-integration/src/__tests__/internal/start-prepare.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/internal/start-prepare.test.ts
@@ -74,6 +74,14 @@ describe(`${testSuiteName}`, () => {
   });
 
   describe('(SHORT)', () => {
+    it('invalid startupChecks value', async () => {
+      _.set(cfgYaml, 'zowe.launchScript.startupChecks.user', 'invalid-entry');
+      _.set(cfgYaml, 'zowe.launchScript.startupChecks.certificate', 'disabled');
+      const result = await testRunner.runZweTest(cfgYaml, 'internal start prepare');
+      expect(result.cleanedStdout).toMatchSnapshot();
+      expect(result.rc).toBe(1);
+    });
+
     it('test startup user if uid=0', async () => {
       const uid = await testRunner.runRaw('id -u');
       // only run test if we're uid 0

--- a/tests/zwe-remote-integration/src/config/ZoweYamlType.ts
+++ b/tests/zwe-remote-integration/src/config/ZoweYamlType.ts
@@ -917,6 +917,11 @@ const zoweSchema = zoweYamlSchema as {
                   enum: ['exit', 'warn', 'disabled'];
                 };
               };
+              patternProperties: {
+                '^.*$': {
+                  $ref: '/schemas/v2/server-common#startupCheck';
+                };
+              };
             };
           };
         };

--- a/tests/zwe-remote-integration/src/config/ZoweYamlType.ts
+++ b/tests/zwe-remote-integration/src/config/ZoweYamlType.ts
@@ -893,28 +893,24 @@ const zoweSchema = zoweYamlSchema as {
                   description: "Checks that every component listed under 'components' in zowe.yaml has a valid manifest file (manifest.yaml, manifest.yml, or manifest.json). Components missing a manifest cannot be started.";
                 };
                 javaMin: {
-                  type: 'string';
+                  $ref: '/schemas/v2/server-common#startupCheck';
                   default: 'exit';
                   description: "Checks that the Java runtime version meets the minimum required version. Defaults to zowe.launchScript.startupChecks.default, or 'exit' if unset.";
-                  enum: ['exit', 'warn', 'disabled'];
                 };
                 javaMax: {
-                  type: 'string';
+                  $ref: '/schemas/v2/server-common#startupCheck';
                   default: 'warn';
                   description: "Checks that the Java runtime version does not exceed the maximum supported version. Defaults to zowe.launchScript.startupChecks.default, or 'warn' if unset.";
-                  enum: ['exit', 'warn', 'disabled'];
                 };
                 nodeMin: {
-                  type: 'string';
+                  $ref: '/schemas/v2/server-common#startupCheck';
                   default: 'exit';
                   description: "Checks that the Node runtime version meets the minimum required version. Defaults to zowe.launchScript.startupChecks.default, or 'exit' if unset.";
-                  enum: ['exit', 'warn', 'disabled'];
                 };
                 nodeMax: {
-                  type: 'string';
+                  $ref: '/schemas/v2/server-common#startupCheck';
                   default: 'warn';
                   description: "Checks that the Node runtime version does not exceed the maximum supported version. Defaults to zowe.launchScript.startupChecks.default, or 'warn' if unset.";
-                  enum: ['exit', 'warn', 'disabled'];
                 };
               };
               patternProperties: {


### PR DESCRIPTION
Addresses #4778. 

The `patternProperties` field guarantees all keys under startupChecks must conform to the `"/schemas/v2/server-common#startupCheck"` ref. This technically overlaps with `refs` per-key within startupChecks, but it won't cause any issues.

I also took this opportunity to change all startupChecks to use the server-common schema ref.  We missed this change when merging everything in for 3.5 (no functional difference, just code consistency).