### PR TITLE
Better vars assigning, removed duplicated code

### DIFF
--- a/bin/commands/init/certificate/index.sh
+++ b/bin/commands/init/certificate/index.sh
@@ -83,7 +83,7 @@ security_groups_admin=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.sec
 for item in caCommonName commonName orgUnit org locality state country; do
   var_name="dname_${item}"
   var_val=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.dname.${item}")
-  eval "${var_name}=\"${var_val}\""
+  set_var_value "${var_name}" "${var_val}"
 done
 # read cert validity
 cert_validity=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.validity")
@@ -92,7 +92,7 @@ if [ "${cert_type}" = "PKCS12" ]; then
   for item in directory lock name password; do
     var_name="pkcs12_${item}"
     var_val=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.pkcs12.${item}")
-    eval "${var_name}=\"${var_val}\""
+    set_var_value "${var_name}" "${var_val}"
   done
   if [ -z "${pkcs12_directory}" ]; then
     print_error_and_exit "Error ZWEL0157E: Keystore directory (zowe.setup.certificate.pkcs12.directory) is not defined in Zowe YAML configuration file." "" 157
@@ -107,7 +107,7 @@ else # JCE* content
   for item in name label caLabel; do
     var_name="keyring_${item}"
     var_val=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.keyring.${item}")
-    eval "${var_name}=\"${var_val}\""
+    set_var_value "${var_name}" "${var_val}"
   done
   # FIXME: currently ZWEKRING jcl will import the cert and chain, CA will also be added to CERTAUTH, but the CA will not be connected to keyring.
   #        the CA imported could have label like LABEL00000001.
@@ -148,13 +148,6 @@ else # JCE* content
     fi
 
   fi
-
-  # read keyring-specific z/OSMF info
-  for item in user ca; do
-    var_name="zosmf_${item}"
-    var_val=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.keyring.zOSMF.${item}")
-    eval "${var_name}=\"${var_val}\""
-  done
 fi
 
 # read keystore CAs
@@ -168,12 +161,12 @@ fi
 for item in user ca; do
   var_name="zosmf_${item}"
   var_val=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.keyring.zOSMF.${item}")
-  eval "${var_name}=\"${var_val}\""
+  set_var_value "${var_name}" "${var_val}"
 done
 for item in host port; do
   var_name="zosmf_${item}"
   var_val=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zOSMF.${item}")
-  eval "${var_name}=\"${var_val}\""
+  set_var_value "${var_name}" "${var_val}"
 done
 keyring_trust_zosmf=0
 verify_certificates=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.verifyCertificates" | upper_case)
@@ -273,7 +266,7 @@ if [ "${cert_type}" = "PKCS12" ]; then
     for item in caCommonName commonName orgUnit org locality state country; do
       var_name="dname_${item}"
       var_val=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.dname.${item}")
-      eval "${var_name}=\"${var_val}\""
+      set_var_value "${var_name}" "${var_val}"
     done
     # read cert validity
     cert_validity=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.validity")

--- a/bin/libs/var.sh
+++ b/bin/libs/var.sh
@@ -46,6 +46,15 @@ get_var_value() {
 }
 
 ###############################
+# safely assign a value to a variable whose name is held in another variable
+#
+# @param string   variable name
+# @param string   value to assign
+set_var_value() {
+  eval "${1}=\"\${2}\""
+}
+
+###############################
 # get all environment variable exports line by line
 get_environment_exports() {
   export -p | \

--- a/bin/libs/zwecli.sh
+++ b/bin/libs/zwecli.sh
@@ -120,7 +120,9 @@ zwecli_set_parameter_value() {
   param_id="${1}"
   value="${2}"
 
-  eval "export $(zwecli_get_parameter_variable "${param_id}")=\"${value}\""
+  var_name=$(zwecli_get_parameter_variable "${param_id}")
+  set_var_value "${var_name}" "${value}"
+  export "${var_name}"
 }
 
 zwecli_load_parameters_default_value() {


### PR DESCRIPTION
#### PR type
- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [x] Other... Please describe:

Better var assignment, the value is substituted by eval's own parameter expansion instead of being spliced into eval's source text, shell metacharacters in the value (quotes, $(...), backticks, ;) are never re-parsed as code.

Also removed duplicated piece of code 
- \# read keyring-specific z/OSMF info - lines 151-157

as it is unconditionally executed a few lines below 
- \# read z/OSMF info - lines 167 - 172
