### PR TITLE
Rename sample apps folder

### DIFF
--- a/.pax/prepare-workspace.sh
+++ b/.pax/prepare-workspace.sh
@@ -185,7 +185,13 @@ echo "[${SCRIPT_NAME}] move binary dependencies ..."
 mkdir -p "${CONTENT_DIR}/files/zlux"
 cd "${PAX_BINARY_DEPENDENCIES}"
 for zlux_dep in zlux-editor tn3270-ng2 vt-ng2 sample-react-app sample-iframe-app sample-angular-app explorer-ip; do
-  mv ${zlux_dep}-*.pax "${CONTENT_DIR}/files/zlux/${zlux_dep}.pax"
+  case "${zlux_dep}" in
+    sample-angular-app) target=angular-sample ;;
+    sample-react-app)   target=react-sample ;;
+    sample-iframe-app)  target=iframe-sample ;;
+    *)                  target="${zlux_dep}" ;;
+  esac
+  mv ${zlux_dep}-*.pax "${CONTENT_DIR}/files/zlux/${target}.pax"
 done
 mv *.pax.Z "${CONTENT_DIR}/files/"
 mv *.pax "${CONTENT_DIR}/files/"


### PR DESCRIPTION
This PR renames the three built-in sample-app folders during packaging so each folder name matches its manifest.yaml name: sample-angular-app becomes angular-sample, sample-react-app becomes react-sample, and sample-iframe-app becomes iframe-sample. The app-server derives a component/plugin locator from the folder name and expects it to match the [name](vscode-file://vscode-app/c:/Users/jstruga/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in manifest.yaml. When they didn't match, no locator was generated, so zwe components install never registered these apps and they never loaded in the Desktop.

Note that this changes the enable name for these samples, so anyone enabling them in [zowe.yaml](vscode-file://vscode-app/c:/Users/jstruga/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html) must use the new names. To enable them, add the following to your [zowe.yaml](vscode-file://vscode-app/c:/Users/jstruga/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and restart Zowe:

```
components:
  angular-sample:
    enabled: true
  react-sample:
    enabled: true
  iframe-sample:
    enabled: true
```