### PR TITLE
use allowed domains = external domains

### DIFF
--- a/example-zowe.yaml
+++ b/example-zowe.yaml
@@ -224,8 +224,7 @@ zowe:
   network:
     # Allowed domains is a list of domains (supporting wildcards) that can be used in services that register to the API ML Discovery Service.
     # Defaults to the external domains + lpar hostnames if defined in haInstances
-    allowedDomains:
-      - www.example.com
+    allowedDomains: "${{ zowe.externalDomains }}"
     server:
       tls:
         attls: false


### PR DESCRIPTION
To reduce the likelihood that the 'allowed domains' field is a disruptive change users, it would make sense to have it templated to  external domains, so that the two match by default and only one needs to be set.