### PR TITLE
Use execOutSync in internal start prepare

### DIFF
--- a/bin/commands/internal/start/prepare/index.ts
+++ b/bin/commands/internal/start/prepare/index.ts
@@ -300,7 +300,7 @@ function validateComponents(enabledComponents:string[]): any {
           //TODO verify that this returns things that we want, currently it just uses setenv
           const envVars = config.loadEnvironmentVariables(componentId);
           componentEnvironments[manifest.name] = envVars;
-          let result = shell.execSync('sh', '-c', `. ${runtimeDirectory}/bin/libs/configmgr-index.sh && cd ${componentDir} && . ${fullPath}`);
+          let result = shell.execOutSync('sh', '-c', `. ${runtimeDirectory}/bin/libs/configmgr-index.sh && cd ${componentDir} && . ${fullPath}`);
           privateErrors=prevErrors;
           if (result.rc) {
             privateErrors++;


### PR DESCRIPTION
See the comment below for details.

## Without fix
```
ZWESVUSR ERROR (zwe-internal-start-prepare,validate_components) Error: Component apiml ended with nonzero rc=1
ZWESVUSR ERROR ZWEL0030E failed to prepare Zowe instance
```

## With fix
```
ZWESVUSR INFO (zwe-internal-start-prepare) Zowe runtime environment prepared
```

Note: `{zowe.runtimeDirectory}/components/apiml/bin/validate.sh` is using a pipe inside.

This should be preferred solution (comparing to [APIML-4916](https://github.com/zowe/api-layer/pull/4916)). Any new script is not limited on `pipe` or other basic unix features.

