### PR TITLE
switch uss/mvs/jes explorer to v3 branch in v2

### DIFF
--- a/manifest.json.template
+++ b/manifest.json.template
@@ -54,13 +54,13 @@
       "exclusions": ["*PR*.zip","*BRANCH*"]
     },
     "org.zowe.explorer-jes": {
-      "version": "~2.0.2-SNAPSHOT"
+      "version": "^3.0.0-SNAPSHOT"
     },
     "org.zowe.explorer-mvs": {
-      "version": "~2.0.2-SNAPSHOT"
+      "version": "^3.0.0-SNAPSHOT"
     },
     "org.zowe.explorer-uss": {
-      "version": "~2.0.2-SNAPSHOT"
+      "version": "^3.0.0-SNAPSHOT"
     },
     "org.zowe.explorer-ip": {
       "version": "~2.0.0-SNAPSHOT",


### PR DESCRIPTION
I believe the explorers, being iframe apps, really do not have any zlux v3/v2 dependencies such that instead of maintaining 2 branches we could just use the v3 branch on v2.
i am making this build to test that theory.