### PR TITLE
Generating a random value instead of a default pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Zowe Installer will be documented in this file.
 - Enhancement: APIML logging level configuration added to the `example-zowe.yaml`. [#4827](https://github.com/zowe/zowe-install-packaging/pull/4827)
 - Enhancement: Improved temporary files and directories handling. [#4820](https://github.com/zowe/zowe-install-packaging/pull/4820)
 - Enhancement: Updated the sequence of workflows in PSWI.[#4854](https://github.com/zowe/zowe-install-packaging/pull/4854)
+- Enhancement: `zwe init certificate` generates a random password instead of "password" when `password` or `caPassword` is left at its default value. Applicable to keystores only, keyring scenarios are unaffected. [#4866](https://github.com/zowe/zowe-install-packaging/pull/4866)
 
 ## `3.5.0`
 

--- a/bin/commands/init/certificate/.errors
+++ b/bin/commands/init/certificate/.errors
@@ -3,4 +3,4 @@ ZWEL0174E|174|Failed to generate certificate in Zowe keyring "%s/%s".
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
 ZWEL0201E|201|File %s does not exist.
 ZWEL0326E|326|An error occurred while processing Zowe YAML config %s:
-ZWEL0362W||The keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later.
+ZWEL0362W||A random password was generated for the following settings and is shown above: %s. Save these values now, since without --update-config they are not written to zowe.yaml and the keystore they protect cannot be opened later.

--- a/bin/commands/init/certificate/.errors
+++ b/bin/commands/init/certificate/.errors
@@ -3,3 +3,4 @@ ZWEL0174E|174|Failed to generate certificate in Zowe keyring "%s/%s".
 ZWEL0319E|319|zowe.setup.dataset.jcllib does not exist, cannot run. Run 'zwe init', 'zwe init generate', or submit JCL zowe.setup.dataset.prefix.SZWESAMP(ZWEGENER) before running this command.
 ZWEL0201E|201|File %s does not exist.
 ZWEL0326E|326|An error occurred while processing Zowe YAML config %s:
+ZWEL0362W||The keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later.

--- a/bin/commands/init/certificate/.help
+++ b/bin/commands/init/certificate/.help
@@ -112,8 +112,11 @@ zOSMF:
   be the default owner of keystore directory.
 - You can also define `name`, `password`, `caAlias` and `caPassword` under
   `zowe.setup.certificate.pkcs12` to customized keystore and truststore. These
-  configurations are optional, but it is recommended to update them from
-  default values.
+  configurations are optional. If `password` or `caPassword` is left at its
+  default value, a random password is generated for the keystore instead. With
+  `--update-config` the generated password is written to your Zowe YAML
+  configuration file; without it, the password is only shown in the command
+  output and must be saved manually.
 - Define `zowe.setup.certificate.pkcs12.import.keystore` if you already acquired
   certificate from other CA, stored them in PKCS12 format, and want to import
   into Zowe PKCS12 keystore.

--- a/bin/commands/init/certificate/index.sh
+++ b/bin/commands/init/certificate/index.sh
@@ -94,6 +94,13 @@ if [ "${cert_type}" = "PKCS12" ]; then
     var_val=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.pkcs12.${item}")
     eval "${var_name}=\"${var_val}\""
   done
+  # replace the well-known schema default so a stock init doesn't ship a guessable keystore password
+  pkcs12_password_generated=false
+  if [ "${pkcs12_password}" = "password" ]; then
+    pkcs12_password="$(get_tmp_rand)$(get_tmp_rand)"
+    pkcs12_password_generated=true
+    print_message "zowe.setup.certificate.pkcs12.password was left as the default value, generated a random password instead"
+  fi
   if [ -z "${pkcs12_directory}" ]; then
     print_error_and_exit "Error ZWEL0157E: Keystore directory (zowe.setup.certificate.pkcs12.directory) is not defined in Zowe YAML configuration file." "" 157
   fi
@@ -279,6 +286,11 @@ if [ "${cert_type}" = "PKCS12" ]; then
     cert_validity=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.validity")
 
     pkcs12_caPassword=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.pkcs12.caPassword")
+    # replace the well-known schema default so a stock init doesn't ship a guessable CA password
+    if [ "${pkcs12_caPassword}" = "local_ca_password" ]; then
+      pkcs12_caPassword="$(get_tmp_rand)$(get_tmp_rand)"
+      print_message "zowe.setup.certificate.pkcs12.caPassword was left as the default value, generated a random password instead"
+    fi
     pkcs12_caAlias=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.pkcs12.caAlias")
     pkcs12_caAlias_lc=$(echo "${pkcs12_caAlias}" | lower_case)
 
@@ -439,6 +451,9 @@ if [ "${cert_type}" = "PKCS12" ]; then
     print_message "      certificate: \"${pkcs12_directory}/${pkcs12_name}/${pkcs12_name_lc}.cer\""
     print_message "      certificateAuthorities: \"${yaml_pem_cas}\""
     print_message ""
+    if [ "${pkcs12_password_generated}" = "true" ]; then
+      print_message "Warning ZWEL0362W: the keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later."
+    fi
     print_level2_message "Zowe configuration requires manual updates."
   fi
 ###############################

--- a/bin/commands/init/certificate/index.sh
+++ b/bin/commands/init/certificate/index.sh
@@ -94,10 +94,14 @@ if [ "${cert_type}" = "PKCS12" ]; then
     var_val=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.pkcs12.${item}")
     set_var_value "${var_name}" "${var_val}"
   done
-  # replace the well-known schema default so a stock init doesn't ship a guessable keystore password
+  # replace the well-known schema default so a stock init doesn't ship a guessable keystore
+  # password. 
+  # The leading letter keeps the value from looking numeric, which update_zowe_yaml
+  # would otherwise coerce with parseInt and corrupt. FIXME: A user set pure numeric password may also get corrupted by --update-config
   pkcs12_password_generated=false
+  pkcs12_caPassword_generated=false
   if [ "${pkcs12_password}" = "password" ]; then
-    pkcs12_password="$(get_tmp_rand)$(get_tmp_rand)"
+    pkcs12_password="a$(get_tmp_rand)$(get_tmp_rand)"
     pkcs12_password_generated=true
     print_message "zowe.setup.certificate.pkcs12.password was left as the default value, generated a random password instead"
   fi
@@ -281,7 +285,8 @@ if [ "${cert_type}" = "PKCS12" ]; then
     pkcs12_caPassword=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.pkcs12.caPassword")
     # replace the well-known schema default so a stock init doesn't ship a guessable CA password
     if [ "${pkcs12_caPassword}" = "local_ca_password" ]; then
-      pkcs12_caPassword="$(get_tmp_rand)$(get_tmp_rand)"
+      pkcs12_caPassword="a$(get_tmp_rand)$(get_tmp_rand)"
+      pkcs12_caPassword_generated=true
       print_message "zowe.setup.certificate.pkcs12.caPassword was left as the default value, generated a random password instead"
     fi
     pkcs12_caAlias=$(read_yaml "${ZWE_CLI_PARAMETER_CONFIG}" ".zowe.setup.certificate.pkcs12.caAlias")
@@ -408,6 +413,14 @@ if [ "${cert_type}" = "PKCS12" ]; then
     if [ ! -z "${security_update}" ]; then
       update_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}" $security_update false
     fi
+    # a generated password must be persisted here too, otherwise the keystore and the local
+    # certificate authority are left with a password that is recorded nowhere
+    if [ "${pkcs12_password_generated}" = "true" ]; then
+      update_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}" "zowe.setup.certificate.pkcs12.password" "${pkcs12_password}" false
+    fi
+    if [ "${pkcs12_caPassword_generated}" = "true" ]; then
+      update_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}" "zowe.setup.certificate.pkcs12.caPassword" "${pkcs12_caPassword}" false
+    fi
     update_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}" "zowe.certificate.keystore.type" "PKCS12" false
     update_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}" "zowe.certificate.keystore.file" "${pkcs12_directory}/${pkcs12_name}/${pkcs12_name}.keystore.p12" false
     update_zowe_yaml "${ZWE_CLI_PARAMETER_CONFIG}" "zowe.certificate.keystore.password" "${pkcs12_password}" false
@@ -424,10 +437,22 @@ if [ "${cert_type}" = "PKCS12" ]; then
     print_message "Please manually update to these values:"
     print_message ""
     print_message "zowe:"
-    if [ ! -z "${security_update}" ]; then
+    if [ ! -z "${security_update}" -o "${pkcs12_password_generated}" = "true" -o "${pkcs12_caPassword_generated}" = "true" ]; then
       print_message "  setup:"
+    fi
+    if [ ! -z "${security_update}" ]; then
       print_message "    security:"
       print_message "      product: ${security_product}"
+    fi
+    if [ "${pkcs12_password_generated}" = "true" -o "${pkcs12_caPassword_generated}" = "true" ]; then
+      print_message "    certificate:"
+      print_message "      pkcs12:"
+      if [ "${pkcs12_password_generated}" = "true" ]; then
+        print_message "        password: \"${pkcs12_password}\""
+      fi
+      if [ "${pkcs12_caPassword_generated}" = "true" ]; then
+        print_message "        caPassword: \"${pkcs12_caPassword}\""
+      fi
     fi
     print_message "  certificate:"
     print_message "    keystore:"
@@ -444,8 +469,22 @@ if [ "${cert_type}" = "PKCS12" ]; then
     print_message "      certificate: \"${pkcs12_directory}/${pkcs12_name}/${pkcs12_name_lc}.cer\""
     print_message "      certificateAuthorities: \"${yaml_pem_cas}\""
     print_message ""
+    # only report the passwords that were actually generated, the other ones are already known
+    generated_keys=
     if [ "${pkcs12_password_generated}" = "true" ]; then
-      print_message "Warning ZWEL0362W: The keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later."
+      generated_keys="zowe.setup.certificate.pkcs12.password"
+    fi
+    if [ "${pkcs12_caPassword_generated}" = "true" ]; then
+      if [ -n "${generated_keys}" ]; then
+        generated_keys="${generated_keys} and "
+      fi
+      generated_keys="${generated_keys}zowe.setup.certificate.pkcs12.caPassword"
+    fi
+    if [ -n "${generated_keys}" ]; then
+      print_message "Warning ZWEL0362W: A random password was generated for the following settings and is shown above: ${generated_keys}. Save these values now, since without --update-config they are not written to zowe.yaml and the keystore they protect cannot be opened later."
+      if [ "${pkcs12_caPassword_generated}" = "true" ]; then
+        print_message "Without the certificate authority password the local certificate authority cannot sign additional certificates."
+      fi
     fi
     print_level2_message "Zowe configuration requires manual updates."
   fi

--- a/bin/commands/init/certificate/index.sh
+++ b/bin/commands/init/certificate/index.sh
@@ -445,7 +445,7 @@ if [ "${cert_type}" = "PKCS12" ]; then
     print_message "      certificateAuthorities: \"${yaml_pem_cas}\""
     print_message ""
     if [ "${pkcs12_password_generated}" = "true" ]; then
-      print_message "Warning ZWEL0362W: the keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later."
+      print_message "Warning ZWEL0362W: The keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later."
     fi
     print_level2_message "Zowe configuration requires manual updates."
   fi

--- a/files/examples/setup/certificate/scenario-1.yaml
+++ b/files/examples/setup/certificate/scenario-1.yaml
@@ -30,12 +30,14 @@ zowe:
         # Certificate alias name. Optional, default value is localhost.
         # Note: please use all lower cases as alias.
         name: localhost
-        # Keystore password. Optional, default value is password.
+        # Keystore password. Optional. If left as "password", a random
+        # password is generated instead and shown in the command output.
         password: password
         # Alias name of self-signed certificate authority. Optional, default value is local_ca.
         # Note: please use all lower cases as alias.
         caAlias: local_ca
-        # Password of keystore stored self-signed certificate authority. Optional, default value is local_ca_password.
+        # Password of keystore stored self-signed certificate authority. Optional.
+        # If left as "local_ca_password", a random password is generated instead.
         caPassword: local_ca_password
       validity: 3650
       # # Distinguished name for Zowe generated certificates. All optional.

--- a/files/examples/setup/certificate/scenario-2.yaml
+++ b/files/examples/setup/certificate/scenario-2.yaml
@@ -30,7 +30,8 @@ zowe:
         # Certificate alias name. Optional, default value is localhost.
         # Note: please use all lower cases as alias.
         name: localhost
-        # Keystore password. Optional, default value is password.
+        # Keystore password. Optional. If left as "password", a random
+        # password is generated instead and shown in the command output.
         password: password
         import:
           # Existing PKCS12 keystore which holds the certificate issued by external CA.

--- a/playbooks/all_host_vars_list.yml
+++ b/playbooks/all_host_vars_list.yml
@@ -70,7 +70,9 @@ zowe_keyring_external_intermediate_ca:
 zowe_keyring_external_root_ca: brcmso
 zowe_keystore_alias: localhost
 zowe_keystore_dir: ~/.zowe/keystore
-zowe_keystore_password: password
+# NOTE: must not be the schema default "password" - zwe init certificate replaces that with a
+# random value, which would no longer match the keytool -storepass calls in custom_for_test.
+zowe_keystore_password: zowetestpw
 zowe_launch_components:
 zowe_launch_scripts_loglevel:
 zowe_lock_keystore: true

--- a/playbooks/roles/configfmid/defaults/main.yml
+++ b/playbooks/roles/configfmid/defaults/main.yml
@@ -94,7 +94,9 @@ zowe_external_certficate:
 zowe_external_certficate_alias:
 zowe_external_certficate_authorities:
 zowe_keystore_dir: ~/.zowe/keystore
-zowe_keystore_password: password
+# NOTE: must not be the schema default "password" - zwe init certificate replaces that with a
+# random value, which would no longer match the keytool -storepass calls in custom_for_test.
+zowe_keystore_password: zowetestpw
 zowe_keyring_alias: ZoweKeyring
 zowe_keyring_certname: ZoweCert
 zowe_keyring_external_intermediate_ca:

--- a/playbooks/roles/configure/defaults/main.yml
+++ b/playbooks/roles/configure/defaults/main.yml
@@ -96,7 +96,9 @@ zowe_external_certficate:
 zowe_external_certficate_alias:
 zowe_external_certficate_authorities:
 zowe_keystore_dir: ~/.zowe/keystore
-zowe_keystore_password: password
+# NOTE: must not be the schema default "password" - zwe init certificate replaces that with a
+# random value, which would no longer match the keytool -storepass calls in custom_for_test.
+zowe_keystore_password: zowetestpw
 zowe_keystore_ca_password: ca-password
 zowe_keystore_alias: localhost
 zowe_keystore_ca_label: localca

--- a/playbooks/roles/custom_for_test/defaults/main.yml
+++ b/playbooks/roles/custom_for_test/defaults/main.yml
@@ -95,7 +95,9 @@ zowe_external_certficate:
 zowe_external_certficate_alias:
 zowe_external_certficate_authorities:
 zowe_keystore_dir: ~/.zowe/keystore
-zowe_keystore_password: password
+# NOTE: must not be the schema default "password" - zwe init certificate replaces that with a
+# random value, which would no longer match the keytool -storepass calls in custom_for_test.
+zowe_keystore_password: zowetestpw
 zowe_keyring_alias: ZoweKeyring
 zowe_keyring_certname: ZoweCert
 zowe_keyring_external_intermediate_ca:

--- a/schemas/zowe-yaml-schema.json
+++ b/schemas/zowe-yaml-schema.json
@@ -303,7 +303,7 @@
                         },
                         "password": {
                           "type": [ "string", "null" ],
-                          "description": "Keystore password",
+                          "description": "Keystore password. If left at the default value, `zwe init certificate` generates a random password instead.",
                           "default": "password"
                         },
                         "caAlias": {
@@ -313,7 +313,7 @@
                         },
                         "caPassword": {
                           "type": [ "string", "null" ],
-                          "description": "Password of keystore stored self-signed certificate authority.",
+                          "description": "Password of keystore stored self-signed certificate authority. If left at the default value, `zwe init certificate` generates a random password instead.",
                           "default": "local_ca_password"
                         },
                         "lock": {

--- a/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/certificate.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/certificate.test.ts.snap
@@ -3,6 +3,8 @@
 exports[`init-cert (LONG) cert bad hostname 1`] = `
 "-------------------------------------------------------------------------------
 >> Generate certificate
+zowe.setup.certificate.pkcs12.password was left as the default value, generated a random password instead
+zowe.setup.certificate.pkcs12.caPassword was left as the default value, generated a random password instead
 -------------------------------------------------------------------------------
 >> Creating certificate authority "local_ca"
 >>>> Generate PKCS12 format local CA with alias local_ca:
@@ -31,6 +33,8 @@ Error ZWEL0170E: Failed to trust z/OSMF "doesnt-exist.anywhere.cloud:12321"."
 exports[`init-cert (LONG) passing init 1`] = `
 "-------------------------------------------------------------------------------
 >> Generate certificate
+zowe.setup.certificate.pkcs12.password was left as the default value, generated a random password instead
+zowe.setup.certificate.pkcs12.caPassword was left as the default value, generated a random password instead
 -------------------------------------------------------------------------------
 >> Creating certificate authority "local_ca"
 >>>> Generate PKCS12 format local CA with alias local_ca:
@@ -84,16 +88,17 @@ zowe:
     keystore:
       type: PKCS12
       file: "/test/dir/pkcs12/localhost/localhost.keystore.p12"
-      password: "password"
+      password: "0000000000000000"
       alias: "localhost"
     truststore:
       type: PKCS12
       file: "/test/dir/pkcs12/localhost/localhost.truststore.p12"
-      password: "password"
+      password: "0000000000000000"
     pem:
       key: "/test/dir/pkcs12/localhost/localhost.key"
       certificate: "/test/dir/pkcs12/localhost/localhost.cer"
       certificateAuthorities: "/test/dir/pkcs12/local_ca/local_ca.cer"
+Warning ZWEL0362W: the keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later.
 >> Zowe configuration requires manual updates."
 `;
 
@@ -330,6 +335,8 @@ Error ZWEL0326E: An error occurred while processing Zowe YAML config /test/dir/z
 exports[`init-cert (SHORT) run each scenario 1`] = `
 "-------------------------------------------------------------------------------
 >> Generate certificate
+zowe.setup.certificate.pkcs12.password was left as the default value, generated a random password instead
+zowe.setup.certificate.pkcs12.caPassword was left as the default value, generated a random password instead
 -------------------------------------------------------------------------------
 >> Creating certificate authority "local_ca"
 >>>> Generate PKCS12 format local CA with alias local_ca:
@@ -383,16 +390,17 @@ zowe:
     keystore:
       type: PKCS12
       file: "/test/dir/pkcs12/localhost/localhost.keystore.p12"
-      password: "password"
+      password: "0000000000000000"
       alias: "localhost"
     truststore:
       type: PKCS12
       file: "/test/dir/pkcs12/localhost/localhost.truststore.p12"
-      password: "password"
+      password: "0000000000000000"
     pem:
       key: "/test/dir/pkcs12/localhost/localhost.key"
       certificate: "/test/dir/pkcs12/localhost/localhost.cer"
       certificateAuthorities: "/test/dir/pkcs12/local_ca/local_ca.cer"
+Warning ZWEL0362W: the keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later.
 >> Zowe configuration requires manual updates.
 -------------------------------------------------------------------------------
 >> Verify certificate of "some.test.hostname:12321"
@@ -404,6 +412,7 @@ Error ZWEL0171E: Failed to verify certificate (CN and SAN) of "some.test.hostnam
 exports[`init-cert (SHORT) run each scenario 2`] = `
 "-------------------------------------------------------------------------------
 >> Generate certificate
+zowe.setup.certificate.pkcs12.password was left as the default value, generated a random password instead
 -------------------------------------------------------------------------------
 >> Import certificate into keystore /test/dir/pkcs12_scen2/localhost/localhost.keystore.p12
 >>>> Import localhost from keystore "/test/dir/pkcs12/localhost/localhost.keystore.p12" to "/test/dir/pkcs12_scen2/localhost/localhost.keystore.p12" as localhost:
@@ -439,16 +448,17 @@ zowe:
     keystore:
       type: PKCS12
       file: "/test/dir/pkcs12_scen2/localhost/localhost.keystore.p12"
-      password: "password"
+      password: "0000000000000000"
       alias: "localhost"
     truststore:
       type: PKCS12
       file: "/test/dir/pkcs12_scen2/localhost/localhost.truststore.p12"
-      password: "password"
+      password: "0000000000000000"
     pem:
       key: "/test/dir/pkcs12_scen2/localhost/localhost.key"
       certificate: "/test/dir/pkcs12_scen2/localhost/localhost.cer"
       certificateAuthorities: ""
+Warning ZWEL0362W: the keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later.
 >> Zowe configuration requires manual updates.
 -------------------------------------------------------------------------------
 >> Verify certificate of "some.test.hostname:12321"

--- a/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/certificate.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/certificate.test.ts.snap
@@ -84,6 +84,11 @@ zowe.setup.certificate.pkcs12.caPassword was left as the default value, generate
 >> Update certificate configuration to /test/dir/zowe.test.yaml
 Please manually update to these values:
 zowe:
+  setup:
+    certificate:
+      pkcs12:
+        password: "0000000000000000"
+        caPassword: "0000000000000000"
   certificate:
     keystore:
       type: PKCS12
@@ -98,7 +103,8 @@ zowe:
       key: "/test/dir/pkcs12/localhost/localhost.key"
       certificate: "/test/dir/pkcs12/localhost/localhost.cer"
       certificateAuthorities: "/test/dir/pkcs12/local_ca/local_ca.cer"
-Warning ZWEL0362W: The keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later.
+Warning ZWEL0362W: A random password was generated for the following settings and is shown above: zowe.setup.certificate.pkcs12.password and zowe.setup.certificate.pkcs12.caPassword. Save these values now, since without --update-config they are not written to zowe.yaml and the keystore they protect cannot be opened later.
+Without the certificate authority password the local certificate authority cannot sign additional certificates.
 >> Zowe configuration requires manual updates."
 `;
 
@@ -335,8 +341,6 @@ Error ZWEL0326E: An error occurred while processing Zowe YAML config /test/dir/z
 exports[`init-cert (SHORT) run each scenario 1`] = `
 "-------------------------------------------------------------------------------
 >> Generate certificate
-zowe.setup.certificate.pkcs12.password was left as the default value, generated a random password instead
-zowe.setup.certificate.pkcs12.caPassword was left as the default value, generated a random password instead
 -------------------------------------------------------------------------------
 >> Creating certificate authority "local_ca"
 >>>> Generate PKCS12 format local CA with alias local_ca:
@@ -390,17 +394,16 @@ zowe:
     keystore:
       type: PKCS12
       file: "/test/dir/pkcs12/localhost/localhost.keystore.p12"
-      password: "0000000000000000"
+      password: "keystoretestpw"
       alias: "localhost"
     truststore:
       type: PKCS12
       file: "/test/dir/pkcs12/localhost/localhost.truststore.p12"
-      password: "0000000000000000"
+      password: "keystoretestpw"
     pem:
       key: "/test/dir/pkcs12/localhost/localhost.key"
       certificate: "/test/dir/pkcs12/localhost/localhost.cer"
       certificateAuthorities: "/test/dir/pkcs12/local_ca/local_ca.cer"
-Warning ZWEL0362W: The keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later.
 >> Zowe configuration requires manual updates.
 -------------------------------------------------------------------------------
 >> Verify certificate of "some.test.hostname:12321"
@@ -412,7 +415,6 @@ Error ZWEL0171E: Failed to verify certificate (CN and SAN) of "some.test.hostnam
 exports[`init-cert (SHORT) run each scenario 2`] = `
 "-------------------------------------------------------------------------------
 >> Generate certificate
-zowe.setup.certificate.pkcs12.password was left as the default value, generated a random password instead
 -------------------------------------------------------------------------------
 >> Import certificate into keystore /test/dir/pkcs12_scen2/localhost/localhost.keystore.p12
 >>>> Import localhost from keystore "/test/dir/pkcs12/localhost/localhost.keystore.p12" to "/test/dir/pkcs12_scen2/localhost/localhost.keystore.p12" as localhost:
@@ -448,17 +450,16 @@ zowe:
     keystore:
       type: PKCS12
       file: "/test/dir/pkcs12_scen2/localhost/localhost.keystore.p12"
-      password: "0000000000000000"
+      password: "keystoretestpw"
       alias: "localhost"
     truststore:
       type: PKCS12
       file: "/test/dir/pkcs12_scen2/localhost/localhost.truststore.p12"
-      password: "0000000000000000"
+      password: "keystoretestpw"
     pem:
       key: "/test/dir/pkcs12_scen2/localhost/localhost.key"
       certificate: "/test/dir/pkcs12_scen2/localhost/localhost.cer"
       certificateAuthorities: ""
-Warning ZWEL0362W: The keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later.
 >> Zowe configuration requires manual updates.
 -------------------------------------------------------------------------------
 >> Verify certificate of "some.test.hostname:12321"

--- a/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/certificate.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/init/__snapshots__/certificate.test.ts.snap
@@ -98,7 +98,7 @@ zowe:
       key: "/test/dir/pkcs12/localhost/localhost.key"
       certificate: "/test/dir/pkcs12/localhost/localhost.cer"
       certificateAuthorities: "/test/dir/pkcs12/local_ca/local_ca.cer"
-Warning ZWEL0362W: the keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later.
+Warning ZWEL0362W: The keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later.
 >> Zowe configuration requires manual updates."
 `;
 
@@ -400,7 +400,7 @@ zowe:
       key: "/test/dir/pkcs12/localhost/localhost.key"
       certificate: "/test/dir/pkcs12/localhost/localhost.cer"
       certificateAuthorities: "/test/dir/pkcs12/local_ca/local_ca.cer"
-Warning ZWEL0362W: the keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later.
+Warning ZWEL0362W: The keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later.
 >> Zowe configuration requires manual updates.
 -------------------------------------------------------------------------------
 >> Verify certificate of "some.test.hostname:12321"
@@ -458,7 +458,7 @@ zowe:
       key: "/test/dir/pkcs12_scen2/localhost/localhost.key"
       certificate: "/test/dir/pkcs12_scen2/localhost/localhost.cer"
       certificateAuthorities: ""
-Warning ZWEL0362W: the keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later.
+Warning ZWEL0362W: The keystore password above was randomly generated and is not stored anywhere else. Save it now, since without --update-config it will not be written to zowe.yaml and cannot be recovered later.
 >> Zowe configuration requires manual updates.
 -------------------------------------------------------------------------------
 >> Verify certificate of "some.test.hostname:12321"

--- a/tests/zwe-remote-integration/src/__tests__/init/certificate.test.ts
+++ b/tests/zwe-remote-integration/src/__tests__/init/certificate.test.ts
@@ -60,14 +60,21 @@ describe(`${testSuiteName}`, () => {
     it('run each scenario', async () => {
       const keyringScenarios = scenarioYamls.slice(2);
       const scenarioSettings = {
+        // NOTE: these scenarios are chained - scenario 2 imports the keystore scenario 1 creates,
+        // so both must use explicit passwords. Left at the schema defaults, zwe init certificate
+        // generates a random password and scenario 2 could not open the source keystore.
+        // The default-password path is covered by the (LONG) tests below.
         'scenario-1.yaml': {
           'zowe.setup.certificate.pkcs12.directory': remotePkcs12Dir,
+          'zowe.setup.certificate.pkcs12.password': 'keystoretestpw',
+          'zowe.setup.certificate.pkcs12.caPassword': 'catestpw',
         },
         'scenario-2.yaml': {
           'zowe.setup.certificate.pkcs12.directory': remotePkcs12Dir + '_scen2',
+          'zowe.setup.certificate.pkcs12.password': 'keystoretestpw',
           // generated in step 1
           'zowe.setup.certificate.pkcs12.import.keystore': remotePkcs12Dir + '/localhost/localhost.keystore.p12',
-          'zowe.setup.certificate.pkcs12.import.password': 'password',
+          'zowe.setup.certificate.pkcs12.import.password': 'keystoretestpw',
           'zowe.setup.certificate.pkcs12.import.alias': 'localhost',
         },
         'scenario-3.yaml': {},

--- a/tests/zwe-remote-integration/src/__tests__/migrate/__resources__/setup.scenario.1.yml
+++ b/tests/zwe-remote-integration/src/__tests__/migrate/__resources__/setup.scenario.1.yml
@@ -9,9 +9,12 @@ zowe:
         directory: {@ ussTestDir @}/pkcs12
         # Certificate alias name. Optional, default value is localhost.
         name: localhost
-        password: password
+        # NOTE: intentionally not the schema default "password" - zwe init certificate now
+        # generates a random keystore password when the default is left in place, which
+        # would no longer match the "zowe.certificate.keystore.password" below.
+        password: keystoretestpw
         caAlias: local_ca
-        caPassword: local_ca_password
+        caPassword: catestpw
       validity: 3650
       # san:
       #  # sample domain name
@@ -22,12 +25,12 @@ zowe:
     keystore:
       type: PKCS12
       file: {@ ussTestDir @}/pkcs12/localhost/localhost.keystore.p12
-      password: password
+      password: keystoretestpw
       alias: localhost
     truststore:
       type: PKCS12
       file: {@ ussTestDir @}/pkcs12/localhost/localhost.truststore.p12
-      password: password
+      password: keystoretestpw
     pem:
       key: {@ ussTestDir @}/pkcs12/localhost/localhost.key
       certificate: {@ ussTestDir @}/pkcs12/localhost/localhost.cer

--- a/tests/zwe-remote-integration/src/__tests__/migrate/__snapshots__/for.kubernetes.test.ts.snap
+++ b/tests/zwe-remote-integration/src/__tests__/migrate/__snapshots__/for.kubernetes.test.ts.snap
@@ -72,9 +72,9 @@ You can customize domains by passing --domains option to this command.
 - update "zowe.certificate.pem.key" with value: /home/zowe/keystore/keystore.key
 - update "zowe.certificate.pem.certificate" with value: /home/zowe/keystore/keystore.cer
 - update "zowe.certificate.keystore.alias" with value: localhost
-- update "zowe.certificate.keystore.password" with value: password
+- update "zowe.certificate.keystore.password" with value: keystoretestpw
 - update "zowe.certificate.keystore.type" with value: PKCS12
-- update "zowe.certificate.truststore.password" with value: password
+- update "zowe.certificate.truststore.password" with value: keystoretestpw
 - update "zowe.certificate.truststore.type" with value: PKCS12
 -------------------------------------------------------------------------------
 >> Output Kubernetes ConfigMap and Secret manifests
@@ -121,20 +121,20 @@ data:
           pkcs12:
             directory: "/test/dir/pkcs12"
             name: "localhost"
-            password: "password"
+            password: "keystoretestpw"
             caAlias: "local_ca"
-            caPassword: "local_ca_password"
+            caPassword: "catestpw"
           validity: 3650
       certificate:
         keystore:
           type: "PKCS12"
           file: "/home/zowe/keystore/keystore.p12"
-          password: "password"
+          password: "keystoretestpw"
           alias: "localhost"
         truststore:
           type: "PKCS12"
           file: "/home/zowe/keystore/truststore.p12"
-          password: "password"
+          password: "keystoretestpw"
         pem:
           key: "/home/zowe/keystore/keystore.key"
           certificate: "/home/zowe/keystore/keystore.cer"

--- a/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
+++ b/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
@@ -437,6 +437,8 @@ export class RemoteTestRunner {
       .replace(/\/tmp\/\.zweenv-[0-9a-f]+/g, '/tmp/.zweenv-0000')
       .replace(/\/tmp\/zwe-[0-9a-f]+/g, '/tmp/zwe-0000')
       .replace(/\/tmp\/zowe-convert-for-k8s-[0-9a-f]+/g, '/tmp/zowe-convert-for-k8s-0000')
+      // zwe init certificate generates a random password when the default keystore/CA password is left unset
+      .replace(/password: "[0-9a-f]{16}"/g, 'password: "0000000000000000"')
       .replaceAll(REMOTE_SYSTEM_INFO.volume, 'TSTVOL')
       .replaceAll(REMOTE_SYSTEM_INFO.hostname, this.dummyHostname)
       .replaceAll(REMOTE_SYSTEM_INFO.zosmfPort, this.dummyPort)

--- a/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
+++ b/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
@@ -427,27 +427,29 @@ export class RemoteTestRunner {
       cleanedOutput = cleanedOutput.replaceAll(HEADER_REMOVAL_PATTERN, replacePattern);
     }
     // built-in
-    return cleanedOutput
-      .replace(/(JOB[0-9]{5})/gim, 'JOB00000')
-      .replaceAll(REMOTE_SYSTEM_INFO.zosJavaHome, '/test/java/home')
-      .replaceAll(REMOTE_SYSTEM_INFO.zosNodeHome, '/test/node/home')
-      .replaceAll(REMOTE_SYSTEM_INFO.ussTestDir, '/test/dir')
-      .replaceAll(`${REMOTE_SYSTEM_INFO.prefix}`, 'TEST.DATASET.PFX')
-      .replaceAll(`${this.session.ISession.user}`, 'TESTUSR0')
-      .replace(/\/tmp\/\.zweenv-[0-9a-f]+/g, '/tmp/.zweenv-0000')
-      .replace(/\/tmp\/zwe-[0-9a-f]+/g, '/tmp/zwe-0000')
-      .replace(/\/tmp\/zowe-convert-for-k8s-[0-9a-f]+/g, '/tmp/zowe-convert-for-k8s-0000')
-      // zwe init certificate generates a random password when the default keystore/CA password is left unset
-      .replace(/password: "[0-9a-f]{16}"/g, 'password: "0000000000000000"')
-      .replaceAll(REMOTE_SYSTEM_INFO.volume, 'TSTVOL')
-      .replaceAll(REMOTE_SYSTEM_INFO.hostname, this.dummyHostname)
-      .replaceAll(REMOTE_SYSTEM_INFO.zosmfPort, this.dummyPort)
-      .replaceAll(new RegExp(`Zowe version: v${getZoweVersion()}`, 'g'), 'Zowe version: v0.0.0')
-      .replaceAll(new RegExp(`Zowe v${getZoweVersion()}`, 'g'), 'Zowe v0.0.0')
-      .replaceAll(/\d{4}-\d{2}-\d{2}.+?<.+?>/g, '')
-      .replaceAll(/z\/OS Version: \d\.\d/g, 'z/OS Version: 0.0')
-      .replaceAll(/NodeJS version: v.*?$/gm, 'NodeJS version: v0.0.0')
-      .replaceAll(/Java version: .*?$/gm, 'Java version: v0.0.0');
+    return (
+      cleanedOutput
+        .replace(/(JOB[0-9]{5})/gim, 'JOB00000')
+        .replaceAll(REMOTE_SYSTEM_INFO.zosJavaHome, '/test/java/home')
+        .replaceAll(REMOTE_SYSTEM_INFO.zosNodeHome, '/test/node/home')
+        .replaceAll(REMOTE_SYSTEM_INFO.ussTestDir, '/test/dir')
+        .replaceAll(`${REMOTE_SYSTEM_INFO.prefix}`, 'TEST.DATASET.PFX')
+        .replaceAll(`${this.session.ISession.user}`, 'TESTUSR0')
+        .replace(/\/tmp\/\.zweenv-[0-9a-f]+/g, '/tmp/.zweenv-0000')
+        .replace(/\/tmp\/zwe-[0-9a-f]+/g, '/tmp/zwe-0000')
+        .replace(/\/tmp\/zowe-convert-for-k8s-[0-9a-f]+/g, '/tmp/zowe-convert-for-k8s-0000')
+        // zwe init certificate generates a random password when the default keystore/CA password is left unset
+        .replace(/password: "[0-9a-f]{16}"/g, 'password: "0000000000000000"')
+        .replaceAll(REMOTE_SYSTEM_INFO.volume, 'TSTVOL')
+        .replaceAll(REMOTE_SYSTEM_INFO.hostname, this.dummyHostname)
+        .replaceAll(REMOTE_SYSTEM_INFO.zosmfPort, this.dummyPort)
+        .replaceAll(new RegExp(`Zowe version: v${getZoweVersion()}`, 'g'), 'Zowe version: v0.0.0')
+        .replaceAll(new RegExp(`Zowe v${getZoweVersion()}`, 'g'), 'Zowe v0.0.0')
+        .replaceAll(/\d{4}-\d{2}-\d{2}.+?<.+?>/g, '')
+        .replaceAll(/z\/OS Version: \d\.\d/g, 'z/OS Version: 0.0')
+        .replaceAll(/NodeJS version: v.*?$/gm, 'NodeJS version: v0.0.0')
+        .replaceAll(/Java version: .*?$/gm, 'Java version: v0.0.0')
+    );
   }
 
   public getMask(maskType: string): string {

--- a/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
+++ b/tests/zwe-remote-integration/src/zos/RemoteTestRunner.ts
@@ -438,8 +438,9 @@ export class RemoteTestRunner {
         .replace(/\/tmp\/\.zweenv-[0-9a-f]+/g, '/tmp/.zweenv-0000')
         .replace(/\/tmp\/zwe-[0-9a-f]+/g, '/tmp/zwe-0000')
         .replace(/\/tmp\/zowe-convert-for-k8s-[0-9a-f]+/g, '/tmp/zowe-convert-for-k8s-0000')
-        // zwe init certificate generates a random password when the default keystore/CA password is left unset
-        .replace(/password: "[0-9a-f]{16}"/g, 'password: "0000000000000000"')
+        // zwe init certificate generates a random password when the default keystore/CA password
+        // is left unset. Matches caPassword too, and get_tmp_rand's fallback path is not always 16 chars.
+        .replace(/(?<pre>(?:ca)?[Pp]assword: ")[0-9a-f]{8,}(?<post>")/g, '$<pre>0000000000000000$<post>')
         .replaceAll(REMOTE_SYSTEM_INFO.volume, 'TSTVOL')
         .replaceAll(REMOTE_SYSTEM_INFO.hostname, this.dummyHostname)
         .replaceAll(REMOTE_SYSTEM_INFO.zosmfPort, this.dummyPort)


### PR DESCRIPTION
Generating a random value instead of a default pass for certificates generation scenarios 1 and 2

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Necessary documentation (if appropriate) have been added / updated
- [x] DCO signoffs have been added to all commits, including this PR

#### PR type
What type of changes does your PR introduce to Zowe? _Put an `x` in the box that applies to this PR. If you're unsure about any of them, don't hesitate to ask._ 
- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [x] Feature <!-- non-breaking change which adds functionality -->
- [ ] Other... Please describe:

